### PR TITLE
go: Delegate responsibility to free C-allocated memory to caller

### DIFF
--- a/examples/heif-test.go
+++ b/examples/heif-test.go
@@ -78,6 +78,7 @@ func testHeifLowlevel(filename string) {
 		fmt.Printf("Could not create context: %s\n", err)
 		return
 	}
+	defer c.Free()
 
 	if err := c.ReadFromFile(filename); err != nil {
 		fmt.Printf("Could not read file %s: %s\n", filename, err)
@@ -101,13 +102,17 @@ func testHeifLowlevel(filename string) {
 		fmt.Printf("Could not get primary image: %s\n", err)
 		return
 	}
+	defer handle.Free()
 
 	fmt.Printf("Image size: %v × %v\n", handle.GetWidth(), handle.GetHeight())
 
 	img, err := handle.DecodeImage(heif.ColorspaceUndefined, heif.ChromaUndefined, nil)
 	if err != nil {
 		fmt.Printf("Could not decode image: %s\n", err)
-	} else if i, err := img.GetImage(); err != nil {
+	}
+	defer img.Free()
+
+	if i, err := img.GetImage(); err != nil {
 		fmt.Printf("Could not get image: %s\n", err)
 	} else {
 		fmt.Printf("Rectangle: %v\n", i.Bounds())


### PR DESCRIPTION
This fixes an issue where struct members were passed to external C
functions after which the struct was no longer referenced.
As described in the docs of runtime.SetFinalizer, this would allow
the Go garbage collector to run every finalizer associated with the
struct (as it will no longer be used). Unfortunately, as we bound
a finalizer to free every C-allocated struct member, those
finalizers were run, freeing the struct members too early.

This patch currently requires the caller to manually call .Free()
on the following structs once they are no longer required:
- Context
- ImageHandle
- DecodingOptions
- Image

Such structs are currently returned by the following functions:
- NewContext
- NewDecodingOptions
- NewImage
- Context.GetPrimaryImageHandle
- Context.GetImageHandle
- ImageHandle.GetDepthImageHandle
- ImageHandle.GetThumbnail
- ImageHandle.DecodeImage
- Image.ScaleImage