### PR TITLE
Fix for the gdk pixbuf `gdk_pixbuf_new_from_file_at_size` call

### DIFF
--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -99,19 +99,19 @@ static gboolean stop_load(gpointer context, GError** error)
 
   width = heif_image_get_width(img, heif_channel_interleaved);
   height = heif_image_get_height(img, heif_channel_interleaved);
-  requested_width = 0;
-  requested_height = 0;
+  requested_width = width;
+  requested_height = height;
+
   if (hpc->size_func) {
     (*hpc->size_func)(&requested_width, &requested_height, hpc->user_data);
   }
 
-  if (requested_width == 0 || requested_height == 0) {
-    width = heif_image_get_width(img, heif_channel_interleaved);
-    height = heif_image_get_height(img, heif_channel_interleaved);
-  } else {
+  if (requested_width && requested_height) {
     struct heif_image* resized;
     heif_image_scale_image(img, &resized, requested_width, requested_height, NULL);
     heif_image_release(img);
+    width = requested_width;
+    height = requested_height;
     img = resized;
   }
 

--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -106,7 +106,7 @@ static gboolean stop_load(gpointer context, GError** error)
     (*hpc->size_func)(&requested_width, &requested_height, hpc->user_data);
   }
 
-  if (requested_width && requested_height) {
+  if (requested_width > 0 && requested_height > 0) {
     struct heif_image* resized;
     heif_image_scale_image(img, &resized, requested_width, requested_height, NULL);
     heif_image_release(img);


### PR DESCRIPTION
1. If new size was requested and image was scaled - redefine width/height to the new values
2. Do not duplicate `heif_image_get_width` for no reason
3. Send image width/height to the size_func call as other pixbuf loaders doing.

This fixing `gdk_pixbuf_new_from_file_at_size` for me.