### PR TITLE
Initialize a member of hdlf box.

### DIFF
--- a/libheif/box.h
+++ b/libheif/box.h
@@ -246,7 +246,7 @@ namespace heif {
   private:
     uint32_t m_pre_defined = 0;
     uint32_t m_handler_type = fourcc("pict");
-    uint32_t m_reserved[3];
+    uint32_t m_reserved[3] = {0, };
     std::string m_name;
   };
 


### PR DESCRIPTION
### Changes
 - Initialize a member of the box_hdlr class.

### Related commit:
 - https://github.com/strukturag/libheif/commit/6f5658898e46cf51be5a80fa60cdd4503037615d

### Note
Hello, I'm first commit for libheif library. :) 
I used this library to make ".heif" file from hevc encoded bytes.
The happen is that sometimes, my MacOS doesn't identify the heif file which made by libheif library. 
Finally, I found the reason why heif file is not valid, it is not initialized properly to `m_reserved[3]` value in box_hdlr.
Hopely, I would like to get your reviews and please let me know any comments for this changes.

Thank you. :)