### PR TITLE
Pass "-no-undefined" when linking with MinGW.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_GREP
+AM_CONDITIONAL(MINGW, expr $host : '.*-mingw' >/dev/null 2>&1)
 
 AM_INIT_AUTOMAKE([foreign])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,9 @@ libheif_la_CXXFLAGS = \
 libheif_la_LIBADD = $(ADDITIONAL_LIBS)
 
 libheif_la_LDFLAGS = -version-info $(LIBHEIF_CURRENT):$(LIBHEIF_REVISION):$(LIBHEIF_AGE)
+if MINGW
+libheif_la_LDFLAGS += -no-undefined
+endif
 
 libheif_la_SOURCES = \
   bitstream.h \


### PR DESCRIPTION
This should fix the error reported in #28.

@Jehan: could you please check if this fixes the error you were getting?