### PR TITLE
rav1e: ensure linker knows of dl dependency

### DIFF
--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -122,7 +122,7 @@ if(USE_LOCAL_RAV1E)
             heif_encoder_rav1e.h
             )
     target_include_directories(heif PRIVATE ${CMAKE_SOURCE_DIR}/third-party/rav1e/target/release/include)
-    target_link_libraries(heif PRIVATE ${CMAKE_SOURCE_DIR}/third-party/rav1e/target/release/librav1e.a)
+    target_link_libraries(heif PRIVATE ${CMAKE_SOURCE_DIR}/third-party/rav1e/target/release/librav1e.a -ldl)
 endif()
 
 write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY ExactVersion)

--- a/libheif/Makefile.am
+++ b/libheif/Makefile.am
@@ -22,7 +22,7 @@ ADDITIONAL_LIBS += $(x265_LIBS)
 endif
 
 if ENABLE_LOCAL_RAV1E
-ADDITIONAL_LIBS += ../third-party/rav1e/target/release/librav1e.a
+ADDITIONAL_LIBS += ../third-party/rav1e/target/release/librav1e.a -ldl
 endif
 
 libheif_la_CPPFLAGS =


### PR DESCRIPTION
The next version of rav1e (v0.4.0) will require this linker flag. Adding it prevents the following linker errors:
```
/usr/bin/ld: ../libheif/.libs/libheif.so: undefined reference to `dladdr'
/usr/bin/ld: ../libheif/.libs/libheif.so: undefined reference to `dlsym'
```
Linking against the current v0.3.4 of rav1e works with and without this change so it's both backwards and forwards compatible.