### PR TITLE
Ensure 64-bit int bitstream ranges, prevents possible overflow

### DIFF
--- a/libheif/bitstream.cc
+++ b/libheif/bitstream.cc
@@ -266,7 +266,7 @@ std::string BitstreamRange::read_string()
 }
 
 
-bool BitstreamRange::read(uint8_t* data, int n)
+bool BitstreamRange::read(uint8_t* data, int64_t n)
 {
   if (!prepare_read(n)) {
     return false;

--- a/libheif/bitstream.h
+++ b/libheif/bitstream.h
@@ -146,7 +146,7 @@ namespace heif {
     uint16_t read16();
     uint32_t read32();
     std::string read_string();
-    bool read(uint8_t* data, int n);
+    bool read(uint8_t* data, int64_t n);
 
     bool prepare_read(int64_t nBytes);
 

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -2717,7 +2717,7 @@ Error Box_av1C::parse(BitstreamRange& range)
     c.initial_presentation_delay_minus_one = byte & 0x0F;
   }
 
-  int configOBUs_bytes = range.get_remaining_bytes();
+  const int64_t configOBUs_bytes = range.get_remaining_bytes();
   m_config_OBUs.resize(configOBUs_bytes);
 
   if (!range.read(m_config_OBUs.data(), configOBUs_bytes)) {


### PR DESCRIPTION
Thank you for creating and maintaining this very useful library.

I've been reviewing the recently-added AVIF logic and ran into this problem with a possible integer overflow. It looks like all the existing bitstream logic was expecting/able to handle 64-bit integers apart from one method signature, which this PR should hopefully fix.