### PR TITLE
aom: expose decoder error messages to aid debugging

### DIFF
--- a/libheif/heif_decoder_aom.cc
+++ b/libheif/heif_decoder_aom.cc
@@ -97,7 +97,7 @@ struct heif_error aom_new_decoder(void** dec)
 
     delete decoder;
 
-    struct heif_error err = {heif_error_Decoder_plugin_error, heif_suberror_Unspecified, kSuccess};
+    struct heif_error err = {heif_error_Decoder_plugin_error, heif_suberror_Unspecified, aom_codec_err_to_string(aomerr)};
     return err;
   }
 
@@ -133,7 +133,7 @@ struct heif_error aom_push_data(void* decoder_raw, const void* frame_data, size_
   aom_codec_err_t aomerr;
   aomerr = aom_codec_decode(&decoder->codec, (const uint8_t*) frame_data, frame_size, NULL);
   if (aomerr) {
-    struct heif_error err = {heif_error_Invalid_input, heif_suberror_Unspecified, kSuccess};
+    struct heif_error err = {heif_error_Invalid_input, heif_suberror_Unspecified, aom_codec_err_to_string(aomerr)};
     return err;
   }
 


### PR DESCRIPTION
Errors that occur in the aom decoder currently return a generic "Success" message.

```sh
$ heif-convert testimage.avif out.png
File contains 1 images
Could not decode image: 0: Invalid input: Unspecified: Success
```

To make such problems easier to debug, this PR calls the `aom_codec_err_to_string` public API to lookup the underlying error mesage.

```sh
$ heif-convert testimage.avif out.png
File contains 1 images
Could not decode image: 0: Invalid input: Unspecified: Bitstream not supported by this decoder
```

As originally reported at https://github.com/lovell/sharp/issues/2688