### PR TITLE
remove rtti and exception

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1000,8 +1000,8 @@ heif_color_profile_type heif_image_handle_get_color_profile_type(const struct he
 size_t heif_image_handle_get_raw_color_profile_size(const struct heif_image_handle* handle)
 {
   auto profile = handle->image->get_color_profile();
-  auto raw_profile = std::dynamic_pointer_cast<const color_profile_raw>(profile);
-  if (raw_profile) {
+  if (profile && profile->get_type() != fourcc("nclx")) {
+    auto raw_profile = std::static_pointer_cast<const color_profile_raw>(profile);
     return raw_profile->get_data().size();
   }
   else {
@@ -1076,7 +1076,8 @@ struct heif_error heif_image_handle_get_nclx_color_profile(const struct heif_ima
   }
 
   auto profile = handle->image->get_color_profile();
-  auto nclx_profile = std::dynamic_pointer_cast<const color_profile_nclx>(profile);
+  auto nclx_profile = profile->get_type() == fourcc("nclx") ?
+          std::static_pointer_cast<const color_profile_nclx>(profile) : nullptr;
   Error err = get_nclx_color_profile(nclx_profile, out_data);
 
   return err.error_struct(handle->image.get());
@@ -1093,8 +1094,8 @@ struct heif_error heif_image_handle_get_raw_color_profile(const struct heif_imag
   }
 
   auto profile = handle->image->get_color_profile();
-  auto raw_profile = std::dynamic_pointer_cast<const color_profile_raw>(profile);
-  if (raw_profile) {
+  if (profile && profile->get_type() != fourcc("nclx")) {
+    auto raw_profile = std::static_pointer_cast<const color_profile_raw>(profile);
     memcpy(out_data,
            raw_profile->get_data().data(),
            raw_profile->get_data().size());
@@ -1120,8 +1121,8 @@ enum heif_color_profile_type heif_image_get_color_profile_type(const struct heif
 size_t heif_image_get_raw_color_profile_size(const struct heif_image* image)
 {
   auto profile = image->image->get_color_profile();
-  auto raw_profile = std::dynamic_pointer_cast<const color_profile_raw>(profile);
-  if (raw_profile) {
+  if (profile && profile->get_type() != fourcc("nclx")) {
+    auto raw_profile = std::static_pointer_cast<const color_profile_raw>(profile);
     return raw_profile->get_data().size();
   }
   else {
@@ -1140,8 +1141,8 @@ struct heif_error heif_image_get_raw_color_profile(const struct heif_image* imag
   }
 
   auto profile = image->image->get_color_profile();
-  auto raw_profile = std::dynamic_pointer_cast<const color_profile_raw>(profile);
-  if (raw_profile) {
+  if (profile && profile->get_type() != fourcc("nclx")) {
+    auto raw_profile = std::static_pointer_cast<const color_profile_raw>(profile);
     memcpy(out_data,
            raw_profile->get_data().data(),
            raw_profile->get_data().size());
@@ -1161,7 +1162,8 @@ struct heif_error heif_image_get_nclx_color_profile(const struct heif_image* ima
   }
 
   auto profile = image->image->get_color_profile();
-  auto nclx_profile = std::dynamic_pointer_cast<const color_profile_nclx>(profile);
+  auto nclx_profile = profile->get_type() == fourcc("nclx") ?
+          std::static_pointer_cast<const color_profile_nclx>(profile) : nullptr;
   Error err = get_nclx_color_profile(nclx_profile, out_data);
 
   return err.error_struct(image->image.get());

--- a/libheif/heif_colorconversion.cc
+++ b/libheif/heif_colorconversion.cc
@@ -52,6 +52,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_RGB_to_RGB24_32";  }
 };
 
 
@@ -218,6 +220,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_YCbCr_to_RGB";  }
 };
 
 
@@ -396,6 +400,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_RGB_to_YCbCr";  }
 };
 
 
@@ -562,6 +568,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_YCbCr420_to_RGB24";  }
 };
 
 
@@ -661,6 +669,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_YCbCr420_to_RGB32";  }
 };
 
 
@@ -775,6 +785,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_RGB_HDR_to_RRGGBBaa_BE";  }
 };
 
 
@@ -927,6 +939,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_RRGGBBaa_BE_to_RGB_HDR";  }
 };
 
 
@@ -1052,6 +1066,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_RRGGBBaa_swap_endianness";  }
 };
 
 
@@ -1191,6 +1207,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_mono_to_YCbCr420";  }
 };
 
 
@@ -1305,6 +1323,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_mono_to_RGB24_32";  }
 };
 
 
@@ -1441,6 +1461,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_RGB24_32_to_YCbCr420";  }
 };
 
 
@@ -1607,6 +1629,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_drop_alpha_plane";  }
 };
 
 
@@ -1685,6 +1709,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_to_hdr_planes";  }
 };
 
 
@@ -1790,6 +1816,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_to_sdr_planes";  }
 };
 
 
@@ -1893,6 +1921,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_RRGGBBxx_HDR_to_YCbCr420";  }
 };
 
 
@@ -2037,6 +2067,8 @@ public:
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options) override;
+
+  const char* name() const override { return "Op_YCbCr420_to_RRGGBBaa";  }
 };
 
 
@@ -2319,7 +2351,7 @@ bool ColorConversionPipeline::construct_pipeline(ColorState input_state,
 void ColorConversionPipeline::debug_dump_pipeline() const
 {
   for (const auto& op : m_operations) {
-    std::cerr << "> " << typeid(*op).name() << "\n";
+    std::cerr << "> " << op->name() << "\n";
   }
 }
 

--- a/libheif/heif_colorconversion.h
+++ b/libheif/heif_colorconversion.h
@@ -105,6 +105,7 @@ class ColorConversionOperation
   convert_colorspace(const std::shared_ptr<const HeifPixelImage>& input,
                      ColorState target_state,
                      ColorConversionOptions options = ColorConversionOptions()) = 0;
+  virtual const char* name() const = 0;
 };
 
 

--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -558,9 +558,8 @@ Error HeifContext::interpret_heif_file()
 
           std::shared_ptr<Box_auxC> auxC_property;
           for (const auto& property : properties) {
-            auto auxC = std::dynamic_pointer_cast<Box_auxC>(property.property);
-            if (auxC) {
-              auxC_property = auxC;
+            if (property.property->get_short_type() == fourcc("auxC")) {
+              auxC_property = std::static_pointer_cast<Box_auxC>(property.property);
             }
           }
 
@@ -625,8 +624,8 @@ Error HeifContext::interpret_heif_file()
             Error err = decode_hevc_aux_sei_messages(subtypes, sei_messages);
 
             for (auto& msg : sei_messages) {
-              auto depth_msg = std::dynamic_pointer_cast<SEIMessage_depth_representation_info>(msg);
-              if (depth_msg) {
+              if (msg->is_depth_representation_info()) {
+                auto depth_msg = std::static_pointer_cast<SEIMessage_depth_representation_info>(msg);
                 image->set_depth_representation_info(*depth_msg);
               }
             }
@@ -677,8 +676,8 @@ Error HeifContext::interpret_heif_file()
     bool ispe_read = false;
     bool primary_colr_set = false;
     for (const auto& prop : properties) {
-      auto ispe = std::dynamic_pointer_cast<Box_ispe>(prop.property);
-      if (ispe) {
+      if (prop.property->get_short_type() == fourcc("ispe")) {
+        auto ispe = std::static_pointer_cast<Box_ispe>(prop.property);
         uint32_t width = ispe->get_width();
         uint32_t height = ispe->get_height();
 
@@ -702,14 +701,14 @@ Error HeifContext::interpret_heif_file()
       }
 
       if (ispe_read) {
-        auto clap = std::dynamic_pointer_cast<Box_clap>(prop.property);
-        if (clap) {
+        if (prop.property->get_short_type() == fourcc("clap")) {
+          auto clap = std::static_pointer_cast<Box_clap>(prop.property);
           image->set_resolution( clap->get_width_rounded(),
                                  clap->get_height_rounded() );
         }
 
-        auto irot = std::dynamic_pointer_cast<Box_irot>(prop.property);
-        if (irot) {
+        if (prop.property->get_short_type() == fourcc("irot")) {
+          auto irot = std::static_pointer_cast<Box_irot>(prop.property);
           if (irot->get_rotation()==90 ||
               irot->get_rotation()==270) {
             // swap width and height
@@ -719,8 +718,8 @@ Error HeifContext::interpret_heif_file()
         }
       }
 
-      auto colr = std::dynamic_pointer_cast<Box_colr>(prop.property);
-      if (colr) {
+      if (prop.property->get_short_type() == fourcc("colr")) {
+        auto colr = std::static_pointer_cast<Box_colr>(prop.property);
         auto profile = colr->get_color_profile();
 
         image->set_color_profile(profile);
@@ -1090,8 +1089,8 @@ Error HeifContext::decode_image_planar(heif_item_id ID,
     error = ipco_box->get_properties_for_item_ID(ID, ipma_box, properties);
 
     for (const auto& property : properties) {
-      auto rot = std::dynamic_pointer_cast<Box_irot>(property.property);
-      if (rot) {
+      if (property.property->get_short_type() == fourcc("irot")) {
+        auto rot = std::static_pointer_cast<Box_irot>(property.property);
         std::shared_ptr<HeifPixelImage> rotated_img;
         error = img->rotate_ccw(rot->get_rotation(), rotated_img);
         if (error) {
@@ -1102,8 +1101,8 @@ Error HeifContext::decode_image_planar(heif_item_id ID,
       }
 
 
-      auto mirror = std::dynamic_pointer_cast<Box_imir>(property.property);
-      if (mirror) {
+      if (property.property->get_short_type() == fourcc("imir")) {
+        auto mirror = std::static_pointer_cast<Box_imir>(property.property);
         error = img->mirror_inplace(mirror->get_mirror_axis() == Box_imir::MirrorAxis::Horizontal);
         if (error) {
           return error;
@@ -1111,8 +1110,8 @@ Error HeifContext::decode_image_planar(heif_item_id ID,
       }
 
 
-      auto clap = std::dynamic_pointer_cast<Box_clap>(property.property);
-      if (clap) {
+      if (property.property->get_short_type() == fourcc("clap")) {
+        auto clap = std::static_pointer_cast<Box_clap>(property.property);
         std::shared_ptr<HeifPixelImage> clap_img;
 
         int img_width = img->get_width();
@@ -1205,7 +1204,8 @@ Error HeifContext::decode_full_grid_image(heif_item_id ID,
   auto ipma = m_heif_file->get_ipma_box();
   auto ipco = m_heif_file->get_ipco_box();
   auto pixi_box = ipco->get_property_for_item_ID(ID, ipma, fourcc("pixi"));
-  auto pixi = std::dynamic_pointer_cast<Box_pixi>(pixi_box);
+  auto pixi = pixi_box->get_short_type() == fourcc("pixi") ?
+          std::static_pointer_cast<Box_pixi>(pixi_box) : nullptr;
 
   const uint32_t w = grid.get_width();
   const uint32_t h = grid.get_height();
@@ -1931,7 +1931,7 @@ Error HeifContext::Image::encode_image_as_av1(std::shared_ptr<HeifPixelImage> im
   m_heif_context->m_heif_file->add_av1C_property(m_id);
   m_heif_context->m_heif_file->set_av1C_configuration(m_id, config);
 
-  
+
 
   heif_image c_api_image;
   c_api_image.image = image;

--- a/libheif/heif_hevc.h
+++ b/libheif/heif_hevc.h
@@ -38,6 +38,7 @@ class SEIMessage
 {
 public:
   virtual ~SEIMessage() { }
+  virtual bool is_depth_representation_info() const { return false; }
 };
 
 
@@ -45,6 +46,7 @@ class SEIMessage_depth_representation_info : public SEIMessage,
                                              public heif_depth_representation_info
 {
 public:
+  bool is_depth_representation_info() const override { return true; }
 };
 
 

--- a/libheif/heif_image.cc
+++ b/libheif/heif_image.cc
@@ -164,9 +164,12 @@ bool HeifPixelImage::add_plane(heif_channel channel, int width, int height, int 
   plane.stride = width * bytes_per_pixel;
   plane.stride = (plane.stride+alignment-1) & ~(alignment-1);
 
-  try {
-    plane.allocated_mem = new uint8_t[height * plane.stride + alignment-1];
+  {
+    plane.allocated_mem = new (std::nothrow) uint8_t[height * plane.stride + alignment-1];
     plane.mem = plane.allocated_mem;
+    if (!plane.mem) {
+      return false;
+    }
 
     // shift beginning of image data to aligned memory position
 
@@ -177,9 +180,6 @@ bool HeifPixelImage::add_plane(heif_channel channel, int width, int height, int 
     }
 
     m_planes.insert(std::make_pair(channel, std::move(plane)));
-  }
-  catch (const std::bad_alloc& excpt) {
-    return false;
   }
 
   return true;


### PR DESCRIPTION
For some project will not use libheif.so, but compile libheif to their own libraries with -fno-rtti, and -fno-exception compile flags, so refactor code and remove riit and exception codes