### PR TITLE
fix shared install on cross environments

### DIFF
--- a/gnome/Makefile.am
+++ b/gnome/Makefile.am
@@ -1,7 +1,7 @@
-thumbnailer_dir = $(prefix)/share/thumbnailers
+thumbnailer_dir = $(datadir)/thumbnailers
 thumbnailer__DATA = heif.thumbnailer
 
-mime_dir = $(prefix)/share/mime/packages
+mime_dir = $(datadir)/mime/packages
 mime__DATA = heif.xml
 
 EXTRA_DIST = \


### PR DESCRIPTION
Do not install arch independent files into prefix, which can be e.g.
/usr/x86_64-pc-linux-gnu for cross environments so instead of the files
landing in the arch independent /usr/share they wrongly get installed into
the arch dependent /usr/x86_64-pc-linux-gnu/share location.