### PR TITLE
Various API changes

### DIFF
--- a/examples/convert.cc
+++ b/examples/convert.cc
@@ -147,8 +147,7 @@ int main(int argc, char** argv)
     }
 
     struct heif_image* image;
-    err = heif_decode_image(ctx, handle, &image, encoder->colorspace(),
-        encoder->chroma());
+    err = heif_decode_image(handle, &image, encoder->colorspace(), encoder->chroma());
     if (err.code) {
       heif_image_handle_release(handle);
       std::cerr << "Could not decode HEIF image: " << idx << ": "

--- a/examples/heif.cc
+++ b/examples/heif.cc
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
   }
 
   struct heif_image* image;
-  err = heif_decode_image(ctx, handle, &image, heif_colorspace_YCbCr,
+  err = heif_decode_image(handle, &image, heif_colorspace_YCbCr,
       heif_chroma_420);
   if (err.code != 0) {
     heif_image_handle_release(handle);

--- a/src/error.cc
+++ b/src/error.cc
@@ -22,6 +22,8 @@
 
 #include <assert.h>
 
+// static
+const char heif::Error::kSuccess[] = "Success";
 
 heif::Error::Error()
   : error_code(heif_error_Ok)

--- a/src/error.h
+++ b/src/error.h
@@ -75,6 +75,8 @@ namespace heif {
 
     static Error Ok;
 
+    static const char kSuccess[];
+
     bool operator==(const Error& other) const { return error_code == other.error_code; }
     bool operator!=(const Error& other) const { return !(*this == other); }
 

--- a/src/file-fuzzer.cc
+++ b/src/file-fuzzer.cc
@@ -33,11 +33,11 @@ static void TestDecodeImage(struct heif_context* ctx,
   struct heif_error err;
   int width = 0, height = 0;
 
-  heif_image_handle_is_primary_image(ctx, handle);
-  heif_image_handle_get_resolution(ctx, handle, &width, &height);
+  heif_image_handle_is_primary_image(handle);
+  heif_image_handle_get_resolution(handle, &width, &height);
   assert(width > 0);
   assert(height > 0);
-  err = heif_decode_image(ctx, handle, &image, kFuzzColorSpace, kFuzzChroma);
+  err = heif_decode_image(handle, &image, kFuzzColorSpace, kFuzzChroma);
   if (err.code != heif_error_Ok) {
     return;
   }
@@ -76,7 +76,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   err = heif_context_get_primary_image_handle(ctx, &handle);
   if (err.code == heif_error_Ok) {
-    assert(heif_image_handle_is_primary_image(ctx, handle));
+    assert(heif_image_handle_is_primary_image(handle));
     TestDecodeImage(ctx, handle);
     heif_image_handle_release(handle);
   }
@@ -96,10 +96,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
     TestDecodeImage(ctx, handle);
 
-    int num_thumbnails = heif_image_handle_get_number_of_thumbnails(ctx, handle);
+    int num_thumbnails = heif_image_handle_get_number_of_thumbnails(handle);
     for (int t = 0; t < num_thumbnails; ++t) {
       struct heif_image_handle* thumbnail_handle = nullptr;
-      heif_image_handle_get_thumbnail(ctx, handle, t, &thumbnail_handle);
+      heif_image_handle_get_thumbnail(handle, t, &thumbnail_handle);
       if (thumbnail_handle) {
         TestDecodeImage(ctx, thumbnail_handle);
         heif_image_handle_release(thumbnail_handle);

--- a/src/heif.cc
+++ b/src/heif.cc
@@ -155,8 +155,7 @@ heif_error heif_image_handle_get_thumbnail(const struct heif_image_handle* handl
 }
 
 
-void heif_image_handle_get_resolution(const struct heif_context* ctx,
-                                      const struct heif_image_handle* handle,
+void heif_image_handle_get_resolution(const struct heif_image_handle* handle,
                                       int* width, int* height)
 {
   int w, h;

--- a/src/heif.cc
+++ b/src/heif.cc
@@ -191,19 +191,20 @@ struct heif_error heif_decode_image(struct heif_context* ctx,
 }
 
 
-struct heif_error heif_image_create(struct heif_context* ctx,
-                                    int width, int height,
+struct heif_error heif_image_create(int width, int height,
                                     heif_colorspace colorspace,
                                     heif_chroma chroma,
                                     struct heif_image** image)
 {
   struct heif_image* img = new heif_image;
-  img->image = std::make_shared<HeifPixelImage>(ctx->context);
+  img->image = std::make_shared<HeifPixelImage>();
 
   img->image->create(width, height, colorspace, chroma);
 
   *image = img;
-  return Error::Ok.error_struct(ctx->context.get());
+
+  struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, Error::kSuccess };
+  return err;
 }
 
 void heif_image_release(const struct heif_image* img)
@@ -243,7 +244,9 @@ struct heif_error heif_image_add_plane(struct heif_image* image,
                                        heif_channel channel, int width, int height, int bit_depth)
 {
   image->image->add_plane(channel, width, height, bit_depth);
-  return Error::Ok.error_struct(image->image->context().get());
+
+  struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, Error::kSuccess };
+  return err;
 }
 
 

--- a/src/heif.cc
+++ b/src/heif.cc
@@ -158,13 +158,23 @@ heif_error heif_image_handle_get_thumbnail(const struct heif_context* h,
 }
 
 
-struct heif_error heif_image_handle_get_resolution(const struct heif_context* h,
-                                                   const struct heif_image_handle* handle,
-                                                   int* width, int* height)
+void heif_image_handle_get_resolution(const struct heif_context* ctx,
+                                      const struct heif_image_handle* handle,
+                                      int* width, int* height)
 {
-  if (width) *width = handle->image->get_width();
-  if (height) *height = handle->image->get_height();
-  return Error::Ok.error_struct(h->context.get());
+  int w, h;
+
+  if (handle && handle->image) {
+    w = handle->image->get_width();
+    h = handle->image->get_height();
+  }
+  else {
+    w = 0;
+    h = 0;
+  }
+
+  if (width)  *width = w;
+  if (height) *height = h;
 }
 
 struct heif_error heif_decode_image(struct heif_context* ctx,

--- a/src/heif.cc
+++ b/src/heif.cc
@@ -176,7 +176,7 @@ struct heif_error heif_decode_image(struct heif_context* ctx,
   *out_img = new heif_image();
 
   //Error err = ctx->context->decode_image(in_handle->image_ID, (*out_img)->image);
-  Error err = in_handle->image->decode_image(ctx, (*out_img)->image,
+  Error err = in_handle->image->decode_image((*out_img)->image,
                                              colorspace,
                                              chroma,
                                              nullptr);

--- a/src/heif.cc
+++ b/src/heif.cc
@@ -124,22 +124,19 @@ heif_error heif_context_get_image_handle(heif_context* ctx, size_t image_idx, he
 }
 
 
-int heif_image_handle_is_primary_image(const struct heif_context* h,
-                                       const struct heif_image_handle* handle)
+int heif_image_handle_is_primary_image(const struct heif_image_handle* handle)
 {
   return handle->image->is_primary();
 }
 
 
-size_t heif_image_handle_get_number_of_thumbnails(const struct heif_context* h,
-                                                  const struct heif_image_handle* handle)
+size_t heif_image_handle_get_number_of_thumbnails(const struct heif_image_handle* handle)
 {
   return handle->image->get_thumbnails().size();
 }
 
 
-heif_error heif_image_handle_get_thumbnail(const struct heif_context* h,
-                                           const struct heif_image_handle* handle,
+heif_error heif_image_handle_get_thumbnail(const struct heif_image_handle* handle,
                                            size_t thumbnail_idx,
                                            struct heif_image_handle** out_thumbnail_handle)
 {
@@ -148,13 +145,13 @@ heif_error heif_image_handle_get_thumbnail(const struct heif_context* h,
   auto thumbnails = handle->image->get_thumbnails();
   if (thumbnail_idx >= thumbnails.size()) {
     Error err(heif_error_Usage_error, heif_suberror_Nonexisting_image_referenced);
-    return err.error_struct(h->context.get());
+    return err.error_struct(handle->image.get());
   }
 
   *out_thumbnail_handle = new heif_image_handle();
   (*out_thumbnail_handle)->image = thumbnails[thumbnail_idx];
 
-  return Error::Ok.error_struct(h->context.get());
+  return Error::Ok.error_struct(handle->image.get());
 }
 
 
@@ -177,8 +174,7 @@ void heif_image_handle_get_resolution(const struct heif_context* ctx,
   if (height) *height = h;
 }
 
-struct heif_error heif_decode_image(struct heif_context* ctx,
-                                    const struct heif_image_handle* in_handle,
+struct heif_error heif_decode_image(const struct heif_image_handle* in_handle,
                                     struct heif_image** out_img,
                                     heif_colorspace colorspace,
                                     heif_chroma chroma)
@@ -200,7 +196,7 @@ struct heif_error heif_decode_image(struct heif_context* ctx,
 
   // TODO: colorspace conversion
 
-  return err.error_struct(ctx->context.get());
+  return err.error_struct(in_handle->image.get());
 }
 
 

--- a/src/heif.cc
+++ b/src/heif.cc
@@ -90,14 +90,14 @@ heif_error heif_context_get_primary_image_handle(heif_context* ctx, heif_image_h
 }
 
 
-size_t heif_context_get_number_of_images(heif_context* ctx)
+int heif_context_get_number_of_images(heif_context* ctx)
 {
-  return ctx->context->get_top_level_images().size();
+  return (int)ctx->context->get_top_level_images().size();
 }
 
 
 // NOTE: data types will change ! (TODO)
-heif_error heif_context_get_image_handle(heif_context* ctx, size_t image_idx, heif_image_handle** img)
+heif_error heif_context_get_image_handle(heif_context* ctx, int image_idx, heif_image_handle** img)
 {
   if (!img) {
     // TODO
@@ -106,7 +106,7 @@ heif_error heif_context_get_image_handle(heif_context* ctx, size_t image_idx, he
   //const auto& IDs = ctx->context->get_image_IDs();
 
   const std::vector<std::shared_ptr<HeifContext::Image>> images = ctx->context->get_top_level_images();
-  if (image_idx >= images.size()) {
+  if (image_idx<0 || (size_t)image_idx >= images.size()) {
     Error err(heif_error_Usage_error, heif_suberror_Nonexisting_image_referenced);
     return err.error_struct(ctx->context.get());
   }
@@ -130,20 +130,20 @@ int heif_image_handle_is_primary_image(const struct heif_image_handle* handle)
 }
 
 
-size_t heif_image_handle_get_number_of_thumbnails(const struct heif_image_handle* handle)
+int heif_image_handle_get_number_of_thumbnails(const struct heif_image_handle* handle)
 {
-  return handle->image->get_thumbnails().size();
+  return (int)handle->image->get_thumbnails().size();
 }
 
 
 heif_error heif_image_handle_get_thumbnail(const struct heif_image_handle* handle,
-                                           size_t thumbnail_idx,
+                                           int thumbnail_idx,
                                            struct heif_image_handle** out_thumbnail_handle)
 {
   assert(out_thumbnail_handle);
 
   auto thumbnails = handle->image->get_thumbnails();
-  if (thumbnail_idx >= thumbnails.size()) {
+  if (thumbnail_idx<0 || (size_t)thumbnail_idx >= thumbnails.size()) {
     Error err(heif_error_Usage_error, heif_suberror_Nonexisting_image_referenced);
     return err.error_struct(handle->image.get());
   }

--- a/src/heif.cc
+++ b/src/heif.cc
@@ -183,10 +183,10 @@ struct heif_error heif_decode_image(struct heif_context* ctx,
                                     heif_colorspace colorspace,
                                     heif_chroma chroma)
 {
-  *out_img = new heif_image();
+  std::shared_ptr<HeifPixelImage> img;
 
   //Error err = ctx->context->decode_image(in_handle->image_ID, (*out_img)->image);
-  Error err = in_handle->image->decode_image((*out_img)->image,
+  Error err = in_handle->image->decode_image(img,
                                              colorspace,
                                              chroma,
                                              nullptr);
@@ -194,6 +194,9 @@ struct heif_error heif_decode_image(struct heif_context* ctx,
     delete *out_img;
     *out_img = nullptr;
   }
+
+  *out_img = new heif_image();
+  (*out_img)->image = std::move(img);
 
   // TODO: colorspace conversion
 

--- a/src/heif.h
+++ b/src/heif.h
@@ -378,7 +378,7 @@ struct heif_error heif_image_add_plane(struct heif_image* image,
 struct heif_decoder_plugin
 {
   // Create a new decoder context for decoding an image
-  struct heif_error (*new_decoder)(struct heif_context* ctx, void** decoder);
+  struct heif_error (*new_decoder)(void** decoder);
 
   // Free the decoder context (heif_image can still be used after destruction)
   void (*free_decoder)(void* decoder);

--- a/src/heif.h
+++ b/src/heif.h
@@ -363,8 +363,7 @@ void heif_image_release(const struct heif_image*);
 // Note: no memory for the actual image data is reserved yet. You have to use
 // heif_image_add_plane() to add the image planes required by your colorspace/chroma.
 LIBHEIF_API
-struct heif_error heif_image_create(struct heif_context* ctx,
-                                    int width, int height,
+struct heif_error heif_image_create(int width, int height,
                                     enum heif_colorspace colorspace,
                                     enum heif_chroma chroma,
                                     struct heif_image** image);

--- a/src/heif.h
+++ b/src/heif.h
@@ -205,12 +205,12 @@ struct heif_error heif_context_get_primary_image_handle(struct heif_context* h,
 // tile images that are composed to an image grid. You can get access to the thumbnails via
 // the main image handle.
 LIBHEIF_API
-size_t heif_context_get_number_of_images(struct heif_context* h);
+int heif_context_get_number_of_images(struct heif_context* h);
 
 // Get the handle for a specific top-level image.
 LIBHEIF_API
 struct heif_error heif_context_get_image_handle(struct heif_context* h,
-                                                size_t image_index,
+                                                int image_index,
                                                 struct heif_image_handle**);
 
 // Release image handle.
@@ -223,12 +223,12 @@ int heif_image_handle_is_primary_image(const struct heif_image_handle* handle);
 
 // List the number of thumbnails assigned to this image handle. Usually 0 or 1.
 LIBHEIF_API
-size_t heif_image_handle_get_number_of_thumbnails(const struct heif_image_handle* handle);
+int heif_image_handle_get_number_of_thumbnails(const struct heif_image_handle* handle);
 
 // Get the image handle of a thumbnail image.
 LIBHEIF_API
 struct heif_error heif_image_handle_get_thumbnail(const struct heif_image_handle* main_image_handle,
-                                                  size_t thumbnail_idx,
+                                                  int thumbnail_idx,
                                                   struct heif_image_handle** out_thumbnail_handle);
 
 // Get the resolution of an image.

--- a/src/heif.h
+++ b/src/heif.h
@@ -186,7 +186,7 @@ struct heif_error heif_context_read_from_memory(struct heif_context*,
                                                 const void* mem, size_t size);
 
 // TODO
-LIBHEIF_API
+// LIBHEIF_API
 struct heif_error heif_context_read_from_file_descriptor(struct heif_context*, int fd);
 
 
@@ -241,13 +241,13 @@ struct heif_error heif_image_handle_get_resolution(const struct heif_context* h,
                                                    int* width, int* height);
 
 // TODO
-LIBHEIF_API
+//LIBHEIF_API
 size_t heif_image_handle_get_exif_data_size(const struct heif_context* h,
                                             const struct heif_image_handle* handle);
 
 // TODO
 // out_data must point to a memory area of size heif_image_handle_get_exif_data_size().
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_handle_get_exif_data(const struct heif_context* h,
                                                   const struct heif_image_handle* handle,
                                                   void* out_data);
@@ -315,7 +315,7 @@ LIBHEIF_API
 enum heif_chroma heif_image_get_chroma_format(const struct heif_image*);
 
 // TODO
-LIBHEIF_API
+//LIBHEIF_API
 enum heif_compression_format heif_image_get_compression_format(struct heif_image*);
 
 // Get width of the given image channel in pixels.

--- a/src/heif.h
+++ b/src/heif.h
@@ -219,37 +219,31 @@ void heif_image_handle_release(const struct heif_image_handle*);
 
 // Check whether the given image_handle is the primary image of the file.
 LIBHEIF_API
-int heif_image_handle_is_primary_image(const struct heif_context* h,
-                                       const struct heif_image_handle* handle);
+int heif_image_handle_is_primary_image(const struct heif_image_handle* handle);
 
 // List the number of thumbnails assigned to this image handle. Usually 0 or 1.
 LIBHEIF_API
-size_t heif_image_handle_get_number_of_thumbnails(const struct heif_context* h,
-                                                  const struct heif_image_handle* handle);
+size_t heif_image_handle_get_number_of_thumbnails(const struct heif_image_handle* handle);
 
 // Get the image handle of a thumbnail image.
 LIBHEIF_API
-struct heif_error heif_image_handle_get_thumbnail(const struct heif_context* h,
-                                                  const struct heif_image_handle* main_image_handle,
+struct heif_error heif_image_handle_get_thumbnail(const struct heif_image_handle* main_image_handle,
                                                   size_t thumbnail_idx,
                                                   struct heif_image_handle** out_thumbnail_handle);
 
 // Get the resolution of an image.
 LIBHEIF_API
-void heif_image_handle_get_resolution(const struct heif_context* h,
-                                      const struct heif_image_handle* handle,
+void heif_image_handle_get_resolution(const struct heif_image_handle* handle,
                                       int* width, int* height);
 
 // TODO
 //LIBHEIF_API
-size_t heif_image_handle_get_exif_data_size(const struct heif_context* h,
-                                            const struct heif_image_handle* handle);
+size_t heif_image_handle_get_exif_data_size(const struct heif_image_handle* handle);
 
 // TODO
 // out_data must point to a memory area of size heif_image_handle_get_exif_data_size().
 //LIBHEIF_API
-struct heif_error heif_image_handle_get_exif_data(const struct heif_context* h,
-                                                  const struct heif_image_handle* handle,
+struct heif_error heif_image_handle_get_exif_data(const struct heif_image_handle* handle,
                                                   void* out_data);
 
 
@@ -300,8 +294,7 @@ enum heif_channel {
 // If colorspace or chroma is set up heif_colorspace_undefined or heif_chroma_undefined,
 // respectively, the original colorspace is taken.
 LIBHEIF_API
-struct heif_error heif_decode_image(struct heif_context* ctx,
-                                    const struct heif_image_handle* in_handle,
+struct heif_error heif_decode_image(const struct heif_image_handle* in_handle,
                                     struct heif_image** out_img,
                                     enum heif_colorspace colorspace,
                                     enum heif_chroma chroma);

--- a/src/heif.h
+++ b/src/heif.h
@@ -236,9 +236,9 @@ struct heif_error heif_image_handle_get_thumbnail(const struct heif_context* h,
 
 // Get the resolution of an image.
 LIBHEIF_API
-struct heif_error heif_image_handle_get_resolution(const struct heif_context* h,
-                                                   const struct heif_image_handle* handle,
-                                                   int* width, int* height);
+void heif_image_handle_get_resolution(const struct heif_context* h,
+                                      const struct heif_image_handle* handle,
+                                      int* width, int* height);
 
 // TODO
 //LIBHEIF_API

--- a/src/heif_context.cc
+++ b/src/heif_context.cc
@@ -158,12 +158,13 @@ HeifContext::Image::~Image()
 {
 }
 
-Error HeifContext::Image::decode_image(std::shared_ptr<HeifPixelImage>& img,
+Error HeifContext::Image::decode_image(struct heif_context* ctx,
+                                       std::shared_ptr<HeifPixelImage>& img,
                                        heif_colorspace colorspace,
                                        heif_chroma chroma,
                                        HeifColorConversionParams* config) const
 {
-  Error err = m_heif_file->decode_image(m_id, img);
+  Error err = m_heif_file->decode_image(ctx, m_id, img);
   if (err) {
     return err;
   }

--- a/src/heif_context.cc
+++ b/src/heif_context.cc
@@ -158,13 +158,12 @@ HeifContext::Image::~Image()
 {
 }
 
-Error HeifContext::Image::decode_image(struct heif_context* ctx,
-                                       std::shared_ptr<HeifPixelImage>& img,
+Error HeifContext::Image::decode_image(std::shared_ptr<HeifPixelImage>& img,
                                        heif_colorspace colorspace,
                                        heif_chroma chroma,
                                        HeifColorConversionParams* config) const
 {
-  Error err = m_heif_file->decode_image(ctx, m_id, img);
+  Error err = m_heif_file->decode_image(m_id, img);
   if (err) {
     return err;
   }

--- a/src/heif_context.h
+++ b/src/heif_context.h
@@ -26,8 +26,6 @@
 #include <map>
 #include <set>
 
-struct heif_context;
-
 namespace heif {
 
   // This is a higher-level view than HeifFile.
@@ -65,7 +63,7 @@ namespace heif {
 
       std::vector<std::shared_ptr<Image>> get_thumbnails() const { return m_thumbnails; }
 
-      Error decode_image(struct heif_context* ctx, std::shared_ptr<HeifPixelImage>& img,
+      Error decode_image(std::shared_ptr<HeifPixelImage>& img,
                          heif_colorspace colorspace = heif_colorspace_undefined,
                          heif_chroma chroma = heif_chroma_undefined,
                          class HeifColorConversionParams* config = nullptr) const;

--- a/src/heif_context.h
+++ b/src/heif_context.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <set>
 
+struct heif_context;
 
 namespace heif {
 
@@ -64,7 +65,7 @@ namespace heif {
 
       std::vector<std::shared_ptr<Image>> get_thumbnails() const { return m_thumbnails; }
 
-      Error decode_image(std::shared_ptr<HeifPixelImage>& img,
+      Error decode_image(struct heif_context* ctx, std::shared_ptr<HeifPixelImage>& img,
                          heif_colorspace colorspace = heif_colorspace_undefined,
                          heif_chroma chroma = heif_chroma_undefined,
                          class HeifColorConversionParams* config = nullptr) const;

--- a/src/heif_context.h
+++ b/src/heif_context.h
@@ -40,7 +40,7 @@ namespace heif {
     Error read_from_memory(const void* data, size_t size);
 
 
-    class Image {
+    class Image : public ErrorBuffer {
     public:
       Image(std::shared_ptr<HeifFile> file, uint32_t id);
       ~Image();

--- a/src/heif_decoder_libde265.cc
+++ b/src/heif_decoder_libde265.cc
@@ -32,7 +32,6 @@
 
 struct libde265_decoder
 {
-  struct heif_context* heif_ctx;
   de265_decoder_context* ctx;
 };
 
@@ -91,12 +90,11 @@ struct heif_error convert_libde265_image_to_heif_image(struct libde265_decoder* 
 }
 
 
-struct heif_error libde265_new_decoder(struct heif_context* ctx, void** dec)
+struct heif_error libde265_new_decoder(void** dec)
 {
   struct libde265_decoder* decoder = new libde265_decoder();
   struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, kSuccess };
 
-  decoder->heif_ctx = ctx;
   decoder->ctx = de265_new_decoder();
   de265_start_worker_threads(decoder->ctx,1);
 

--- a/src/heif_decoder_libde265.cc
+++ b/src/heif_decoder_libde265.cc
@@ -43,7 +43,7 @@ struct heif_error convert_libde265_image_to_heif_image(struct libde265_decoder* 
     const struct de265_image* de265img, struct heif_image** image)
 {
   struct heif_image* out_img;
-  struct heif_error err = heif_image_create(decoder->heif_ctx,
+  struct heif_error err = heif_image_create(
     de265_get_image_width(de265img, 0),
     de265_get_image_height(de265img, 0),
     heif_colorspace_YCbCr, // TODO

--- a/src/heif_decoder_libde265.cc
+++ b/src/heif_decoder_libde265.cc
@@ -19,7 +19,6 @@
  */
 
 #include "heif.h"
-#include "heif_image.h"
 
 #if defined(HAVE_CONFIG_H)
 #include "config.h"
@@ -28,30 +27,31 @@
 #include <memory>
 #include <string.h>
 
-extern "C" {
-
 #include <libde265/de265.h>
 #include <stdio.h>
 
-using namespace heif;
-
-
 struct libde265_decoder
 {
+  struct heif_context* heif_ctx;
   de265_decoder_context* ctx;
 };
 
+static const char kSuccess[] = "Success";
 
 
-heif_image* convert_libde265_image_to_heif_image(const struct de265_image* de265img)
+struct heif_error convert_libde265_image_to_heif_image(struct libde265_decoder* decoder,
+    const struct de265_image* de265img, struct heif_image** image)
 {
-  auto out_img = std::make_shared<HeifPixelImage>();
-
-  out_img->create( de265_get_image_width(de265img, 0),
-                   de265_get_image_height(de265img, 0),
-                   heif_colorspace_YCbCr, // TODO
-                   (heif_chroma)de265_get_chroma_format(de265img) );
-
+  struct heif_image* out_img;
+  struct heif_error err = heif_image_create(decoder->heif_ctx,
+    de265_get_image_width(de265img, 0),
+    de265_get_image_height(de265img, 0),
+    heif_colorspace_YCbCr, // TODO
+    (heif_chroma)de265_get_chroma_format(de265img),
+    &out_img);
+  if (err.code != heif_error_Ok) {
+    return err;
+  }
 
   // --- transfer data from de265_image to HeifPixelImage
 
@@ -71,11 +71,13 @@ heif_image* convert_libde265_image_to_heif_image(const struct de265_image* de265
     int w = de265_get_image_width(de265img, c);
     int h = de265_get_image_height(de265img, c);
 
-
-    out_img->add_plane(channel2plane[c], w,h, bpp);
+    err = heif_image_add_plane(out_img, channel2plane[c], w,h, bpp);
+    if (err.code != heif_error_Ok) {
+      return err;
+    }
 
     int dst_stride;
-    uint8_t* dst_mem = out_img->get_plane(channel2plane[c], &dst_stride);
+    uint8_t* dst_mem = heif_image_get_plane(out_img, channel2plane[c], &dst_stride);
 
     int bytes_per_pixel = (bpp+7)/8;
 
@@ -84,21 +86,22 @@ heif_image* convert_libde265_image_to_heif_image(const struct de265_image* de265
     }
   }
 
-
-  heif_image* out_C_img = (heif_image*)(new std::shared_ptr<HeifPixelImage>(out_img));
-
-  return out_C_img;
+  *image = out_img;
+  return err;
 }
 
 
-void* libde265_new_decoder()
+struct heif_error libde265_new_decoder(struct heif_context* ctx, void** dec)
 {
   struct libde265_decoder* decoder = new libde265_decoder();
+  struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, kSuccess };
 
+  decoder->heif_ctx = ctx;
   decoder->ctx = de265_new_decoder();
   de265_start_worker_threads(decoder->ctx,1);
 
-  return decoder;
+  *dec = decoder;
+  return err;
 }
 
 void libde265_free_decoder(void* decoder_raw)
@@ -114,48 +117,58 @@ void libde265_free_decoder(void* decoder_raw)
 
 #if LIBDE265_NUMERIC_VERSION >= 0x02000000
 
-void libde265_v2_push_data(void* decoder_raw, const void* data, size_t size)
+struct heif_error libde265_v2_push_data(void* decoder_raw, const void* data, size_t size)
 {
   struct libde265_decoder* decoder = (struct libde265_decoder*)decoder_raw;
+  struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, kSuccess };
 
+  // TODO(farindk): Set "err" if data could not be pushed
   de265_push_data(decoder->ctx, data, size, 0, nullptr);
+  return err;
 }
 
 
-void libde265_v2_decode_image(void* decoder_raw, struct heif_image** out_img)
+struct heif_error libde265_v2_decode_image(void* decoder_raw, struct heif_image** out_img)
 {
   struct libde265_decoder* decoder = (struct libde265_decoder*)decoder_raw;
+  struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, kSuccess };
 
   de265_push_end_of_stream(decoder->ctx);
 
   int action = de265_get_action(decoder->ctx, 1);
 
+  // TODO(farindk): Set "err" if no image was decoded.
   if (action==de265_action_get_image) {
     const de265_image* img = de265_get_next_picture(decoder->ctx);
     if (img) {
-      *out_img = convert_libde265_image_to_heif_image(img);
-
+      err = convert_libde265_image_to_heif_image(decoder, img, out_img);
       de265_release_picture(img);
     }
   }
+  return err;
 }
 
 #else
 
-void libde265_v1_push_data(void* decoder_raw, const void* data, size_t size)
+struct heif_error libde265_v1_push_data(void* decoder_raw, const void* data, size_t size)
 {
   struct libde265_decoder* decoder = (struct libde265_decoder*)decoder_raw;
+  struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, kSuccess };
 
+  // TODO(farindk): Set "err" if data could not be pushed
   de265_push_data(decoder->ctx, data, size, 0, nullptr);
+  return err;
 }
 
 
-void libde265_v1_decode_image(void* decoder_raw, struct heif_image** out_img)
+struct heif_error libde265_v1_decode_image(void* decoder_raw, struct heif_image** out_img)
 {
   struct libde265_decoder* decoder = (struct libde265_decoder*)decoder_raw;
+  struct heif_error err = { heif_error_Ok, heif_suberror_Unspecified, kSuccess };
 
   de265_flush_data(decoder->ctx);
 
+  // TODO(farindk): Set "err" if no image was decoded.
   int more;
   de265_error decode_err;
   do {
@@ -168,11 +181,13 @@ void libde265_v1_decode_image(void* decoder_raw, struct heif_image** out_img)
 
     const struct de265_image* image = de265_get_next_picture(decoder->ctx);
     if (image) {
-      *out_img = convert_libde265_image_to_heif_image(image);
+      err = convert_libde265_image_to_heif_image(decoder, image, out_img);
 
       de265_release_next_picture(decoder->ctx);
     }
   } while (more);
+
+  return err;
 }
 
 #endif
@@ -203,6 +218,6 @@ static const struct heif_decoder_plugin decoder_libde265
 
 #endif
 
-const struct heif_decoder_plugin* get_decoder_plugin_libde265() { return &decoder_libde265; }
-
+const struct heif_decoder_plugin* get_decoder_plugin_libde265() {
+  return &decoder_libde265;
 }

--- a/src/heif_decoder_libde265.h
+++ b/src/heif_decoder_libde265.h
@@ -21,10 +21,6 @@
 #ifndef LIBHEIF_HEIF_DECODER_DE265_H
 #define LIBHEIF_HEIF_DECODER_DE265_H
 
-extern "C" {
-
 const struct heif_decoder_plugin* get_decoder_plugin_libde265();
-
-}
 
 #endif

--- a/src/heif_file.cc
+++ b/src/heif_file.cc
@@ -562,7 +562,7 @@ Error HeifFile::decode_full_grid_image(struct heif_context* ctx, uint16_t ID,
   int h = grid.get_height();
   int bpp = 8; // TODO: how do we know ?
 
-  img = std::make_shared<HeifPixelImage>(ctx->context);
+  img = std::make_shared<HeifPixelImage>();
   img->create(w,h,
               heif_colorspace_YCbCr, // TODO: how do we know ?
               heif_chroma_420); // TODO: how do we know ?

--- a/src/heif_file.cc
+++ b/src/heif_file.cc
@@ -451,7 +451,7 @@ Error HeifFile::decode_image(struct heif_context* ctx, uint32_t ID,
     assert(m_decoder_plugin); // TODO
 
     void* decoder;
-    struct heif_error err = m_decoder_plugin->new_decoder(ctx, &decoder);
+    struct heif_error err = m_decoder_plugin->new_decoder(&decoder);
     if (err.code != heif_error_Ok) {
       return Error(err.code, err.subcode, err.message);
     }

--- a/src/heif_file.cc
+++ b/src/heif_file.cc
@@ -22,7 +22,6 @@
 #include "config.h"
 #endif
 
-#include "heif.h"
 #include "heif_file.h"
 #include "heif_image.h"
 #include "heif_api_structs.h"
@@ -434,7 +433,7 @@ Error HeifFile::get_compressed_image_data(uint16_t ID, std::vector<uint8_t>* dat
 }
 
 
-Error HeifFile::decode_image(struct heif_context* ctx, uint32_t ID,
+Error HeifFile::decode_image(uint32_t ID,
                              std::shared_ptr<HeifPixelImage>& img) const
 {
   std::string image_type = get_image_type(ID);
@@ -489,7 +488,7 @@ Error HeifFile::decode_image(struct heif_context* ctx, uint32_t ID,
 #endif
   }
   else if (image_type == "grid") {
-    error = decode_full_grid_image(ctx, ID, img, data);
+    error = decode_full_grid_image(ID, img, data);
     if (error) {
       return error;
     }
@@ -528,7 +527,7 @@ Error HeifFile::decode_image(struct heif_context* ctx, uint32_t ID,
 
 // TODO: this function only works with YCbCr images, chroma 4:2:0, and 8 bpp at the moment
 // It will crash badly if we get anything else.
-Error HeifFile::decode_full_grid_image(struct heif_context* ctx, uint16_t ID,
+Error HeifFile::decode_full_grid_image(uint16_t ID,
                                        std::shared_ptr<HeifPixelImage>& img,
                                        const std::vector<uint8_t>& grid_data) const
 {
@@ -582,7 +581,7 @@ Error HeifFile::decode_full_grid_image(struct heif_context* ctx, uint16_t ID,
 
       std::shared_ptr<HeifPixelImage> tile_img;
 
-      Error err = decode_image(ctx, image_references[reference_idx],
+      Error err = decode_image(image_references[reference_idx],
                                tile_img);
       if (err != Error::Ok) {
         return err;

--- a/src/heif_file.h
+++ b/src/heif_file.h
@@ -26,8 +26,6 @@
 #include <map>
 #include <assert.h>
 
-struct heif_context;
-
 namespace heif {
 
   class HeifPixelImage;
@@ -54,7 +52,7 @@ namespace heif {
 
     Error get_compressed_image_data(uint16_t ID, std::vector<uint8_t>* out_data) const;
 
-    Error decode_image(struct heif_context* ctx, uint32_t ID, std::shared_ptr<HeifPixelImage>& img) const;
+    Error decode_image(uint32_t ID, std::shared_ptr<HeifPixelImage>& img) const;
 
 
 
@@ -100,7 +98,7 @@ namespace heif {
     const struct heif_decoder_plugin* m_decoder_plugin = nullptr;
 
     Error parse_heif_file(BitstreamRange& bitstream);
-    Error decode_full_grid_image(struct heif_context* ctx, uint16_t ID,
+    Error decode_full_grid_image(uint16_t ID,
                                  std::shared_ptr<HeifPixelImage>& img,
                                  const std::vector<uint8_t>& grid_data) const;
 

--- a/src/heif_file.h
+++ b/src/heif_file.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <assert.h>
 
+struct heif_context;
 
 namespace heif {
 
@@ -53,7 +54,7 @@ namespace heif {
 
     Error get_compressed_image_data(uint16_t ID, std::vector<uint8_t>* out_data) const;
 
-    Error decode_image(uint32_t ID, std::shared_ptr<HeifPixelImage>& img) const;
+    Error decode_image(struct heif_context* ctx, uint32_t ID, std::shared_ptr<HeifPixelImage>& img) const;
 
 
 
@@ -99,7 +100,7 @@ namespace heif {
     const struct heif_decoder_plugin* m_decoder_plugin = nullptr;
 
     Error parse_heif_file(BitstreamRange& bitstream);
-    Error decode_full_grid_image(uint16_t ID,
+    Error decode_full_grid_image(struct heif_context* ctx, uint16_t ID,
                                  std::shared_ptr<HeifPixelImage>& img,
                                  const std::vector<uint8_t>& grid_data) const;
 

--- a/src/heif_image.cc
+++ b/src/heif_image.cc
@@ -20,7 +20,6 @@
 
 
 #include "heif_image.h"
-#include "heif_context.h"
 
 #include <assert.h>
 
@@ -28,7 +27,7 @@
 using namespace heif;
 
 
-HeifPixelImage::HeifPixelImage(std::shared_ptr<HeifContext> context) : m_context(context)
+HeifPixelImage::HeifPixelImage()
 {
 }
 
@@ -179,7 +178,7 @@ std::shared_ptr<HeifPixelImage> HeifPixelImage::convert_YCbCr420_to_RGB() const
     return nullptr;
   }
 
-  auto outimg = std::make_shared<HeifPixelImage>(m_context);
+  auto outimg = std::make_shared<HeifPixelImage>();
 
   int bpp = 8; // TODO: how do we specify the output BPPs ?
 
@@ -229,7 +228,7 @@ std::shared_ptr<HeifPixelImage> HeifPixelImage::convert_YCbCr420_to_RGB24() cons
     return nullptr;
   }
 
-  auto outimg = std::make_shared<HeifPixelImage>(m_context);
+  auto outimg = std::make_shared<HeifPixelImage>();
 
   outimg->create(m_width, m_height, heif_colorspace_RGB, heif_chroma_interleaved_24bit);
 
@@ -281,7 +280,7 @@ Error HeifPixelImage::rotate(int angle_degrees,
     std::swap(out_width, out_height);
   }
 
-  out_img = std::make_shared<HeifPixelImage>(m_context);
+  out_img = std::make_shared<HeifPixelImage>();
   out_img->create(out_width, out_height, m_colorspace, m_chroma);
 
 

--- a/src/heif_image.cc
+++ b/src/heif_image.cc
@@ -20,12 +20,17 @@
 
 
 #include "heif_image.h"
+#include "heif_context.h"
 
 #include <assert.h>
 
 
 using namespace heif;
 
+
+HeifPixelImage::HeifPixelImage(std::shared_ptr<HeifContext> context) : m_context(context)
+{
+}
 
 HeifPixelImage::~HeifPixelImage()
 {
@@ -174,7 +179,7 @@ std::shared_ptr<HeifPixelImage> HeifPixelImage::convert_YCbCr420_to_RGB() const
     return nullptr;
   }
 
-  auto outimg = std::make_shared<HeifPixelImage>();
+  auto outimg = std::make_shared<HeifPixelImage>(m_context);
 
   int bpp = 8; // TODO: how do we specify the output BPPs ?
 
@@ -224,7 +229,7 @@ std::shared_ptr<HeifPixelImage> HeifPixelImage::convert_YCbCr420_to_RGB24() cons
     return nullptr;
   }
 
-  auto outimg = std::make_shared<HeifPixelImage>();
+  auto outimg = std::make_shared<HeifPixelImage>(m_context);
 
   outimg->create(m_width, m_height, heif_colorspace_RGB, heif_chroma_interleaved_24bit);
 
@@ -276,7 +281,7 @@ Error HeifPixelImage::rotate(int angle_degrees,
     std::swap(out_width, out_height);
   }
 
-  out_img = std::make_shared<HeifPixelImage>();
+  out_img = std::make_shared<HeifPixelImage>(m_context);
   out_img->create(out_width, out_height, m_colorspace, m_chroma);
 
 

--- a/src/heif_image.h
+++ b/src/heif_image.h
@@ -33,12 +33,17 @@
 
 namespace heif {
 
+class HeifContext;
+
 class HeifPixelImage : public std::enable_shared_from_this<HeifPixelImage>
 {
  public:
+  explicit HeifPixelImage(std::shared_ptr<HeifContext> context);
   ~HeifPixelImage();
 
   void create(int width,int height, heif_colorspace colorspace, heif_chroma chroma);
+
+  std::shared_ptr<heif::HeifContext> context() const { return m_context; }
 
   void add_plane(heif_channel channel, int width, int height, int bit_depth);
 
@@ -79,6 +84,7 @@ class HeifPixelImage : public std::enable_shared_from_this<HeifPixelImage>
     int stride;
   };
 
+  std::shared_ptr<HeifContext> m_context;
   int m_width = 0;
   int m_height = 0;
   heif_colorspace m_colorspace = heif_colorspace_undefined;

--- a/src/heif_image.h
+++ b/src/heif_image.h
@@ -33,17 +33,13 @@
 
 namespace heif {
 
-class HeifContext;
-
 class HeifPixelImage : public std::enable_shared_from_this<HeifPixelImage>
 {
  public:
-  explicit HeifPixelImage(std::shared_ptr<HeifContext> context);
+  explicit HeifPixelImage();
   ~HeifPixelImage();
 
   void create(int width,int height, heif_colorspace colorspace, heif_chroma chroma);
-
-  std::shared_ptr<heif::HeifContext> context() const { return m_context; }
 
   void add_plane(heif_channel channel, int width, int height, int bit_depth);
 
@@ -84,7 +80,6 @@ class HeifPixelImage : public std::enable_shared_from_this<HeifPixelImage>
     int stride;
   };
 
-  std::shared_ptr<HeifContext> m_context;
   int m_width = 0;
   int m_height = 0;
   heif_colorspace m_colorspace = heif_colorspace_undefined;


### PR DESCRIPTION
- All functions that can potentially fail now return a `heif_error`.
- Decoding plugins can also return errors in case something fails.
- The libde265 decoder only uses the public API.