### PR TITLE
Make the vendored rav1e completely static

### DIFF
--- a/third-party/rav1e.cmd
+++ b/third-party/rav1e.cmd
@@ -14,5 +14,5 @@ git clone -b 0.4 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cargo-c
-cargo cinstall --release --prefix="$(pwd)/dist" --library-type=staticlib
+cargo cinstall --crt-static --release --prefix="$(pwd)/dist" --library-type=staticlib
 cd ..


### PR DESCRIPTION
It sidetracks the problem of linking the static library without using the information provided by the pkg-config file.

Discovered when investigating https://github.com/lu-zero/cargo-c/issues/181