### PR TITLE
aom: improve AVIF encoding performance by ~2x

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -691,7 +691,10 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
 
 
   unsigned int aomUsage = 0;
-#if defined(AOM_USAGE_REALTIME)
+#if defined(AOM_USAGE_ALL_INTRA)
+  // aom 3.1.0
+  aomUsage = (encoder->realtime_mode ? AOM_USAGE_REALTIME : AOM_USAGE_ALL_INTRA);
+#elif defined(AOM_USAGE_REALTIME)
   // aom 2.0
   aomUsage = (encoder->realtime_mode ? AOM_USAGE_REALTIME : AOM_USAGE_GOOD_QUALITY);
 #endif


### PR DESCRIPTION
Available from aom v3.1.0, the new "all intra" usage mode is now considered its best setting for still images.

From what I can tell, it uses a single pass and skips the keyframe logic (i.e. everything is intra-frame), resulting in significantly fewer memory allocations in addition to almost halving CPU time. The compression ratio is nearly identical, sometimes better, and the worst case I've found so far was 0.8% larger.

https://aomedia.googlesource.com/aom/+/refs/tags/v3.1.0

libavif has already adopted this as the default - see https://github.com/AOMediaCodec/libavif/pull/539

Homebrew currently provides aom v3.1.0 so the macOS CI job will test this.