### PR TITLE
Mark operator() on comparator function as const

### DIFF
--- a/src/heif_plugin_registry.cc
+++ b/src/heif_plugin_registry.cc
@@ -39,7 +39,7 @@ std::set<const struct heif_decoder_plugin*> heif::s_decoder_plugins;
 struct encoder_descriptor_priority_order
 {
   bool operator() (const std::unique_ptr<struct heif_encoder_descriptor>& a,
-                   const std::unique_ptr<struct heif_encoder_descriptor>& b) consts {
+                   const std::unique_ptr<struct heif_encoder_descriptor>& b) const {
     return a->plugin->priority > b->plugin->priority;  // highest priority first
   }
 };

--- a/src/heif_plugin_registry.cc
+++ b/src/heif_plugin_registry.cc
@@ -39,7 +39,7 @@ std::set<const struct heif_decoder_plugin*> heif::s_decoder_plugins;
 struct encoder_descriptor_priority_order
 {
   bool operator() (const std::unique_ptr<struct heif_encoder_descriptor>& a,
-                   const std::unique_ptr<struct heif_encoder_descriptor>& b) {
+                   const std::unique_ptr<struct heif_encoder_descriptor>& b) consts {
     return a->plugin->priority > b->plugin->priority;  // highest priority first
   }
 };


### PR DESCRIPTION
Without this, on a sufficiently new clang, with enough warnings turned on, you get a compilation error:

https://gist.github.com/reaperhulk/17f35e9410177970677bb9a30958f884