### PR TITLE
Add `-module` flag to get correct extension on macOS

### DIFF
--- a/gdk-pixbuf/Makefile.am
+++ b/gdk-pixbuf/Makefile.am
@@ -7,7 +7,7 @@ gdk_pixbuf_module_LTLIBRARIES += libpixbufloader-heif.la
 libpixbufloader_heif_la_DEPENDENCIES = ../libheif/libheif.la
 libpixbufloader_heif_la_CFLAGS = -I$(top_srcdir) -I$(top_builddir) $(gdkpixbuf_CFLAGS)
 libpixbufloader_heif_la_LIBADD = ../libheif/libheif.la $(gdkpixbuf_LIBS)
-libpixbufloader_heif_la_LDFLAGS = -avoid-version
+libpixbufloader_heif_la_LDFLAGS = -avoid-version -module
 libpixbufloader_heif_la_SOURCES = pixbufloader-heif.c
 endif
 


### PR DESCRIPTION
Without `-module` flag libtool generats `.dylib` extension and pixbuf expects `.so`