### PR TITLE
expose set_max_decoding_threads

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -2337,3 +2337,9 @@ void heif_context_set_maximum_image_size_limit(struct heif_context* ctx, int max
 {
   ctx->context->set_maximum_image_size_limit(maximum_width);
 }
+
+
+void heif_context_set_max_decoding_threads(struct heif_context* ctx, int max_threads)
+{
+  ctx->context->set_max_decoding_threads(max_threads);
+}

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -494,6 +494,9 @@ void heif_context_debug_dump_boxes_to_file(struct heif_context* ctx, int fd);
 LIBHEIF_API
 void heif_context_set_maximum_image_size_limit(struct heif_context* ctx, int maximum_width);
 
+LIBHEIF_API
+void heif_context_set_max_decoding_threads(struct heif_context* ctx, int max_threads);
+
 
 // ========================= heif_image_handle =========================
 


### PR DESCRIPTION
Gives the C API access to the `HeifContext::set_max_decoding_threads`. For some reason it was missing, making it impossible to control threading, if enabled.