### PR TITLE
Expose have_aom status via pkg-config variables

### DIFF
--- a/libheif.pc.in
+++ b/libheif.pc.in
@@ -4,6 +4,8 @@ libdir=@libdir@
 includedir=@includedir@
 builtin_h265_decoder=@have_libde265@
 builtin_h265_encoder=@have_x265@
+builtin_avif_decoder=@have_aom@
+builtin_avif_encoder=@have_aom@
 
 Name: libheif
 Description: HEIF image codec.


### PR DESCRIPTION
This allows for compile-time feature detection of AOM, which will be very useful for consumers of this library, especially where h265 support must be disabled e.g. due to patent issues.