### PR TITLE
Set color_range to full range (1) in aom

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -665,6 +665,10 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
     aom_codec_control(&encoder->codec, AV1E_SET_ROW_MT, 1);
 #endif
   }
+  
+  // In aom, color_range defaults to limited range (0). Set it to full range (1).
+  // TODO: color_range should ideally come from the nclx profile. See issue 288.
+  aom_codec_control(&codec, AV1E_SET_COLOR_RANGE, 1);
 
   // --- encode frame
 


### PR DESCRIPTION
Until issue #288 is fixed, we have to live with using a hardcoded value
of color_range in the aom encoder. It is more common for images to be
full range than limited range. So set color_range to full range (1) in
aom.