### PR TITLE
Allow 10-bit and 12-bit encoding

### DIFF
--- a/examples/encoder_png.cc
+++ b/examples/encoder_png.cc
@@ -85,7 +85,7 @@ bool PngEncoder::Encode(const struct heif_image_handle* handle,
     heif_image_handle_get_raw_color_profile(handle, profile_data);
     char profile_name[] = "unknown";
     png_set_iCCP(png_ptr, info_ptr, profile_name, PNG_COMPRESSION_TYPE_BASE,
-#if PNG_LIBPNG_VER <= 10250
+#if PNG_LIBPNG_VER < 10500
                  (png_charp)profile_data,
 #else
                  (png_const_bytep)profile_data,


### PR DESCRIPTION
As it is now, libheif encoding (with x265) would force an 8-bit encoding (which would not give the expected result if the input image has a higher bit depth). This pull request makes it use the 10-bit or 12-bit variant of x265 if the input image is 10-bit or 12-bit.

I also added or changed some of the x265 parameters; in general, these are to get better compression and better perceptual quality, at the expense of encode speed (since for still images I assume encode speed is not that important but compression and perceptual quality are).

(also libpng introduced png_const_bytep a bit later than what the ifdef said, so the code didn't compile on some libpng versions)