### PR TITLE
Add temporary installation directory in macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,30 @@ Also install x265 and its development files if you want to use HEIF encoding.
     brew install automake make pkg-config x265 libde265 libjpeg
     ```
 
+1. Create temporary installation directory for architecture-independent files
 
-1. Configure and build project
+    ```
+    mkdir -p /tmp/libheif
+    ```
+
+1. Configure
 
     ```
     ./autogen.sh
-    ./configure
-    make
+    ./configure --prefix="/tmp/libheif"
     ```
 
+    See `./configure --help` for more options.
+
+1. Build and install
+
+    ```
+    make install
+    ```
+
+For example execute fresh compilation `/tmp/libheif/bin/heif-enc`.
+
+For an other compilation description see the [libheif Formula in Homebrew Core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/libheif.rb).
 
 ## Compiling to JavaScript
 


### PR DESCRIPTION
My motivation was not depend on the repository maintainers to get new binaries with bug fixes. In my case the compilation instructions for macOS work but the executables in the 'examples' directory are wrappers. Because I needed the binaries I added the 'prefix'-flag in the macOS build instructions. Hopefully now it should be transparent where to find fresh compilated binaries. This could decrease the dependence of users on the repository maintainers.

Or is there just a directory where I can find compilated binaries? With a single reference to this directory you could dismiss the temporary directory and the `--prefix` flag.

Thanks @fancycode @farindk for this awesome repository :)