### PR TITLE
Fixed adding the aom decoder and encoder files.

### DIFF
--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -93,7 +93,7 @@ if(X265_FOUND)
 endif()
 
 if(AOM_FOUND)
-  add_definitions(-DAOM=1)
+  target_compile_definitions(heif PRIVATE HAVE_AOM=1)
   target_sources(heif PRIVATE
     heif_decoder_aom.cc
     heif_decoder_aom.h

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -94,8 +94,7 @@ endif()
 
 if(AOM_FOUND)
   add_definitions(-DAOM=1)
-  set (libheif_sources
-    ${libheif_sources}
+  target_sources(heif PRIVATE
     heif_decoder_aom.cc
     heif_decoder_aom.h
     heif_encoder_aom.cc


### PR DESCRIPTION
This PR fixes the CMake build when AOM_FOUND is set to 1.