### PR TITLE
Fix heif_image_get_primary_height for interleaved RGB images

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -774,7 +774,7 @@ int heif_image_get_primary_height(const struct heif_image* img)
       return img->image->get_height(heif_channel_G);
     }
     else {
-      return img->image->get_width(heif_channel_interleaved);
+      return img->image->get_height(heif_channel_interleaved);
     }
   }
   else {


### PR DESCRIPTION
The image width was being returned instead of the height.