### PR TITLE
Several fixes to build libheif

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required (VERSION 3.3.2)
 
-project (heif
-    LANGUAGES C CXX
-    VERSION 1.6.1.0
-)
+project(libheif LANGUAGES C CXX VERSION 1.6.1.0)
 
 # https://cmake.org/cmake/help/v3.1/policy/CMP0054.html
 cmake_policy(SET CMP0054 NEW)
@@ -50,8 +47,6 @@ CHECK_CXX_COMPILER_FLAG(-Wno-error=potentially-evaluated-expression has_potentia
 if (has_potentially_evaluated_expression)
   add_definitions(-Wno-error=potentially-evaluated-expression)
 endif()
-
-include_directories ("${PROJECT_SOURCE_DIR}")
 
 add_subdirectory (examples)
 add_subdirectory (libheif)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,6 @@ include(GNUInstallDirs)
 # The version number.
 set (PACKAGE_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 
-configure_file ("libheif/heif_version.h.in" "libheif/heif_version.h")
-
-
 # Check for unistd.h
 
 include (${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,34 @@ if (has_potentially_evaluated_expression)
   add_definitions(-Wno-error=potentially-evaluated-expression)
 endif()
 
+if (UNIX)
+  find_package(PkgConfig)
+  pkg_check_modules(LIBDE265 libde265)
+  pkg_check_modules(X265 x265)
+endif()
+
+# Create libheif pkgconfig file
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+if (LIBDE265_FOUND)
+    set(have_libde265 yes)
+else()
+    set(have_libde265 no)
+endif()
+if (X265_FOUND)
+    set(have_x265 yes)
+else()
+    set(have_x265 no)
+endif()
+set(VERSION ${PROJECT_VERSION})
+
+configure_file(libheif.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libheif.pc @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libheif.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 add_subdirectory (examples)
 add_subdirectory (libheif)
 add_subdirectory (gdk-pixbuf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Create the compile command database for clang by default
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 include(CheckCXXCompilerFlag)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Needed to find libheif/heif_version.h while compiling the library
-include_directories(${PROJECT_BINARY_DIR})
+include_directories(${libheif_BINARY_DIR} ${libheif_SOURCE_DIR})
 
 set (heif_convert_sources
   encoder.cc
@@ -83,16 +83,16 @@ if(MSVC)
 endif()
 
 add_executable (heif-convert ${heif_convert_sources} ${getopt_sources})
-target_link_libraries (heif-convert ${PROJECT_NAME} ${additional_libraries})
+target_link_libraries (heif-convert heif ${additional_libraries})
 
 add_executable (heif-info ${heif_info_sources} ${getopt_sources})
-target_link_libraries (heif-info ${PROJECT_NAME})
+target_link_libraries (heif-info heif)
 
 add_executable (heif-enc ${heif_enc_sources} ${getopt_sources})
-target_link_libraries (heif-enc ${PROJECT_NAME} ${additional_libraries})
+target_link_libraries (heif-enc heif ${additional_libraries})
 
 add_executable (heif-test ${heif_test_sources} ${getopt_sources})
-target_link_libraries (heif-test ${PROJECT_NAME})
+target_link_libraries (heif-test heif)
 
 
 if(LIBPNG_FOUND)
@@ -105,5 +105,5 @@ if(LIBPNG_FOUND)
     )
 
   add_executable (heif-thumbnailer ${heif_thumbnailer_sources})
-  target_link_libraries (heif-thumbnailer ${PROJECT_NAME} ${LIBPNG_LIBRARIES})
+  target_link_libraries (heif-thumbnailer heif ${LIBPNG_LIBRARIES})
 endif()

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -649,8 +649,8 @@ std::shared_ptr<heif_image> loadPNG(const char* filename, int output_bit_depth)
 
       for (uint32_t x = 0; x < nVal ; x++) {
         uint16_t v = (uint16_t)(((p[0]<<8) | p[1]) >> bdShift);
-        p_out[2*x + y*stride + 0] = (v>>8);
-        p_out[2*x + y*stride + 1] = (v & 0xFF);
+        p_out[2*x + y*stride + 0] = (uint8_t)(v >> 8);
+        p_out[2*x + y*stride + 1] = (uint8_t)(v & 0xFF);
         p += 2;
       }
     }

--- a/gdk-pixbuf/CMakeLists.txt
+++ b/gdk-pixbuf/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(UNIX)
-  include (${CMAKE_ROOT}/Modules/FindPkgConfig.cmake)
-  pkg_check_modules (GDKPIXBUF2 gdk-pixbuf-2.0)
+  find_package(PkgConfig)
+  pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
 
   if(GDKPIXBUF2_FOUND)
     execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} gdk-pixbuf-2.0 --variable gdk_pixbuf_moduledir OUTPUT_VARIABLE GDKPIXBUF2_MODULE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/gdk-pixbuf/CMakeLists.txt
+++ b/gdk-pixbuf/CMakeLists.txt
@@ -7,7 +7,7 @@ if(UNIX)
 
     add_library(pixbufloader-heif MODULE pixbufloader-heif.c)
 
-    target_include_directories(pixbufloader-heif PRIVATE ${GDKPIXBUF2_INCLUDE_DIRS})
+    target_include_directories(pixbufloader-heif PRIVATE ${GDKPIXBUF2_INCLUDE_DIRS} ${PROJECT_BINARY_DIR})
     target_link_libraries(pixbufloader-heif PUBLIC ${GDKPIXBUF2_LIBRARIES} ${LIBHEIF_LIBRARY_NAME})
 
     install(TARGETS pixbufloader-heif LIBRARY DESTINATION ${GDKPIXBUF2_MODULE_DIR})

--- a/gdk-pixbuf/CMakeLists.txt
+++ b/gdk-pixbuf/CMakeLists.txt
@@ -7,7 +7,11 @@ if(UNIX)
 
     add_library(pixbufloader-heif MODULE pixbufloader-heif.c)
 
-    target_include_directories(pixbufloader-heif PRIVATE ${GDKPIXBUF2_INCLUDE_DIRS} ${PROJECT_BINARY_DIR})
+    target_include_directories(pixbufloader-heif
+                               PRIVATE
+                                   ${GDKPIXBUF2_INCLUDE_DIRS}
+                                   ${libheif_BINARY_DIR}
+                                   ${libheif_SOURCE_DIR})
     target_link_libraries(pixbufloader-heif PUBLIC ${GDKPIXBUF2_LIBRARIES} ${LIBHEIF_LIBRARY_NAME})
 
     install(TARGETS pixbufloader-heif LIBRARY DESTINATION ${GDKPIXBUF2_MODULE_DIR})

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -1,11 +1,5 @@
 include(CMakePackageConfigHelpers)
 
-if(UNIX)
-  include (${CMAKE_ROOT}/Modules/FindPkgConfig.cmake)
-  pkg_check_modules (LIBDE265 libde265)
-  pkg_check_modules (X265 x265)
-endif()
-
 configure_file(heif_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/heif_version.h)
 
 set(libheif_headers

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -6,6 +6,8 @@ if(UNIX)
   pkg_check_modules (X265 x265)
 endif()
 
+configure_file(heif_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/heif_version.h)
+
 set(libheif_headers
     bitstream.h
     box.h
@@ -21,7 +23,7 @@ set(libheif_headers
     heif_limits.h
     heif_plugin.h
     logging.h
-    ${PROJECT_BINARY_DIR}/libheif/heif_version.h
+    ${CMAKE_CURRENT_BINARY_DIR}/heif_version.h
 )
 
 add_library(${PROJECT_NAME}

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -26,7 +26,7 @@ set(libheif_headers
     ${CMAKE_CURRENT_BINARY_DIR}/heif_version.h
 )
 
-add_library(${PROJECT_NAME}
+add_library(heif
     bitstream.cc
     box.cc
     error.cc
@@ -42,27 +42,31 @@ add_library(${PROJECT_NAME}
 )
 
 # Needed to find libheif/heif_version.h while compiling the library
-target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_BINARY_DIR})
+target_include_directories(heif PRIVATE ${libheif_BINARY_DIR} ${libheif_SOURCE_DIR})
 
 # Propagate include/libheif to consume the headers from other projects
-target_include_directories(${PROJECT_NAME} PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
+target_include_directories(heif
+                           PUBLIC
+                               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}>
+                               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                               $<INSTALL_INTERFACE:include>)
 
-target_compile_definitions(${PROJECT_NAME}
-    PUBLIC 
-        LIBHEIF_EXPORTS
-        HAVE_VISIBILITY
-)
+set_target_properties(heif
+                      PROPERTIES
+                          VERSION ${PROJECT_VERSION}
+                          SOVERSION ${PROJECT_VERSION_MAJOR})
+
+target_compile_definitions(heif
+                           PUBLIC
+                               LIBHEIF_EXPORTS
+                               HAVE_VISIBILITY)
 
 if(LIBDE265_FOUND)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_LIBDE265=1)
-    target_sources(${PROJECT_NAME} PRIVATE
-        heif_decoder_libde265.cc
-        heif_decoder_libde265.h
-    )
+    target_compile_definitions(heif PRIVATE HAVE_LIBDE265=1)
+    target_sources(heif
+                   PRIVATE
+                       heif_decoder_libde265.cc
+                       heif_decoder_libde265.h)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LIBDE265_CFLAGS}")
 
@@ -70,14 +74,14 @@ if(LIBDE265_FOUND)
         set(LIBDE265_LINKDIR "-L${LIBDE265_LIBRARY_DIRS}")
     endif()
 
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBDE265_LIBRARIES} ${LIBDE265_LINKDIR})
+    target_link_libraries(heif PRIVATE ${LIBDE265_LIBRARIES} ${LIBDE265_LINKDIR})
 
     install(FILES heif_decoder_libde265.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 endif()
 
 if(X265_FOUND)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_X265=1)
-    target_sources(${PROJECT_NAME} PRIVATE
+    target_compile_definitions(heif PRIVATE HAVE_X265=1)
+    target_sources(heif PRIVATE
         heif_encoder_x265.cc
         heif_encoder_x265.h
     )
@@ -87,14 +91,14 @@ if(X265_FOUND)
         set(X265_LINKDIR "-L${X265_LIBRARY_DIRS}")
     endif()
 
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${X265_LIBRARIES} ${X265_LINKDIR})
+    target_link_libraries(heif PRIVATE ${X265_LIBRARIES} ${X265_LINKDIR})
 
     install(FILES heif_encoder_x265.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 endif()
 
 write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY ExactVersion)
 
-install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-config
+install(TARGETS heif EXPORT ${PROJECT_NAME}-config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -514,7 +514,7 @@ Error Box::read(BitstreamRange& range, std::shared_ptr<heif::Box>* result)
 
   // Security check: make sure that box size does not exceed int64 size.
 
-  if (hdr.get_box_size() > std::numeric_limits<int64_t>::max()) {
+  if (hdr.get_box_size() > (uint64_t)std::numeric_limits<int64_t>::max()) {
     return Error(heif_error_Invalid_input,
                  heif_suberror_Invalid_box_size);
   }


### PR DESCRIPTION
This fixes building libheif with gcc 9.2.1.

`cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..`