### PR TITLE
New defined _MSC_VER for GCC

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -323,7 +323,7 @@ void heif_context_debug_dump_boxes_to_file(struct heif_context* ctx, int fd)
 
   std::string dump = ctx->context->debug_dump_boxes();
   // TODO(fancycode): Should we return an error if writing fails?
-#if defined(_MSC_VER)
+#if (defined(__MINGW32__)  || defined(__MINGW64__) || defined(_MSC_VER)) && !defined(HAVE_UNISTD_H)
   auto written = _write(fd, dump.c_str(), dump.size());
 #else
   auto written = write(fd, dump.c_str(), dump.size());

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -43,14 +43,13 @@
 #include <utility>
 #include <vector>
 #include <string.h>
-#if defined(HAVE_UNISTD_H)
-#include <unistd.h>
-#endif
 
-#if defined(_MSC_VER)
+#if (defined(__MINGW32__)  || defined(__MINGW64__) || defined(_MSC_VER)) && !defined(HAVE_UNISTD_H)
 // for _write
 #include <io.h>
-#endif
+#else
+#include <unistd.h>
+#endif 
 
 using namespace heif;
 


### PR DESCRIPTION
I have error with gcc 11.0. _MSC_VER should be less than 1900
```
heif.cc: In function 'void heif_context_debug_dump_boxes_to_file(heif_context*, int)':
heif.cc:330:18: error: 'write' was not declared in this scope; did you mean 'fwrite'?
  330 |   auto written = write(fd, dump.c_str(), dump.size());
      |                  ^~~~~
      |                  fwrite
```