### PR TITLE
Library libheif/avif with tune butteraugli

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -73,7 +73,10 @@ static const char* const kParam_chroma_valid_values[] = {
 
 static const char* kParam_tune = "tune";
 static const char* const kParam_tune_valid_values[] = {
-    "psnr", "ssim", "butteraugli"
+    "psnr", "ssim"
+#if CONFIG_TUNE_BUTTERAUGLI
+    , "butteraugli"
+#endif
 };
 
 static const int AOM_PLUGIN_PRIORITY = 40;
@@ -422,10 +425,12 @@ struct heif_error aom_set_parameter_string(void* encoder_raw, const char* name, 
       encoder->tune = AOM_TUNE_SSIM;
       return heif_error_ok;
     }
+#if CONFIG_TUNE_BUTTERAUGLI
     else if (strcmp(value, "butteraugli") == 0) {
       encoder->tune = AOM_TUNE_BUTTERAUGLI;
       return heif_error_ok;
     }
+#endif
     else {
       return heif_error_invalid_parameter_value;
     }
@@ -471,9 +476,11 @@ struct heif_error aom_get_parameter_string(void* encoder_raw, const char* name,
       case AOM_TUNE_SSIM:
         save_strcpy(value, value_size, "ssim");
         break;
+#if CONFIG_TUNE_BUTTERAUGLI
       case AOM_TUNE_BUTTERAUGLI:
         save_strcpy(value, value_size, "butteraugli");
         break;
+#endif
       default:
         assert(false);
         return heif_error_invalid_parameter_value;

--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -73,7 +73,7 @@ static const char* const kParam_chroma_valid_values[] = {
 
 static const char* kParam_tune = "tune";
 static const char* const kParam_tune_valid_values[] = {
-    "psnr", "ssim"
+    "psnr", "ssim", "butteraugli"
 };
 
 static const int AOM_PLUGIN_PRIORITY = 40;
@@ -422,6 +422,10 @@ struct heif_error aom_set_parameter_string(void* encoder_raw, const char* name, 
       encoder->tune = AOM_TUNE_SSIM;
       return heif_error_ok;
     }
+    else if (strcmp(value, "butteraugli") == 0) {
+      encoder->tune = AOM_TUNE_BUTTERAUGLI;
+      return heif_error_ok;
+    }
     else {
       return heif_error_invalid_parameter_value;
     }
@@ -466,6 +470,9 @@ struct heif_error aom_get_parameter_string(void* encoder_raw, const char* name,
         break;
       case AOM_TUNE_SSIM:
         save_strcpy(value, value_size, "ssim");
+        break;
+      case AOM_TUNE_BUTTERAUGLI:
+        save_strcpy(value, value_size, "butteraugli");
         break;
       default:
         assert(false);

--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -402,11 +402,7 @@ struct heif_error aom_set_parameter_string(void* encoder_raw, const char* name, 
 {
   struct encoder_struct_aom* encoder = (struct encoder_struct_aom*) encoder_raw;
 
-#if CONFIG_TUNE_BUTTERAUGLI
-  if ((!strcmp(name, kParam_tune) == 0) && (strcmp(name, kParam_chroma) == 0)) {
-#else
   if (strcmp(name, kParam_chroma) == 0) {
-#endif
     if (strcmp(value, "420") == 0) {
       encoder->chroma = heif_chroma_420;
       return heif_error_ok;
@@ -442,7 +438,7 @@ struct heif_error aom_set_parameter_string(void* encoder_raw, const char* name, 
       return heif_error_ok;
     }
 #if CONFIG_TUNE_BUTTERAUGLI
-    else if (((strcmp(value, "butteraugli") == 0) || (strcmp(value, "") == 0)) && ((strcmp(name, kParam_chroma) == 0) && (strcmp(value, "420") == 0))) {
+    else if (strcmp(value, "butteraugli") == 0) {
       encoder->tune = AOM_TUNE_BUTTERAUGLI;
       return heif_error_ok;
     }

--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -181,7 +181,11 @@ static void aom_init_parameters()
   p->version = 2;
   p->name = kParam_tune;
   p->type = heif_encoder_parameter_type_string;
+#if CONFIG_TUNE_BUTTERAUGLI
+  p->string.default_value = "butteraugli";
+#else
   p->string.default_value = "ssim";
+#endif
   p->has_default = true;
   p->string.valid_values = kParam_tune_valid_values;
   d[i++] = p++;
@@ -398,18 +402,30 @@ struct heif_error aom_set_parameter_string(void* encoder_raw, const char* name, 
 {
   struct encoder_struct_aom* encoder = (struct encoder_struct_aom*) encoder_raw;
 
+#if CONFIG_TUNE_BUTTERAUGLI
+  if ((!strcmp(name, kParam_tune) == 0) && (strcmp(name, kParam_chroma) == 0)) {
+#else
   if (strcmp(name, kParam_chroma) == 0) {
+#endif
     if (strcmp(value, "420") == 0) {
       encoder->chroma = heif_chroma_420;
       return heif_error_ok;
     }
     else if (strcmp(value, "422") == 0) {
       encoder->chroma = heif_chroma_422;
+#if CONFIG_TUNE_BUTTERAUGLI
+      return heif_error_invalid_parameter_value;
+#else
       return heif_error_ok;
+#endif
     }
     else if (strcmp(value, "444") == 0) {
       encoder->chroma = heif_chroma_444;
+#if CONFIG_TUNE_BUTTERAUGLI
+      return heif_error_invalid_parameter_value;
+#else
       return heif_error_ok;
+#endif
     }
     else {
       return heif_error_invalid_parameter_value;
@@ -426,7 +442,7 @@ struct heif_error aom_set_parameter_string(void* encoder_raw, const char* name, 
       return heif_error_ok;
     }
 #if CONFIG_TUNE_BUTTERAUGLI
-    else if (strcmp(value, "butteraugli") == 0) {
+    else if (((strcmp(value, "butteraugli") == 0) || (strcmp(value, "") == 0)) && ((strcmp(name, kParam_chroma) == 0) && (strcmp(value, "420") == 0))) {
       encoder->tune = AOM_TUNE_BUTTERAUGLI;
       return heif_error_ok;
     }


### PR DESCRIPTION
Library libheif/avif with new aom 2.0.2-8de6aba + tune butteraugli for jpeg + integrated jpegxl

heifenc.exe image_21447_420.jpg -v -A -L -q 100 --no-alpha -p chroma=420 -p tune=butteraugli -p speed=5 --full_range_flag=0 -o image_21447_24bit.avif