### PR TITLE
Omit set_default call on new color_profile_nclx

### DIFF
--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -1626,7 +1626,6 @@ create_alpha_image_from_image_alpha_channel(const std::shared_ptr<HeifPixelImage
   alpha_image->fill_new_plane(heif_channel_Cr, half_range, chroma_width, chroma_height, bpp);
 
   auto nclx = std::make_shared<color_profile_nclx>();
-  nclx->set_default();
   nclx->set_full_range_flag(true); // in default, but just to be sure in case defaults change
   alpha_image->set_color_profile_nclx(nclx);
 
@@ -1800,9 +1799,7 @@ Error HeifContext::Image::encode_image_as_hevc(std::shared_ptr<HeifPixelImage> i
   heif_chroma chroma = image->get_chroma_format();
   auto nclx_profile = image->get_color_profile_nclx();
   if (!nclx_profile) {
-    auto default_nclx_profile = std::make_shared<color_profile_nclx>();
-    default_nclx_profile->set_default();
-    nclx_profile = default_nclx_profile;
+    nclx_profile = std::make_shared<color_profile_nclx>();
   }
 
   if (encoder->plugin->plugin_api_version >= 2) {
@@ -1940,9 +1937,7 @@ Error HeifContext::Image::encode_image_as_av1(std::shared_ptr<HeifPixelImage> im
   heif_chroma chroma = image->get_chroma_format();
   auto color_profile = image->get_color_profile_nclx();
   if (!color_profile) {
-    auto nclx = std::make_shared<color_profile_nclx>();
-    nclx->set_default();
-    color_profile = nclx;
+    color_profile = std::make_shared<color_profile_nclx>();
   }
   auto nclx_profile = std::dynamic_pointer_cast<const color_profile_nclx>(color_profile);
 


### PR DESCRIPTION
No need to call set_default() on newly constructed color_profile_nclx
objects because the color_profile_nclx constructor calls set_default().