### PR TITLE
Modified the search order: directory first, then library

### DIFF
--- a/libheif.pc.in
+++ b/libheif.pc.in
@@ -10,6 +10,6 @@ Description: HEIF image codec.
 URL: https://github.com/strukturag/libheif
 Version: @VERSION@
 Requires:
-Libs: -lheif -L@libdir@
+Libs: -L@libdir@ -lheif
 Libs.private: @LIBS@ -lstdc++
 Cflags: -I@includedir@


### PR DESCRIPTION
During development of [HEIF plug-in for darktable](https://gitlab.websupport.sk/peter.kovar/darktable/tree/HEIF) I've noticed incorrect library search path order.