### PR TITLE
Fix heif_cxx get_metadata with 0-size metadata

### DIFF
--- a/libheif/heif_cxx.h
+++ b/libheif/heif_cxx.h
@@ -765,6 +765,9 @@ namespace heif {
                                                            metadata_id);
 
     std::vector<uint8_t> data(data_size);
+    //.data() of 0 size vector is nullptr so return early
+    if (data_size == 0)
+      return data;
 
     Error err = Error(heif_image_handle_get_metadata(m_image_handle.get(),
                                                      metadata_id,


### PR DESCRIPTION
Some Apple HEIC files seem to have 0-size Exif data which causes the cxx wrapper to throw an error. The equivalent code in the examples dir checks for 0-size, so we should here too I think.

See https://github.com/OpenImageIO/oiio/pull/2809 and https://github.com/OpenImageIO/oiio/issues/2794