### PR TITLE
Support generic metadata

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1858,6 +1858,22 @@ struct heif_error heif_context_add_XMP_metadata(struct heif_context* ctx,
 }
 
 
+struct heif_error heif_context_add_generic_metadata(struct heif_context* ctx,
+                                                    const struct heif_image_handle* image_handle,
+                                                    const void* data, int size,
+                                                    const char* item_type, const char* content_type)
+{
+  Error error = ctx->context->add_generic_metadata(image_handle->image, data, size,
+                                                   item_type, content_type);
+  if (error != Error::Ok) {
+    return error.error_struct(ctx->context.get());
+  }
+  else {
+    return error_Ok;
+  }
+}
+
+
 void heif_context_set_maximum_image_size_limit(struct heif_context* ctx, int maximum_width)
 {
   ctx->context->set_maximum_image_size_limit(maximum_width);

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -1175,6 +1175,15 @@ struct heif_error heif_context_add_XMP_metadata(struct heif_context*,
                                                 const struct heif_image_handle* image_handle,
                                                 const void* data, int size);
 
+// Add generic, proprietary metadata to an image. You have to specify an 'item_type' that will
+// identify your metadata. 'content_type' can be an additional type, or it can be NULL.
+// For example, this function can be used to add IPTC metadata (IIM stream, not XMP) to an image.
+// Even not standard, we propose to store IPTC data with item type="iptc", content_type=NULL.
+struct heif_error heif_context_add_generic_metadata(struct heif_context* ctx,
+                                                    const struct heif_image_handle* image_handle,
+                                                    const void* data, int size,
+                                                    const char* item_type, const char* content_type);
+
 // --- heif_image allocation
 
 // Create a new image of the specified resolution and colorspace.

--- a/libheif/heif_context.h
+++ b/libheif/heif_context.h
@@ -245,6 +245,9 @@ namespace heif {
 
     Error add_XMP_metadata(std::shared_ptr<Image> master_image, const void* data, int size);
 
+    Error add_generic_metadata(std::shared_ptr<Image> master_image, const void* data, int size,
+                               const char* item_type, const char* content_type);
+
     void write(StreamWriter& writer);
 
   private:

--- a/libheif/heif_file.cc
+++ b/libheif/heif_file.cc
@@ -461,7 +461,8 @@ Error HeifFile::get_compressed_image_data(heif_item_id ID, std::vector<uint8_t>*
     }
 
     error = m_iloc_box->read_data(*item, m_input_stream, m_idat_box, data);
-  } else if (item_type == "grid" ||
+  } else if (true ||  // fallback case for all kinds of generic metadata (e.g. 'iptc')
+	     item_type == "grid" ||
              item_type == "iovl" ||
              item_type == "Exif" ||
              (item_type == "mime" && content_type=="application/rdf+xml")) {


### PR DESCRIPTION
Can be used to read / write custom metadata, so fixes #124 if used for IPTC.

@farindk please merge when ready.