### PR TITLE
Fix building on anything but Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ include(GNUInstallDirs)
 # The version number.
 set (PACKAGE_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 
-# Check for unistd.h
-
 include (${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
+
+# Check for unistd.h
 
 CHECK_INCLUDE_FILE(unistd.h HAVE_UNISTD_H)
 
@@ -21,6 +21,13 @@ if (HAVE_UNISTD_H)
   add_definitions(-DHAVE_UNISTD_H)
 endif()
 
+# Check for alloca.h
+
+CHECK_INCLUDE_FILE(alloca.h HAVE_ALLOCA_H)
+
+if (HAVE_ALLOCA_H)
+  add_definitions(-DHAVE_ALLOCA_H)
+endif()
 
 if(NOT MSVC)
   add_definitions(-Wall)

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AM_EXTRA_RECURSIVE_TARGETS([format test])
 AX_CXX_COMPILE_STDCXX_11()
 
 AC_HEADER_STDBOOL
-AC_CHECK_HEADERS([inttypes.h stddef.h unistd.h])
+AC_CHECK_HEADERS([inttypes.h stddef.h unistd.h alloca.h])
 AC_C_INLINE
 AC_FUNC_ERROR_AT_LINE
 

--- a/examples/heif_convert.cc
+++ b/examples/heif_convert.cc
@@ -29,7 +29,7 @@
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 # include <malloc.h>
-#else
+#elif defined (HAVE_ALLOCA_H)
 # include <alloca.h>
 #endif
 


### PR DESCRIPTION
The addition of the alloca.h header to heif_convert.cc in commit 20bb92009fc95b95ba598b6485cd35670d79eb32#diff-4fc948cb4190594d731047b3335eed6d broke building on anything but Linux.