### PR TITLE
Update libde265 version and fix Emscripten error

### DIFF
--- a/build-emscripten.sh
+++ b/build-emscripten.sh
@@ -5,7 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CORES=$(nproc --all)
 echo "Build using ${CORES} CPU cores"
 
-LIBDE265_VERSION=1.0.2
+LIBDE265_VERSION=1.0.8
 [ -s "libde265-${LIBDE265_VERSION}.tar.gz" ] || curl \
     -L \
     -o libde265-${LIBDE265_VERSION}.tar.gz \


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/issues/10784, and, possibly, https://github.com/strukturag/libde265/commit/f38489503ee55e6b937d26a4480b081e3c4245e4.