### PR TITLE
WASM output added to Emscripten build process

### DIFF
--- a/build-emscripten.sh
+++ b/build-emscripten.sh
@@ -40,6 +40,7 @@ export TOTAL_MEMORY=16777216
 echo "Running Emscripten..."
 emcc libheif/.libs/libheif.so \
     --bind \
+    -s WASM=1 \
     -s NO_EXIT_RUNTIME=1 \
     -s TOTAL_MEMORY=${TOTAL_MEMORY} \
     -s ALLOW_MEMORY_GROWTH=1 \

--- a/post.js
+++ b/post.js
@@ -1,67 +1,72 @@
-function StringToArrayBuffer(str) {
+(function () {
+  function StringToArrayBuffer(str) {
     var buf = new ArrayBuffer(str.length);
     var bufView = new Uint8Array(buf);
-    for (var i=0, strLen=str.length; i<strLen; i++) {
-        bufView[i] = str.charCodeAt(i);
+    for (var i = 0, strLen = str.length; i < strLen; i++) {
+      bufView[i] = str.charCodeAt(i);
     }
     return buf;
-}
+  }
 
-var HeifImage = function(handle) {
+  var HeifImage = function (handle) {
     this.handle = handle;
     this.img = null;
-};
+  };
 
-HeifImage.prototype.free = function() {
+  HeifImage.prototype.free = function () {
     if (this.handle) {
-        libheif.heif_image_handle_release(this.handle);
-        this.handle = null;
+      libheif.heif_image_handle_release(this.handle);
+      this.handle = null;
     }
-};
+  };
 
-HeifImage.prototype._ensureImage = function() {
+  HeifImage.prototype._ensureImage = function () {
     if (this.img) {
-        return;
+      return;
     }
 
-    var img = libheif.heif_js_decode_image(this.handle,
-        libheif.heif_colorspace_YCbCr, libheif.heif_chroma_420);
+    var img = libheif.heif_js_decode_image(
+      this.handle,
+      libheif.heif_colorspace_YCbCr,
+      libheif.heif_chroma_420
+    );
     if (!img || img.code) {
-        console.log("Decoding image failed", this.handle, img);
-        return;
+      console.log("Decoding image failed", this.handle, img);
+      return;
     }
 
     this.data = new Uint8Array(StringToArrayBuffer(img.data));
     delete img.data;
     this.img = img;
-};
+  };
 
-HeifImage.prototype.get_width = function() {
+  HeifImage.prototype.get_width = function () {
     this._ensureImage();
     return this.img.width;
-};
+  };
 
-HeifImage.prototype.get_height = function() {
+  HeifImage.prototype.get_height = function () {
     this._ensureImage();
     return this.img.height;
-};
+  };
 
-HeifImage.prototype.is_primary = function() {
+  HeifImage.prototype.is_primary = function () {
     this._ensureImage();
     return !!this.img.is_primary;
-}
+  };
 
-HeifImage.prototype.display = function(image_data, callback) {
+  HeifImage.prototype.display = function (image_data, callback) {
     // Defer color conversion.
     var w = this.get_width();
     var h = this.get_height();
 
-    setTimeout(function() {
+    setTimeout(
+      function () {
         this._ensureImage();
         if (!this.img) {
-            // Decoding failed.
-            callback(null);
-            return;
+          // Decoding failed.
+          callback(null);
+          return;
         }
 
         var yval;
@@ -74,181 +79,199 @@ HeifImage.prototype.display = function(image_data, callback) {
         var voffset = 0;
         var x2;
         var i = 0;
-        var maxi = w*h;
+        var maxi = w * h;
         var stridey = w;
         var strideu = Math.ceil(w / 2);
         var stridev = Math.ceil(w / 2);
         var h2 = Math.ceil(h / 2);
         var y = this.data;
-        var u = this.data.subarray(stridey * h, stridey * h + (strideu * h2));
-        var v = this.data.subarray(stridey * h + (strideu * h2), stridey * h + (strideu * h2) + (stridev * h2));
+        var u = this.data.subarray(stridey * h, stridey * h + strideu * h2);
+        var v = this.data.subarray(
+          stridey * h + strideu * h2,
+          stridey * h + strideu * h2 + stridev * h2
+        );
         var dest = image_data.data;
         while (i < maxi) {
-            x2 = (xpos >> 1);
-            yval = 1.164 * (y[yoffset + xpos] - 16);
+          x2 = xpos >> 1;
+          yval = 1.164 * (y[yoffset + xpos] - 16);
 
-            uval = u[uoffset + x2] - 128;
-            vval = v[voffset + x2] - 128;
-            dest[(i<<2)+0] = yval + 1.596 * vval;
-            dest[(i<<2)+1] = yval - 0.813 * vval - 0.391 * uval;
-            dest[(i<<2)+2] = yval + 2.018 * uval;
-            dest[(i<<2)+3] = 0xff;
+          uval = u[uoffset + x2] - 128;
+          vval = v[voffset + x2] - 128;
+          dest[(i << 2) + 0] = yval + 1.596 * vval;
+          dest[(i << 2) + 1] = yval - 0.813 * vval - 0.391 * uval;
+          dest[(i << 2) + 2] = yval + 2.018 * uval;
+          dest[(i << 2) + 3] = 0xff;
+          i++;
+          xpos++;
+
+          if (xpos < w) {
+            yval = 1.164 * (y[yoffset + xpos] - 16);
+            dest[(i << 2) + 0] = yval + 1.596 * vval;
+            dest[(i << 2) + 1] = yval - 0.813 * vval - 0.391 * uval;
+            dest[(i << 2) + 2] = yval + 2.018 * uval;
+            dest[(i << 2) + 3] = 0xff;
             i++;
             xpos++;
+          }
 
-            if (xpos < w) {
-                yval = 1.164 * (y[yoffset + xpos] - 16);
-                dest[(i<<2)+0] = yval + 1.596 * vval;
-                dest[(i<<2)+1] = yval - 0.813 * vval - 0.391 * uval;
-                dest[(i<<2)+2] = yval + 2.018 * uval;
-                dest[(i<<2)+3] = 0xff;
-                i++;
-                xpos++;
-            }
-
-            if (xpos === w) {
-                xpos = 0;
-                ypos++;
-                yoffset += stridey;
-                uoffset = ((ypos >> 1) * strideu);
-                voffset = ((ypos >> 1) * stridev);
-            }
+          if (xpos === w) {
+            xpos = 0;
+            ypos++;
+            yoffset += stridey;
+            uoffset = (ypos >> 1) * strideu;
+            voffset = (ypos >> 1) * stridev;
+          }
         }
         callback(image_data);
-    }.bind(this), 0);
-};
+      }.bind(this),
+      0
+    );
+  };
 
-var HeifDecoder = function() {
+  var HeifDecoder = function () {
     this.decoder = null;
-};
+  };
 
-HeifDecoder.prototype.decode = function(buffer) {
+  HeifDecoder.prototype.decode = function (buffer) {
     if (this.decoder) {
-        libheif.heif_context_free(this.decoder);
+      libheif.heif_context_free(this.decoder);
     }
     this.decoder = libheif.heif_context_alloc();
     if (!this.decoder) {
-        console.log("Could not create HEIF context");
-        return [];
+      console.log("Could not create HEIF context");
+      return [];
     }
     var error = libheif.heif_context_read_from_memory(this.decoder, buffer);
     if (error.code !== libheif.heif_error_Ok) {
-        console.log("Could not parse HEIF file", error);
-        return [];
+      console.log("Could not parse HEIF file", error);
+      return [];
     }
 
-    var ids = libheif.heif_js_context_get_list_of_top_level_image_IDs(this.decoder);
+    var ids = libheif.heif_js_context_get_list_of_top_level_image_IDs(
+      this.decoder
+    );
     if (!ids || ids.code) {
-        console.log("Error loading image ids", ids);
-        return [];
-    }
-    else if (!ids.length) {
-        console.log("No images found");
-        return [];
+      console.log("Error loading image ids", ids);
+      return [];
+    } else if (!ids.length) {
+      console.log("No images found");
+      return [];
     }
 
     var result = [];
     for (var i = 0; i < ids.length; i++) {
-        var handle = libheif.heif_js_context_get_image_handle(this.decoder, ids[i]);
-        if (!handle || handle.code) {
-            console.log("Could not get image data for id", ids[i], handle);
-            continue;
-        }
+      var handle = libheif.heif_js_context_get_image_handle(
+        this.decoder,
+        ids[i]
+      );
+      if (!handle || handle.code) {
+        console.log("Could not get image data for id", ids[i], handle);
+        continue;
+      }
 
-        result.push(new HeifImage(handle));
+      result.push(new HeifImage(handle));
     }
     return result;
-};
+  };
 
-var libheif = {
+  var libheif = {
     // Expose high-level API.
     /** @expose */
     HeifDecoder: HeifDecoder,
 
     // Expose low-level API.
     /** @expose */
-    fourcc: function(s) {
-        return s.charCodeAt(0) << 24 |
-            s.charCodeAt(1) << 16 |
-            s.charCodeAt(2) << 8 |
-            s.charCodeAt(3);
-    }
-};
+    fourcc: function (s) {
+      return (
+        (s.charCodeAt(0) << 24) |
+        (s.charCodeAt(1) << 16) |
+        (s.charCodeAt(2) << 8) |
+        s.charCodeAt(3)
+      );
+    },
 
-var key;
+    // Initialize libheif global export by exposing C API
+    // To be called after WASM been has been loaded asynchronously using Module.onRuntimeInitialized
+    // @reference: https://emscripten.org/docs/api_reference/module.html?highlight=onruntimeinitialized#Module.onRuntimeInitialized
 
-// Expose enum values.
-var enums = {
-    "heif_error_code": true,
-    "heif_suberror_code": true,
-    "heif_compression_format": true,
-    "heif_chroma": true,
-    "heif_colorspace": true,
-    "heif_channel": true
-};
-var e;
-for (e in enums) {
-    if (!enums.hasOwnProperty(e)) {
-        continue;
-    }
-    for (key in Module[e]) {
-        if (!Module[e].hasOwnProperty(key) ||
-            key === "values") {
-            continue;
+    load: function () {
+      var key;
+      // Expose enum values.
+      var enums = {
+        heif_error_code: true,
+        heif_suberror_code: true,
+        heif_compression_format: true,
+        heif_chroma: true,
+        heif_colorspace: true,
+        heif_channel: true,
+      };
+      var e;
+      for (e in enums) {
+        if (!enums.hasOwnProperty(e)) {
+          continue;
         }
+        for (key in Module[e]) {
+          if (!Module[e].hasOwnProperty(key) || key === "values") {
+            continue;
+          }
 
-        libheif[key] = Module[e][key];
-    }
-}
+          libheif[key] = Module[e][key];
 
-// Expose internal C API.
-for (key in Module) {
-    if (enums.hasOwnProperty(key) || key.indexOf("heif_") !== 0) {
-        continue;
-    }
-    libheif[key] = Module[key];
-}
+          // don't pollute the global namespace
+          delete Module[e][key];
+        }
+      }
 
-// don't pollute the global namespace
-delete this['Module'];
+      // Expose internal C API.
+      for (key in Module) {
+        if (enums.hasOwnProperty(key) || key.indexOf("heif_") !== 0) {
+          continue;
+        }
+        libheif[key] = Module[key];
 
-// On IE this function is called with "undefined" as first parameter. Override
-// with a version that supports this behaviour.
-function createNamedFunction(name, body) {
+        // don't pollute the global namespace
+        delete Module[key];
+      }
+    },
+  };
+
+  // On IE this function is called with "undefined" as first parameter. Override
+  // with a version that supports this behaviour.
+  function createNamedFunction(name, body) {
     if (!name) {
-      name = "function_" + (new Date());
+      name = "function_" + new Date();
     }
     name = makeLegalFunctionName(name);
     /*jshint evil:true*/
     return new Function(
-        "body",
-        "return function " + name + "() {\n" +
-        "    \"use strict\";" +
+      "body",
+      "return function " +
+        name +
+        "() {\n" +
+        '    "use strict";' +
         "    return body.apply(this, arguments);\n" +
         "};\n"
     )(body);
-}
+  }
 
-var root = this;
+  var root = this;
 
-if (typeof exports !== 'undefined') {
-    if (typeof module !== 'undefined' && module.exports) {
-        /** @expose */
-        exports = module.exports = libheif;
+  if (typeof exports !== "undefined") {
+    if (typeof module !== "undefined" && module.exports) {
+      /** @expose */
+      exports = module.exports = libheif;
     }
     /** @expose */
     exports.libheif = libheif;
-} else {
+  } else {
     /** @expose */
     root.libheif = libheif;
-}
+  }
 
-if (typeof define === "function" && define.amd) {
+  if (typeof define === "function" && define.amd) {
     /** @expose */
-    define([], function() {
-        return libheif;
+    define([], function () {
+      return libheif;
     });
-}
-
-// NOTE: wrapped inside "(function() {" block from pre.js
-}).call(this);
+  }
+}.call(this));

--- a/pre.js
+++ b/pre.js
@@ -18,16 +18,17 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with libheif.  If not, see <http://www.gnu.org/licenses/>.
  */
-(function() {
-var Module = {
-    print: function(text) {
-        text = Array.prototype.slice.call(arguments).join(' ');
-        console.log(text);
+(function () {
+  var Module = {
+    print: function (text) {
+      text = Array.prototype.slice.call(arguments).join(" ");
+      console.log(text);
     },
-    printErr: function(text) {
-        text = Array.prototype.slice.call(arguments).join(' ');
-        console.error(text);
+    printErr: function (text) {
+      text = Array.prototype.slice.call(arguments).join(" ");
+      console.error(text);
     },
     canvas: {},
-    noInitialRun: true
-};
+    noInitialRun: true,
+  };
+}.call(this));


### PR DESCRIPTION
-s WASM=1 — Specifies that we want wasm output. If we don’t specify this, Emscripten will just output asm.js, as it does by default.

The WASM build will provide significant performance improvement for the dependent JavaScript library: [libheif-js](https://github.com/catdad-experiments/libheif-js)