### PR TITLE
Fix: decrease reference count on GdkPixbuf object so it can be freed

### DIFF
--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -138,6 +138,8 @@ static gboolean stop_load(gpointer context, GError** error)
     (*hpc->update_func)(pixbuf, 0, 0, gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf), hpc->user_data);
   }
 
+  g_clear_object(&pixbuf);
+
   result = TRUE;
 
   cleanup:


### PR DESCRIPTION
GdkPixbuf objects are created with a reference count of 1. This fix decreases the reference count after use so it may actually be freed after use.

This fixes issue #509 - I tested on my machine and eog now really doesn't accumulate memory anymore.
