### PR TITLE
Fix VPATH (out-of-tree) builds.

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -6,7 +6,7 @@ bin_PROGRAMS = \
   heif-info
 
 heif_convert_DEPENDENCIES = ../src/libheif.la
-heif_convert_CXXFLAGS = -I../src
+heif_convert_CXXFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src
 heif_convert_LDFLAGS =
 heif_convert_LDADD = ../src/libheif.la
 heif_convert_SOURCES = encoder.cc encoder.h heif_convert.cc
@@ -15,7 +15,7 @@ heif_convert_SOURCES = encoder.cc encoder.h heif_convert.cc
 if HAVE_LIBPNG
 bin_PROGRAMS += heif-thumbnailer
 heif_thumbnailer_DEPENDENCIES = ../src/libheif.la
-heif_thumbnailer_CXXFLAGS = -I../src $(libpng_CFLAGS)
+heif_thumbnailer_CXXFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src $(libpng_CFLAGS)
 heif_thumbnailer_LDFLAGS = $(libpng_LIBS)
 heif_thumbnailer_LDADD = ../src/libheif.la
 heif_thumbnailer_SOURCES = encoder.cc encoder.h heif_thumbnailer.cc encoder_png.cc encoder_png.h
@@ -34,13 +34,13 @@ heif_convert_SOURCES += encoder_png.cc encoder_png.h
 endif
 
 heif_info_DEPENDENCIES = ../src/libheif.la
-heif_info_CXXFLAGS = -I../src
+heif_info_CXXFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src
 heif_info_LDFLAGS =
 heif_info_LDADD = ../src/libheif.la
 heif_info_SOURCES = heif_info.cc
 
 heif_enc_DEPENDENCIES = ../src/libheif.la
-heif_enc_CXXFLAGS = -I../src
+heif_enc_CXXFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src
 heif_enc_LDFLAGS =
 heif_enc_LDADD = ../src/libheif.la
 heif_enc_SOURCES = heif_enc.cc


### PR DESCRIPTION
I always do VPATH builds, and libheif was not building correctly because some files were in the src dir and other in the build dir, and the current automake code was not properly looking in both.

This fixes it.