### PR TITLE
Allow reading of 'avis' ftyp/filetype/brand images

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -120,6 +120,9 @@ heif_filetype_result heif_check_filetype(const uint8_t* data, int len)
     else if (brand == heif_avif) {
       return heif_filetype_yes_supported;
     }
+    else if (brand == heif_avis) {
+      return heif_filetype_yes_supported;
+    }
     else if (brand == heif_unknown_brand) {
       return heif_filetype_no;
     }

--- a/libheif/heif_file.cc
+++ b/libheif/heif_file.cc
@@ -231,7 +231,8 @@ Error HeifFile::parse_heif_file(BitstreamRange& range)
   if (!m_ftyp_box->has_compatible_brand(fourcc("heic")) &&
       !m_ftyp_box->has_compatible_brand(fourcc("heix")) &&
       !m_ftyp_box->has_compatible_brand(fourcc("mif1")) &&
-      !m_ftyp_box->has_compatible_brand(fourcc("avif"))) {
+      !m_ftyp_box->has_compatible_brand(fourcc("avif")) &&
+      !m_ftyp_box->has_compatible_brand(fourcc("avis"))) {
     std::stringstream sstr;
     sstr << "File does not include any supported brands.\n";
 


### PR DESCRIPTION
Hello, libheif already has some support for HEIF images with an `ftyp` of "avis" e.g. in the `heif_main_brand` function:

https://github.com/strukturag/libheif/blob/63be81f6e2800ccfc7eaece277669d677e126c89/libheif/heif.cc#L184-L186

This PR extends that support to allow these images to be decoded (or at least progress to the next step of validation).

An example AVIF image that currently fails but which this PR will allow can be found at
https://colinbendell.github.io/webperf/animated-gif-decode/2.avif