### PR TITLE
Silence possible integer conversion warnings

### DIFF
--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -1617,8 +1617,8 @@ create_alpha_image_from_image_alpha_channel(const std::shared_ptr<HeifPixelImage
                       heif_colorspace_YCbCr, heif_chroma_420);
   alpha_image->copy_new_plane_from(image, heif_channel_Alpha, heif_channel_Y);
 
-  int bpp = image->get_bits_per_pixel(heif_channel_Alpha);
-  int half_range = 1<<(bpp-1);
+  uint8_t bpp = image->get_bits_per_pixel(heif_channel_Alpha);
+  uint16_t half_range = static_cast<uint16_t>(1 << (bpp - 1));
 
   alpha_image->fill_new_plane(heif_channel_Cb, half_range, chroma_width, chroma_height, bpp);
   alpha_image->fill_new_plane(heif_channel_Cr, half_range, chroma_width, chroma_height, bpp);


### PR DESCRIPTION
Prevents the following compiler warnings:
```
heif_context.cc: In function 'std::shared_ptr<heif::HeifPixelImage> create_alpha_image_from_image_alpha_channel(std::shared_ptr<heif::HeifPixelImage>)':

heif_context.cc:1623:48: warning: conversion from 'int' to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
 1623 |   alpha_image->fill_new_plane(heif_channel_Cb, half_range, chroma_width, chroma_height, bpp);
      |                                                ^~~~~~~~~~

heif_context.cc:1624:48: warning: conversion from 'int' to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
 1624 |   alpha_image->fill_new_plane(heif_channel_Cr, half_range, chroma_width, chroma_height, bpp);
      |                                                ^~~~~~~~~~
```