### PR TITLE
Use "pkg-config" to detect if dav1d is available.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         env:
           - { NAME: "nothing" }
-          - { NAME: "cmake", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_LIBDE265: 1, CMAKE: 1 }
+          - { NAME: "cmake", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_DAV1D: 1, WITH_LIBDE265: 1, CMAKE: 1 }
           - { NAME: "tarball", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_LIBDE265: 1, TARBALL: 1 }
           - { NAME: "graphics", WITH_GRAPHICS: 1 }
           - { NAME: "x265", WITH_X265: 1 }
@@ -22,6 +22,7 @@ jobs:
           - { NAME: "libde265 (1) / x265 / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_LIBDE265: 1 }
           - { NAME: "libde265 (2) / x265 / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_LIBDE265: 2 }
           - { NAME: "libde265 (1) / x265 / aom / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_LIBDE265: 1 }
+          - { NAME: "libde265 (1) / x265 / dav1d / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_DAV1D: 1, WITH_LIBDE265: 1 }
     env: ${{ matrix.env }}
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required (VERSION 3.3.2)
 project(libheif LANGUAGES C CXX VERSION 1.9.1.0)
 
 option(USE_LOCAL_RAV1E "Include rav1e support from local rav1e source" FALSE)
-option(USE_LOCAL_DAV1D "Include dav1d support from local dav1d source" FALSE)
 
 # https://cmake.org/cmake/help/v3.1/policy/CMP0054.html
 cmake_policy(SET CMP0054 NEW)
@@ -58,6 +57,7 @@ LIST (APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 find_package(Libde265 REQUIRED)
 find_package(X265)
 find_package(LibAOM)
+find_package(Dav1d)
 
 if (LIBDE265_FOUND)
     message("HEIF decoder, libde265: found")
@@ -83,10 +83,10 @@ else ()
     message("AVIF encoder, use local rav1e: no")
 endif ()
 
-if (USE_LOCAL_DAV1D)
-    message("AVIF decoder, use local dav1d: yes")
+if (DAV1D_FOUND)
+    message("AVIF decoder, dav1d: found")
 else ()
-    message("AVIF decoder, use local dav1d: no")
+    message("AVIF decoder, dav1d: not found")
 endif ()
 
 
@@ -105,7 +105,7 @@ if (X265_FOUND)
 else()
     set(have_x265 no)
 endif()
-if (AOM_FOUND OR USE_LOCAL_DAV1D)
+if (AOM_FOUND OR DAV1D_FOUND)
     set(have_avif_decoder yes)
 else()
     set(have_avif_decoder no)

--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ With autoconf, use the configure option `--enable-local-rav1e'.
 
 ### Adding dav1d decoder for AVIF
 
-* Install `meson`.
+* Install [`meson`](https://mesonbuild.com/).
 * Run the `dav1d.cmd` script in directory `third-party` to download dav1d and compile it.
 
-When using cmake, you have to enable compiling the local dav1d encoder with `USE_LOCAL_DAV1D'.
-With autoconf, use the configure option `--enable-local-dav1d'.
+When running `cmake` or `configure`, make sure that the environment variable
+`PKG_CONFIG_PATH` includes the path to `third-party/dav1d/dist/lib/x86_64-linux-gnu/pkgconfig`.
 
 
 ## Language bindings

--- a/cmake/modules/FindDav1d.cmake
+++ b/cmake/modules/FindDav1d.cmake
@@ -1,0 +1,24 @@
+include(LibFindMacros)
+libfind_pkg_check_modules(DAV1D_PKGCONF dav1d)
+
+find_path(DAV1D_INCLUDE_DIR
+    NAMES dav1d/dav1d.h
+    HINTS ${DAV1D_PKGCONF_INCLUDE_DIRS} ${DAV1D_PKGCONF_INCLUDEDIR}
+    PATH_SUFFIXES DAV1D
+)
+
+find_library(DAV1D_LIBRARY
+    NAMES libdav1d dav1d
+    HINTS ${DAV1D_PKGCONF_LIBRARY_DIRS} ${DAV1D_PKGCONF_LIBDIR}
+)
+
+set(DAV1D_PROCESS_LIBS DAV1D_LIBRARY)
+set(DAV1D_PROCESS_INCLUDES DAV1D_INCLUDE_DIR)
+libfind_process(DAV1D)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(DAV1D
+    REQUIRED_VARS
+        DAV1D_INCLUDE_DIR
+        DAV1D_LIBRARIES
+)

--- a/configure.ac
+++ b/configure.ac
@@ -205,15 +205,14 @@ fi
 AM_CONDITIONAL([ENABLE_LOCAL_RAV1E], [test "x$enable_local_rav1e" != "xno"])
 AC_SUBST(ENABLE_LOCAL_RAV1E)
 
-AC_ARG_ENABLE([local_dav1d], AS_HELP_STRING([--enable-local-dav1d],
-    [Enable compiling with local dav1d decoder.]), [], [enable_local_dav1d=no])
-if eval "test x$enable_local_dav1d != xno"; then
-    AC_MSG_NOTICE([Enable compiling with local dav1d])
-    AC_DEFINE([HAVE_DAV1D], [1], [Whether dav1d plugin has been enabled.])
+PKG_CHECK_MODULES([dav1d], [dav1d], [
+    AC_DEFINE([HAVE_DAV1D], [1], [Whether dav1d was found.])
+    AC_SUBST(dav1d_CFLAGS)
+    AC_SUBST(dav1d_LIBS)
     have_avif_encoder="yes"
-fi
-AM_CONDITIONAL([ENABLE_LOCAL_DAV1D], [test "x$enable_local_dav1d" != "xno"])
-AC_SUBST(ENABLE_LOCAL_DAV1D)
+    have_dav1d="yes"
+], [have_dav1d="no"])
+AM_CONDITIONAL([HAVE_DAV1D], [test "x$have_dav1d" = "xyes"])
 
 AC_SUBST(have_avif_decoder)
 AC_SUBST(have_avif_encoder)
@@ -256,7 +255,7 @@ AC_MSG_NOTICE([Symbol visibility: $enable_visibility])
 AC_MSG_NOTICE([libaom decoder: $have_aom])
 AC_MSG_NOTICE([libaom encoder: $have_aom])
 AC_MSG_NOTICE([rav1e encoder: $enable_local_rav1e])
-AC_MSG_NOTICE([dav1d decoder: $enable_local_dav1d])
+AC_MSG_NOTICE([dav1d decoder: $have_dav1d])
 AC_MSG_NOTICE([libde265 decoder: $have_libde265])
 AC_MSG_NOTICE([libx265 encoder: $have_x265])
 AC_MSG_NOTICE([JPEG output: $have_libjpeg])

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -126,18 +126,21 @@ if(USE_LOCAL_RAV1E)
     target_link_libraries(heif PRIVATE ${CMAKE_SOURCE_DIR}/third-party/rav1e/target/release/librav1e.a -ldl)
 endif()
 
-if(USE_LOCAL_DAV1D)
+if(DAV1D_FOUND)
     target_compile_definitions(heif PRIVATE HAVE_DAV1D=1)
     target_sources(heif PRIVATE
             heif_decoder_dav1d.cc
             heif_decoder_dav1d.h
             )
-    target_include_directories(heif PRIVATE ${CMAKE_SOURCE_DIR}/third-party/dav1d/build
-            ${CMAKE_SOURCE_DIR}/third-party/dav1d/build/include
-            ${CMAKE_SOURCE_DIR}/third-party/dav1d/build/include/dav1d
-            ${CMAKE_SOURCE_DIR}/third-party/dav1d/include)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${DAV1D_CFLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DAV1D_CFLAGS}")
 
-    target_link_libraries(heif PRIVATE ${CMAKE_SOURCE_DIR}/third-party/dav1d/build/src/libdav1d.a -ldl)
+    if (NOT "${DAV1D_LIBRARY_DIRS}" STREQUAL "")
+        set(DAV1D_LINKDIR "-L${DAV1D_LIBRARY_DIRS}")
+    endif()
+
+    include_directories(SYSTEM ${DAV1D_INCLUDE_DIR})
+    target_link_libraries(heif PRIVATE ${DAV1D_LIBRARIES} ${DAV1D_LINKDIR})
 endif ()
 
 write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY ExactVersion)

--- a/libheif/Makefile.am
+++ b/libheif/Makefile.am
@@ -25,8 +25,8 @@ if ENABLE_LOCAL_RAV1E
 ADDITIONAL_LIBS += ../third-party/rav1e/target/release/librav1e.a -ldl
 endif
 
-if ENABLE_LOCAL_DAV1D
-ADDITIONAL_LIBS += ../third-party/dav1d/build/src/libdav1d.a -ldl
+if HAVE_DAV1D
+ADDITIONAL_LIBS += $(dav1d_LIBS)
 endif
 
 libheif_la_CPPFLAGS =
@@ -38,15 +38,12 @@ libheif_la_CXXFLAGS = \
   $(aom_CFLAGS) \
   $(libde265_CFLAGS) \
   $(x265_CFLAGS) \
+  $(dav1d_CFLAGS) \
   -DLIBHEIF_EXPORTS -I$(top_srcdir)
 libheif_la_LIBADD = $(ADDITIONAL_LIBS)
 
 if ENABLE_LOCAL_RAV1E
 libheif_la_CXXFLAGS += -I../third-party/rav1e/target/release/include
-endif
-
-if ENABLE_LOCAL_DAV1D
-libheif_la_CXXFLAGS += -I../third-party/dav1d/build -I../third-party/dav1d/build/include -I../third-party/dav1d/build/include/dav1d -I../third-party/dav1d/include
 endif
 
 libheif_la_LDFLAGS = -version-info $(LIBHEIF_CURRENT):$(LIBHEIF_REVISION):$(LIBHEIF_AGE)
@@ -105,7 +102,7 @@ libheif_la_SOURCES += \
   heif_encoder_rav1e.h
 endif
 
-if ENABLE_LOCAL_DAV1D
+if HAVE_DAV1D
 libheif_la_SOURCES += \
   heif_decoder_dav1d.cc \
   heif_decoder_dav1d.h

--- a/scripts/install-ci-linux.sh
+++ b/scripts/install-ci-linux.sh
@@ -71,6 +71,16 @@ if [ "$WITH_X265" = "1" ]; then
         "
 fi
 
+if [ "$WITH_DAV1D" = "1" ]; then
+    INSTALL_PACKAGES="$INSTALL_PACKAGES \
+        nasm \
+        ninja-build \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        "
+fi
+
 if [ ! -z "$CHECK_LICENSES" ]; then
     sudo curl --location --output /usr/bin/licensecheck "https://github.com/Debian/devscripts/raw/v2.16.5/scripts/licensecheck.pl"
     sudo chmod a+x /usr/bin/licensecheck
@@ -161,4 +171,13 @@ elif [ "$MINGW" == "64" ]; then
     if [ -x "/usr/bin/x86_64-w64-mingw32-g++-posix" ]; then
         sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
     fi
+fi
+
+if [ "$WITH_DAV1D" = "1" ]; then
+    pip3 install --user meson
+
+    export PATH="$PATH:$HOME/.local/bin"
+    cd third-party
+    sh dav1d.cmd
+    cd ..
 fi

--- a/scripts/install-ci-linux.sh
+++ b/scripts/install-ci-linux.sh
@@ -178,6 +178,6 @@ if [ "$WITH_DAV1D" = "1" ]; then
 
     export PATH="$PATH:$HOME/.local/bin"
     cd third-party
-    sh dav1d.cmd
+    sh dav1d.cmd -Denable_avx512=false
     cd ..
 fi

--- a/scripts/prepare-ci.sh
+++ b/scripts/prepare-ci.sh
@@ -24,8 +24,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 BUILD_ROOT=$ROOT/..
 
+PKG_CONFIG_PATH=
 if [ "$WITH_LIBDE265" = "2" ]; then
-    export PKG_CONFIG_PATH=$BUILD_ROOT/libde265/dist/lib/pkgconfig/
+    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BUILD_ROOT/libde265/dist/lib/pkgconfig/"
+fi
+
+if [ "$WITH_DAV1D" = "1" ]; then
+    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BUILD_ROOT/third-party/dav1d/dist/lib/x86_64-linux-gnu/pkgconfig/"
+fi
+if [ ! -z "$PKG_CONFIG_PATH" ]; then
+    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
 fi
 
 CONFIGURE_HOST=

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -75,6 +75,18 @@ elif [ ! -z "$FUZZER" ]; then
     export CXX="$BUILD_ROOT/clang/bin/clang++"
 fi
 
+PKG_CONFIG_PATH=
+if [ "$WITH_LIBDE265" = "2" ]; then
+    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BUILD_ROOT/libde265/dist/lib/pkgconfig/"
+fi
+
+if [ "$WITH_DAV1D" = "1" ]; then
+    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$BUILD_ROOT/third-party/dav1d/dist/lib/x86_64-linux-gnu/pkgconfig/"
+fi
+if [ ! -z "$PKG_CONFIG_PATH" ]; then
+    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
+fi
+
 if [ ! -z "$CMAKE" ]; then
     echo "Preparing cmake build files ..."
     CMAKE_OPTIONS=

--- a/third-party/dav1d.cmd
+++ b/third-party/dav1d.cmd
@@ -13,12 +13,11 @@
 git clone -b 0.7.1 --depth 1 https://code.videolan.org/videolan/dav1d.git
 
 cd dav1d
-mkdir build
-cd build
 
 : # macOS might require: -Dc_args=-fno-stack-check
 : # Build with asan: -Db_sanitize=address
 : # Build with ubsan: -Db_sanitize=undefined
-meson --default-library=static --buildtype release ..
-ninja
-cd ../..
+meson build --default-library=static --buildtype release --prefix "$(pwd)/dist"
+ninja -C build
+ninja -C build install
+cd ..

--- a/third-party/dav1d.cmd
+++ b/third-party/dav1d.cmd
@@ -17,7 +17,7 @@ cd dav1d
 : # macOS might require: -Dc_args=-fno-stack-check
 : # Build with asan: -Db_sanitize=address
 : # Build with ubsan: -Db_sanitize=undefined
-meson build --default-library=static --buildtype release --prefix "$(pwd)/dist"
+meson build --default-library=static --buildtype release --prefix "$(pwd)/dist" $@
 ninja -C build
 ninja -C build install
 cd ..


### PR DESCRIPTION
This will help in adding support for dav1d when packaging.

Updated the script to build custom version in "third-party" folder so it can be used through "pkg-config" instead of relying on hardcoded folder names.