### PR TITLE
Make heif_context mandatory again.

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1315,7 +1315,7 @@ struct heif_error heif_context_get_encoder(struct heif_context* context,
     return err.error_struct(context ? context->context.get() : nullptr);
   }
 
-  *encoder = new struct heif_encoder(nullptr, descriptor->plugin);
+  *encoder = new struct heif_encoder(descriptor->plugin);
   (*encoder)->alloc();
 
   struct heif_error err = {heif_error_Ok, heif_suberror_Unspecified, kSuccess};
@@ -1351,7 +1351,7 @@ struct heif_error heif_context_get_encoder_for_format(struct heif_context* conte
   descriptors = get_filtered_encoder_descriptors(format, nullptr);
 
   if (descriptors.size() > 0) {
-    *encoder = new struct heif_encoder(nullptr, descriptors[0]->plugin);
+    *encoder = new struct heif_encoder(descriptors[0]->plugin);
 
     (*encoder)->alloc();
 

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1316,10 +1316,7 @@ struct heif_error heif_context_get_encoder(struct heif_context* context,
   }
 
   *encoder = new struct heif_encoder(descriptor->plugin);
-  (*encoder)->alloc();
-
-  struct heif_error err = {heif_error_Ok, heif_suberror_Unspecified, kSuccess};
-  return err;
+  return (*encoder)->alloc();
 }
 
 
@@ -1352,11 +1349,7 @@ struct heif_error heif_context_get_encoder_for_format(struct heif_context* conte
 
   if (descriptors.size() > 0) {
     *encoder = new struct heif_encoder(descriptors[0]->plugin);
-
-    (*encoder)->alloc();
-
-    struct heif_error err = {heif_error_Ok, heif_suberror_Unspecified, kSuccess};
-    return err;
+    return (*encoder)->alloc();
   }
   else {
     Error err(heif_error_Unsupported_filetype, // TODO: is this the right error code?

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1309,7 +1309,9 @@ struct heif_error heif_context_get_encoder(struct heif_context* context,
                                            const struct heif_encoder_descriptor* descriptor,
                                            struct heif_encoder** encoder)
 {
-  if (!context || !descriptor || !encoder) {
+  // Note: be aware that context may be NULL as we explicitly allowed that in an earlier documentation.
+
+  if (!descriptor || !encoder) {
     Error err(heif_error_Usage_error,
               heif_suberror_Null_pointer_argument);
     return err.error_struct(context ? context->context.get() : nullptr);
@@ -1338,7 +1340,9 @@ struct heif_error heif_context_get_encoder_for_format(struct heif_context* conte
                                                       enum heif_compression_format format,
                                                       struct heif_encoder** encoder)
 {
-  if (!context || !encoder) {
+  // Note: be aware that context may be NULL as we explicitly allowed that in an earlier documentation.
+
+  if (!encoder) {
     Error err(heif_error_Usage_error,
               heif_suberror_Null_pointer_argument);
     return err.error_struct(context ? context->context.get() : nullptr);
@@ -1354,7 +1358,7 @@ struct heif_error heif_context_get_encoder_for_format(struct heif_context* conte
   else {
     Error err(heif_error_Unsupported_filetype, // TODO: is this the right error code?
               heif_suberror_Unspecified);
-    return err.error_struct(context->context.get());
+    return err.error_struct(context ? context->context.get() : nullptr);
   }
 }
 

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1309,19 +1309,13 @@ struct heif_error heif_context_get_encoder(struct heif_context* context,
                                            const struct heif_encoder_descriptor* descriptor,
                                            struct heif_encoder** encoder)
 {
-  if (!descriptor || !encoder) {
-    return Error(heif_error_Usage_error,
-                 heif_suberror_Null_pointer_argument).error_struct(nullptr);
+  if (!context || !descriptor || !encoder) {
+    Error err(heif_error_Usage_error,
+              heif_suberror_Null_pointer_argument);
+    return err.error_struct(context ? context->context.get() : nullptr);
   }
 
-  if (context == nullptr) {
-    *encoder = new struct heif_encoder(nullptr, descriptor->plugin);
-  }
-  else {
-    // DEPRECATED. We do not need the context anywhere.
-    *encoder = new struct heif_encoder(context->context, descriptor->plugin);
-  }
-
+  *encoder = new struct heif_encoder(nullptr, descriptor->plugin);
   (*encoder)->alloc();
 
   struct heif_error err = {heif_error_Ok, heif_suberror_Unspecified, kSuccess};
@@ -1347,22 +1341,17 @@ struct heif_error heif_context_get_encoder_for_format(struct heif_context* conte
                                                       enum heif_compression_format format,
                                                       struct heif_encoder** encoder)
 {
-  if (!encoder) {
-    return Error(heif_error_Usage_error,
-                 heif_suberror_Null_pointer_argument).error_struct(nullptr);
+  if (!context || !encoder) {
+    Error err(heif_error_Usage_error,
+              heif_suberror_Null_pointer_argument);
+    return err.error_struct(context ? context->context.get() : nullptr);
   }
 
   std::vector<const struct heif_encoder_descriptor*> descriptors;
   descriptors = get_filtered_encoder_descriptors(format, nullptr);
 
   if (descriptors.size() > 0) {
-    if (context == nullptr) {
-      *encoder = new struct heif_encoder(nullptr, descriptors[0]->plugin);
-    }
-    else {
-      // DEPRECATED. We do not need the context anywhere.
-      *encoder = new struct heif_encoder(context->context, descriptors[0]->plugin);
-    }
+    *encoder = new struct heif_encoder(nullptr, descriptors[0]->plugin);
 
     (*encoder)->alloc();
 
@@ -1370,9 +1359,9 @@ struct heif_error heif_context_get_encoder_for_format(struct heif_context* conte
     return err;
   }
   else {
-    struct heif_error err = {heif_error_Unsupported_filetype, // TODO: is this the right error code?
-                             heif_suberror_Unspecified, kSuccess};
-    return err;
+    Error err(heif_error_Unsupported_filetype, // TODO: is this the right error code?
+              heif_suberror_Unspecified);
+    return err.error_struct(context->context.get());
   }
 }
 

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -1010,7 +1010,6 @@ int heif_encoder_descriptor_supports_lossless_compression(const struct heif_enco
 
 
 // Get an encoder instance that can be used to actually encode images from a descriptor.
-// TODO: why do we need the context here? I think we should remove this. You may pass a NULL context.
 LIBHEIF_API
 struct heif_error heif_context_get_encoder(struct heif_context* context,
                                            const struct heif_encoder_descriptor*,
@@ -1030,7 +1029,6 @@ int heif_have_encoder_for_format(enum heif_compression_format format);
 
 // Get an encoder for the given compression format. If there are several encoder plugins
 // for this format, the encoder with the highest plugin priority will be returned.
-// TODO: why do we need the context here? I think we should remove this. You may pass a NULL context.
 LIBHEIF_API
 struct heif_error heif_context_get_encoder_for_format(struct heif_context* context,
                                                       enum heif_compression_format format,

--- a/libheif/heif_api_structs.h
+++ b/libheif/heif_api_structs.h
@@ -49,8 +49,7 @@ struct heif_context
 
 struct heif_encoder
 {
-  heif_encoder(std::shared_ptr<heif::HeifContext> context,
-               const struct heif_encoder_plugin* plugin);
+  heif_encoder(const struct heif_encoder_plugin* plugin);
 
   ~heif_encoder();
 
@@ -59,7 +58,6 @@ struct heif_encoder
   void release();
 
 
-  //std::shared_ptr<heif::HeifContext> context;
   const struct heif_encoder_plugin* plugin;
   void* encoder = nullptr;
 };

--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -46,11 +46,8 @@
 
 using namespace heif;
 
-
-heif_encoder::heif_encoder(std::shared_ptr<heif::HeifContext> _context,
-                           const struct heif_encoder_plugin* _plugin)
-    : //context(_context),
-    plugin(_plugin)
+heif_encoder::heif_encoder(const struct heif_encoder_plugin* _plugin)
+    : plugin(_plugin)
 {
 
 }


### PR DESCRIPTION
This PR will make the `heif_context` for the `heif_context_get_encoder` and `heif_context_get_encoder_for_format` mandatory again. There is (now was) a comment in the `heif.h` header file with a question why the context was necessary. The context should be passed to allow storing the error message. We could use that to report an error message in our application when we use the C API. The current code now prints the following error message in the @ImageMagick code when the encoder could not be found:

`magick: Success `test.avif' @ error/heic.c/IsHeifSuccess/134.`

This is happening because the error has `kSuccess` as the error message instead of the correct error message.

This PR is split into multiple commits and also removes the unused `context` field from `heif_encoder`. If you would prefer to preserve this I can revert the commit but it looks like this is not used in the public API so it should be possible to remove this now.