### PR TITLE
Added include to fix building with VS2015.

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -27,6 +27,7 @@
 #include "config.h"
 #endif
 
+#include <algorithm>
 #include <cstring>
 #include <cassert>
 #include <vector>


### PR DESCRIPTION
This PR fixes building of this library with Visual Studio 2015. Without this include it reports an error about `std::max`.