### PR TITLE
Fix an out-of-bounds read with the AOM tune parameter array

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -74,7 +74,7 @@ static const char* const kParam_chroma_valid_values[] = {
 
 static const char* kParam_tune = "tune";
 static const char* const kParam_tune_valid_values[] = {
-    "psnr", "ssim"
+    "psnr", "ssim", nullptr
 };
 
 static const int AOM_PLUGIN_PRIORITY = 40;


### PR DESCRIPTION
The kParam_tune_valid_values array was missing the NULL pointer that
marks the end of the list.