### PR TITLE
Default speed value for rav1e is increased to 8

### DIFF
--- a/libheif/heif_encoder_rav1e.cc
+++ b/libheif/heif_encoder_rav1e.cc
@@ -108,7 +108,7 @@ static void rav1e_init_parameters()
   p->version = 2;
   p->name = kParam_speed;
   p->type = heif_encoder_parameter_type_integer;
-  p->integer.default_value = 5;
+  p->integer.default_value = 8;
   p->has_default = true;
   p->integer.have_minimum_maximum = true;
   p->integer.minimum = 0;

--- a/third-party/rav1e.cmd
+++ b/third-party/rav1e.cmd
@@ -10,7 +10,7 @@
 : # Also, the error that "The target windows-msvc is not supported yet" can safely be ignored provided that rav1e/target/release
 : # contains rav1e.h and rav1e.lib.
 
-git clone -b v0.3.1 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b v0.3.3 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cbindgen


### PR DESCRIPTION
The speed value of 5 is very slow for rav1e. Increasing speed to 8 does not compromise much on quality but offers great speed improvements. Ref: https://preview.redd.it/tu4bwpgyco241.png?width=827&format=png&auto=webp&s=e4f0b9cc8f70bf93a0d1ddbb3cb413747fd5b130 this graph from this post: https://www.reddit.com/r/AV1/comments/e65dhl/libaom_vs_rav1e_vs_svtav1_test_results_with/