### PR TITLE
Add rav1e.dll to make cmake find rav1e on MSVC targets

### DIFF
--- a/cmake/modules/FindRav1e.cmake
+++ b/cmake/modules/FindRav1e.cmake
@@ -8,7 +8,7 @@ find_path(RAV1E_INCLUDE_DIR
 )
 
 find_library(RAV1E_LIBRARY
-    NAMES librav1e rav1e
+    NAMES librav1e rav1e rav1e.dll
     HINTS ${RAV1E_PKGCONF_LIBRARY_DIRS} ${RAV1E_PKGCONF_LIBDIR}
 )
 


### PR DESCRIPTION
Useful if the user wants to distribute the `rav1e.dll` along with `heif.dll`