### PR TITLE
Leave color description in AV1 alpha unspecified

### DIFF
--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -1625,11 +1625,6 @@ create_alpha_image_from_image_alpha_channel(const std::shared_ptr<HeifPixelImage
   alpha_image->fill_new_plane(heif_channel_Cb, half_range, chroma_width, chroma_height, bpp);
   alpha_image->fill_new_plane(heif_channel_Cr, half_range, chroma_width, chroma_height, bpp);
 
-  auto nclx = std::make_shared<color_profile_nclx>();
-  nclx->set_default();
-  nclx->set_full_range_flag(true); // in default, but just to be sure in case defaults change
-  alpha_image->set_color_profile_nclx(nclx);
-
   return alpha_image;
 }
 
@@ -1847,6 +1842,10 @@ Error HeifContext::Image::encode_image_as_hevc(std::shared_ptr<HeifPixelImage> i
 
     std::shared_ptr<HeifPixelImage> alpha_image;
     alpha_image = create_alpha_image_from_image_alpha_channel(image);
+    auto nclx = std::make_shared<color_profile_nclx>();
+    nclx->set_default();
+    nclx->set_full_range_flag(true); // in default, but just to be sure in case defaults change
+    alpha_image->set_color_profile_nclx(nclx);
 
 
     // --- encode the alpha image
@@ -1988,6 +1987,8 @@ Error HeifContext::Image::encode_image_as_av1(std::shared_ptr<HeifPixelImage> im
 
     std::shared_ptr<HeifPixelImage> alpha_image;
     alpha_image = create_alpha_image_from_image_alpha_channel(image);
+    // For AV1, do not call alpha_image->set_color_profile_nclx() so that color description in alpha
+    // images is left unspecified. This saves three bytes in the AV1 sequence header OBU.
 
 
     // --- encode the alpha image


### PR DESCRIPTION
For AV1, do not call alpha_image->set_color_profile_nclx() so that color
description in alpha images is left unspecified. This saves three bytes
in the sequence header OBU of alpha images. See Section 5.5.2 (Color
config syntax) in the AV1 spec:

    color_config( ) {
        ...
        color_description_present_flag                  f(1)
        if ( color_description_present_flag ) {
            color_primaries                             f(8)
            transfer_characteristics                    f(8)
            matrix_coefficients                         f(8)
        } else {
            color_primaries = CP_UNSPECIFIED
            transfer_characteristics = TC_UNSPECIFIED
            matrix_coefficients = MC_UNSPECIFIED
        }
        ...
    }

This PR is related to https://github.com/strukturag/libheif/issues/288.