### PR TITLE
Clear encoder->compressedData in aom_encode_image

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -653,7 +653,7 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
     assert(0);
   }
 
-
+  encoder->compressedData.clear();
   const aom_codec_cx_pkt_t* pkt = NULL;
 
   while ((pkt = aom_codec_get_cx_data(&codec, &iter)) != NULL) {
@@ -672,7 +672,7 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
       encoder->compressedData.resize(oldSize + n);
 
       memcpy(encoder->compressedData.data() + oldSize,
-             (uint8_t*) pkt->data.frame.buf,
+             pkt->data.frame.buf,
              n);
 
       encoder->data_read = false;


### PR DESCRIPTION
aom_encode_image() should clear encoder->compressedData before getting
compressed packets. This fixes https://github.com/strukturag/libheif/issues/279.

Also remove an unnecessary (uint8_t*) cast for the second argument to memcpy().