### PR TITLE
Fix warnings treated as errors.

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1529,7 +1529,7 @@ struct heif_error heif_encoder_set_parameter_integer(struct heif_encoder* encode
        params++) {
     if (strcmp((*params)->name, parameter_name) == 0) {
 
-      int have_minimum, have_maximum, minimum, maximum, num_valid_values;
+      int have_minimum = 0, have_maximum = 0, minimum = 0, maximum = 0, num_valid_values = 0;
       const int* valid_values;
       heif_error err = heif_encoder_parameter_get_valid_integer_values((*params), &have_minimum, &have_maximum,
                                                                        &minimum, &maximum,


### PR DESCRIPTION
The warnings were:
libheif/heif.cc:1543:25: error: ‘maximum’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1543 |           (have_maximum && value > maximum)) {
      |           ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
libheif/libheif/heif.cc:1542:25: error: ‘minimum’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1542 |       if ((have_minimum && value < minimum) ||
      |           ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

---------------------------------------------

Note 1: I didn't have this issue previously with Fedora 31 (last builds maybe a few weeks ago though), but I just updated to Fedora 33 with gcc version 10.2.1 20201016 (Red Hat 10.2.1-6) (GCC) and now I got these warnings.

Note 2: the warnings/errors were not explicitly told when building:

```
$ make V=1
make  all-recursive
make[1]: Entering directory '/home/jehan/.local/share/crossroad/artifacts/native/gimp/libheif'
Making all in libheif
make[2]: Entering directory '/home/jehan/.local/share/crossroad/artifacts/native/gimp/libheif/libheif'
/bin/sh ../libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I. -I/home/jehan/dev/src//libheif/libheif -I..    -fvisibility=hidden      -DLIBHEIF_EXPORTS -I/home/jehan/dev/src//libheif -DHAVE_VISIBILITY -g -O2 -Wall -Werror -Wsign-compare -Wconversion -Wno-sign-conversion -Wno-error=conversion -Wno-error=unused-parameter -Wno-error=deprecated-declarations -MT libheif_la-heif.lo -MD -MP -MF .deps/libheif_la-heif.Tpo -c -o libheif_la-heif.lo `test -f 'heif.cc' || echo '/home/jehan/dev/src//libheif/libheif/'`heif.cc
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I/home/jehan/dev/src//libheif/libheif -I.. -fvisibility=hidden -DLIBHEIF_EXPORTS -I/home/jehan/dev/src//libheif -DHAVE_VISIBILITY -g -O2 -Wall -Werror -Wsign-compare -Wconversion -Wno-sign-conversion -Wno-error=conversion -Wno-error=unused-parameter -Wno-error=deprecated-declarations -MT libheif_la-heif.lo -MD -MP -MF .deps/libheif_la-heif.Tpo -c /home/jehan/dev/src//libheif/libheif/heif.cc  -fPIC -DPIC -o .libs/libheif_la-heif.o
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I/home/jehan/dev/src//libheif/libheif -I.. -fvisibility=hidden -DLIBHEIF_EXPORTS -I/home/jehan/dev/src//libheif -DHAVE_VISIBILITY -g -O2 -Wall -Werror -Wsign-compare -Wconversion -Wno-sign-conversion -Wno-error=conversion -Wno-error=unused-parameter -Wno-error=deprecated-declarations -MT libheif_la-heif.lo -MD -MP -MF .deps/libheif_la-heif.Tpo -c /home/jehan/dev/src//libheif/libheif/heif.cc -o libheif_la-heif.o >/dev/null 2>&1
make[2]: *** [Makefile:1170: libheif_la-heif.lo] Error 1
make[2]: Leaving directory '/home/jehan/.local/share/crossroad/artifacts/native/gimp/libheif/libheif'
make[1]: *** [Makefile:535: all-recursive] Error 1
make[1]: Leaving directory '/home/jehan/.local/share/crossroad/artifacts/native/gimp/libheif'
make: *** [Makefile:444: all] Error 2
```
So I tried to simply run the command run by libtool manually and that's how I got the exact warnings info.

Note 3: the warnings somehow only complains about `minimum` and `maximum`, even though `have_(minimum|maximum)` and `num_valid_values` are clearly in the same case. Very inconsistent. So anyway, I just initialized them off to not have bad surprise in future warning check evolution. In any case, these should all be set by `heif_encoder_parameter_get_valid_integer_values()` before use since, if they were not, `err.code` would be set, hence we would return before. It's really to please the compiler.