### PR TITLE
AppVeyor: Also publish build .dll files separately as artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,3 +32,4 @@ build:
 artifacts:
   - path: build
   - path: build\**\Release\*.exe
+  - path: build\**\Release\*.dll


### PR DESCRIPTION
Currently the build `.exe` files are separately uploaded to AppVeyor as artifacts, but since libheif is build dynamically those are useless without the `.dll` library. This PR fixes that.

Small follow up on #470.