### PR TITLE
go: Fix C-allocated struct members being freed too early

### DIFF
--- a/go/heif/heif.go
+++ b/go/heif/heif.go
@@ -329,12 +329,14 @@ func (c *Context) ReadFromFile(filename string) error {
 	defer C.free(unsafe.Pointer(c_filename))
 
 	err := C.heif_context_read_from_file(c.context, c_filename, nil)
+	runtime.KeepAlive(c)
 	return convertHeifError(err)
 }
 
 func (c *Context) ReadFromMemory(data []byte) error {
 	// TODO: Use reader API internally.
 	err := C.heif_context_read_from_memory(c.context, unsafe.Pointer(&data[0]), C.size_t(len(data)), nil)
+	runtime.KeepAlive(c)
 	return convertHeifError(err)
 }
 
@@ -354,16 +356,19 @@ func (e *Encoder) Name() string {
 
 func (e *Encoder) SetQuality(q int) error {
 	err := C.heif_encoder_set_lossy_quality(e.encoder, C.int(q))
+	runtime.KeepAlive(e)
 	return convertHeifError(err)
 }
 
 func (e *Encoder) SetLossless(l LosslessMode) error {
 	err := C.heif_encoder_set_lossless(e.encoder, C.int(l))
+	runtime.KeepAlive(e)
 	return convertHeifError(err)
 }
 
 func (e *Encoder) SetLoggingLevel(l LoggingLevel) error {
 	err := C.heif_encoder_set_logging_level(e.encoder, C.int(l))
+	runtime.KeepAlive(e)
 	return convertHeifError(err)
 }
 
@@ -381,6 +386,7 @@ func (c *Context) convertEncoderDescriptor(d *C.struct_heif_encoder_descriptor) 
 		name: C.GoString(cname),
 	}
 	err := C.heif_context_get_encoder(c.context, d, &enc.encoder)
+	runtime.KeepAlive(c)
 	if err := convertHeifError(err); err != nil {
 		return nil, err
 	}
@@ -392,6 +398,7 @@ func (c *Context) NewEncoder(compression Compression) (*Encoder, error) {
 	const max = 1
 	descriptors := make([]*C.struct_heif_encoder_descriptor, max)
 	num := int(C.heif_context_get_encoder_descriptors(c.context, uint32(compression), nil, &descriptors[0], C.int(max)))
+	runtime.KeepAlive(c)
 	if num == 0 {
 		return nil, fmt.Errorf("no encoder for compression %v", compression)
 	}
@@ -400,35 +407,42 @@ func (c *Context) NewEncoder(compression Compression) (*Encoder, error) {
 
 func (c *Context) WriteToFile(filename string) error {
 	err := C.heif_context_write_to_file(c.context, C.CString(filename))
+	runtime.KeepAlive(c)
 	return convertHeifError(err)
 }
 
 func (c *Context) GetNumberOfTopLevelImages() int {
-	return int(C.heif_context_get_number_of_top_level_images(c.context))
+	i := int(C.heif_context_get_number_of_top_level_images(c.context))
+	runtime.KeepAlive(c)
+	return i
 }
 
 func (c *Context) IsTopLevelImageID(ID int) bool {
-	return C.heif_context_is_top_level_image_ID(c.context, C.heif_item_id(ID)) != 0
+	ok := C.heif_context_is_top_level_image_ID(c.context, C.heif_item_id(ID)) != 0
+	runtime.KeepAlive(c)
+	return ok
 }
 
 func (c *Context) GetListOfTopLevelImageIDs() []int {
 	num := int(C.heif_context_get_number_of_top_level_images(c.context))
+	runtime.KeepAlive(c)
 	if num == 0 {
 		return []int{}
 	}
 
 	origIDs := make([]C.heif_item_id, num)
 	C.heif_context_get_list_of_top_level_image_IDs(c.context, &origIDs[0], C.int(num))
+	runtime.KeepAlive(c)
 	return convertItemIDs(origIDs, num)
 }
 
 func (c *Context) GetPrimaryImageID() (int, error) {
 	var id C.heif_item_id
 	err := C.heif_context_get_primary_image_ID(c.context, &id)
+	runtime.KeepAlive(c)
 	if err := convertHeifError(err); err != nil {
 		return 0, err
 	}
-
 	return int(id), nil
 }
 
@@ -447,6 +461,7 @@ func freeHeifImageHandle(c *ImageHandle) {
 func (c *Context) GetPrimaryImageHandle() (*ImageHandle, error) {
 	var handle ImageHandle
 	err := C.heif_context_get_primary_image_handle(c.context, &handle.handle)
+	runtime.KeepAlive(c)
 	if err := convertHeifError(err); err != nil {
 		return nil, err
 	}
@@ -457,6 +472,7 @@ func (c *Context) GetPrimaryImageHandle() (*ImageHandle, error) {
 func (c *Context) GetImageHandle(id int) (*ImageHandle, error) {
 	var handle ImageHandle
 	err := C.heif_context_get_image_handle(c.context, C.heif_item_id(id), &handle.handle)
+	runtime.KeepAlive(c)
 	if err := convertHeifError(err); err != nil {
 		return nil, err
 	}
@@ -465,43 +481,58 @@ func (c *Context) GetImageHandle(id int) (*ImageHandle, error) {
 }
 
 func (h *ImageHandle) IsPrimaryImage() bool {
-	return C.heif_image_handle_is_primary_image(h.handle) != 0
+	ok := C.heif_image_handle_is_primary_image(h.handle) != 0
+	runtime.KeepAlive(h)
+	return ok
 }
 
 func (h *ImageHandle) GetWidth() int {
-	return int(C.heif_image_handle_get_width(h.handle))
+	i := int(C.heif_image_handle_get_width(h.handle))
+	runtime.KeepAlive(h)
+	return i
 }
 
 func (h *ImageHandle) GetHeight() int {
-	return int(C.heif_image_handle_get_height(h.handle))
+	i := int(C.heif_image_handle_get_height(h.handle))
+	runtime.KeepAlive(h)
+	return i
 }
 
 func (h *ImageHandle) HasAlphaChannel() bool {
-	return C.heif_image_handle_has_alpha_channel(h.handle) != 0
+	ok := C.heif_image_handle_has_alpha_channel(h.handle) != 0
+	runtime.KeepAlive(h)
+	return ok
 }
 
 func (h *ImageHandle) HasDepthImage() bool {
-	return C.heif_image_handle_has_depth_image(h.handle) != 0
+	ok := C.heif_image_handle_has_depth_image(h.handle) != 0
+	runtime.KeepAlive(h)
+	return ok
 }
 
 func (h *ImageHandle) GetNumberOfDepthImages() int {
-	return int(C.heif_image_handle_get_number_of_depth_images(h.handle))
+	i := int(C.heif_image_handle_get_number_of_depth_images(h.handle))
+	runtime.KeepAlive(h)
+	return i
 }
 
 func (h *ImageHandle) GetListOfDepthImageIDs() []int {
 	num := int(C.heif_image_handle_get_number_of_depth_images(h.handle))
+	runtime.KeepAlive(h)
 	if num == 0 {
 		return []int{}
 	}
 
 	origIDs := make([]C.heif_item_id, num)
 	C.heif_image_handle_get_list_of_depth_image_IDs(h.handle, &origIDs[0], C.int(num))
+	runtime.KeepAlive(h)
 	return convertItemIDs(origIDs, num)
 }
 
 func (h *ImageHandle) GetDepthImageHandle(depth_image_id int) (*ImageHandle, error) {
 	var handle ImageHandle
 	err := C.heif_image_handle_get_depth_image_handle(h.handle, C.heif_item_id(depth_image_id), &handle.handle)
+	runtime.KeepAlive(h)
 	if err := convertHeifError(err); err != nil {
 		return nil, err
 	}
@@ -511,23 +542,28 @@ func (h *ImageHandle) GetDepthImageHandle(depth_image_id int) (*ImageHandle, err
 }
 
 func (h *ImageHandle) GetNumberOfThumbnails() int {
-	return int(C.heif_image_handle_get_number_of_thumbnails(h.handle))
+	i := int(C.heif_image_handle_get_number_of_thumbnails(h.handle))
+	runtime.KeepAlive(h)
+	return i
 }
 
 func (h *ImageHandle) GetListOfThumbnailIDs() []int {
 	num := int(C.heif_image_handle_get_number_of_thumbnails(h.handle))
+	runtime.KeepAlive(h)
 	if num == 0 {
 		return []int{}
 	}
 
 	origIDs := make([]C.heif_item_id, num)
 	C.heif_image_handle_get_list_of_thumbnail_IDs(h.handle, &origIDs[0], C.int(num))
+	runtime.KeepAlive(h)
 	return convertItemIDs(origIDs, num)
 }
 
 func (h *ImageHandle) GetThumbnail(thumbnail_id int) (*ImageHandle, error) {
 	var handle ImageHandle
 	err := C.heif_image_handle_get_thumbnail(h.handle, C.heif_item_id(thumbnail_id), &handle.handle)
+	runtime.KeepAlive(h)
 	runtime.SetFinalizer(&handle, freeHeifImageHandle)
 	return &handle, convertHeifError(err)
 }
@@ -587,6 +623,7 @@ func (h *ImageHandle) DecodeImage(colorspace Colorspace, chroma Chroma, options 
 	}
 
 	err := C.heif_decode_image(h.handle, &image.image, uint32(colorspace), uint32(chroma), opt)
+	runtime.KeepAlive(h)
 	if err := convertHeifError(err); err != nil {
 		return nil, err
 	}
@@ -596,23 +633,33 @@ func (h *ImageHandle) DecodeImage(colorspace Colorspace, chroma Chroma, options 
 }
 
 func (img *Image) GetColorspace() Colorspace {
-	return Colorspace(C.heif_image_get_colorspace(img.image))
+	cs := Colorspace(C.heif_image_get_colorspace(img.image))
+	runtime.KeepAlive(img)
+	return cs
 }
 
 func (img *Image) GetChromaFormat() Chroma {
-	return Chroma(C.heif_image_get_chroma_format(img.image))
+	c := Chroma(C.heif_image_get_chroma_format(img.image))
+	runtime.KeepAlive(img)
+	return c
 }
 
 func (img *Image) GetWidth(channel Channel) int {
-	return int(C.heif_image_get_width(img.image, uint32(channel)))
+	i := int(C.heif_image_get_width(img.image, uint32(channel)))
+	runtime.KeepAlive(img)
+	return i
 }
 
 func (img *Image) GetHeight(channel Channel) int {
-	return int(C.heif_image_get_height(img.image, uint32(channel)))
+	i := int(C.heif_image_get_height(img.image, uint32(channel)))
+	runtime.KeepAlive(img)
+	return i
 }
 
 func (img *Image) GetBitsPerPixel(channel Channel) int {
-	return int(C.heif_image_get_bits_per_pixel(img.image, uint32(channel)))
+	i := int(C.heif_image_get_bits_per_pixel(img.image, uint32(channel)))
+	runtime.KeepAlive(img)
+	return i
 }
 
 func (img *Image) GetImage() (image.Image, error) {
@@ -718,12 +765,14 @@ func (i *ImageAccess) setData(data []byte, stride int) {
 
 func (img *Image) GetPlane(channel Channel) (*ImageAccess, error) {
 	height := C.heif_image_get_height(img.image, uint32(channel))
+	runtime.KeepAlive(img)
 	if height == -1 {
 		return nil, fmt.Errorf("No such channel %v", channel)
 	}
 
 	var stride C.int
 	plane := C.heif_image_get_plane(img.image, uint32(channel), &stride)
+	runtime.KeepAlive(img)
 	if plane == nil {
 		return nil, fmt.Errorf("No such channel %v", channel)
 	}
@@ -742,6 +791,7 @@ func (img *Image) GetPlane(channel Channel) (*ImageAccess, error) {
 
 func (img *Image) NewPlane(channel Channel, width, height, depth int) (*ImageAccess, error) {
 	err := C.heif_image_add_plane(img.image, uint32(channel), C.int(width), C.int(height), C.int(depth))
+	runtime.KeepAlive(img)
 	if err := convertHeifError(err); err != nil {
 		return nil, err
 	}
@@ -751,6 +801,7 @@ func (img *Image) NewPlane(channel Channel, width, height, depth int) (*ImageAcc
 func (img *Image) ScaleImage(width int, height int) (*Image, error) {
 	var scaled_image Image
 	err := C.heif_image_scale_image(img.image, &scaled_image.image, C.int(width), C.int(height), nil)
+	runtime.KeepAlive(img)
 	if err := convertHeifError(err); err != nil {
 		return nil, err
 	}
@@ -943,6 +994,10 @@ func EncodeFromImage(img image.Image, compression Compression, quality int, loss
 
 	var handle ImageHandle
 	err2 := C.heif_context_encode_image(ctx.context, out.image, enc.encoder, encOpts.options, &handle.handle)
+	runtime.KeepAlive(ctx)
+	runtime.KeepAlive(out)
+	runtime.KeepAlive(enc)
+	runtime.KeepAlive(encOpts)
 	if err := convertHeifError(err2); err != nil {
 		return nil, fmt.Errorf("failed to encode image: %v", err)
 	}


### PR DESCRIPTION
This fixes an issue where struct members were passed to external C
functions after which the struct was no longer referenced.
As described in the docs of runtime.SetFinalizer, this would allow
the Go garbage collector to run every finalizer associated with the
struct (as it will no longer be used). Unfortunately, as we bound
a finalizer to free every C-allocated struct member, those
finalizers were run, freeing the struct members too early.