### PR TITLE
build for macOS high sierra.

### DIFF
--- a/examples/encoder_jpeg.cc
+++ b/examples/encoder_jpeg.cc
@@ -71,9 +71,9 @@ bool JpegEncoder::Encode(const struct heif_image_handle* handle,
   cinfo.input_components = 3;
   cinfo.in_color_space = JCS_YCbCr;
   jpeg_set_defaults(&cinfo);
-  static const bool kForceBaseline = true;
+  static const boolean kForceBaseline = TRUE;
   jpeg_set_quality(&cinfo, quality_, kForceBaseline);
-  static const bool kWriteAllTables = true;
+  static const boolean kWriteAllTables = TRUE;
   jpeg_start_compress(&cinfo, kWriteAllTables);
 
   size_t exifsize = 0;

--- a/examples/encoder_png.cc
+++ b/examples/encoder_png.cc
@@ -18,6 +18,7 @@
  * along with convert.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <assert.h>
+#include <errno.h>
 #include <math.h>
 #include <png.h>
 #include <string.h>


### PR DESCRIPTION
fixing to build error on macOS high sierra.
- bool & boolean confusion on calling jpeglib functions
- errno variables need errno.h

----
% gcc -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 9.0.0 (clang-900.0.38)
Target: x86_64-apple-darwin17.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
