### PR TITLE
Avoid lroundf using, overall 24% speedup for any images

### DIFF
--- a/libheif/heif_colorconversion.cc
+++ b/libheif/heif_colorconversion.cc
@@ -306,7 +306,7 @@ static inline uint8_t clip_int_u8(int x)
 
 static inline uint16_t clip_f_u16(float fx, int32_t maxi)
 {
-  long x = lroundf(fx);
+  long x = (long int) (fx + 0.5f);
   if (x < 0) return 0;
   if (x > maxi) return (uint16_t) maxi;
   return static_cast<uint16_t>(x);
@@ -1961,7 +1961,7 @@ Op_RGB24_32_to_YCbCr::state_after_conversion(ColorState input_state,
 
 static inline uint8_t clip_f_u8(float fx)
 {
-  long x = lroundf(fx);
+  long x = (long int) (fx + 0.5f);
   if (x < 0) return 0;
   if (x > 255) return 255;
   return static_cast<uint8_t>(x);


### PR DESCRIPTION
If you look to `perf report`, this only function uses a lot of CPU while it is totally avoidable.

```
$ perf record python -m timeit -n3 -r10 \
    -s "import pyheif; data = open('./full.norot.heic', 'rb').read()" \
    "im = pyheif.read(data)"
```

![Screenshot 2021-10-17 at 14 31 52](https://user-images.githubusercontent.com/128982/137625677-adb6e0f7-31d3-40f9-b194-28b77dd2bad1.png)


master:
```
$ taskset 0x1 python -m timeit -n3 -r10 \
    -s "import pyheif; data = open('./full.norot.heic', 'rb').read()" \
    "im = pyheif.read(data)"
3 loops, best of 10: 479 msec per loop
```

native-rounding:
```
$ taskset 0x1 python -m timeit -n3 -r10 \
    -s "import pyheif; data = open('./full.norot.heic', 'rb').read()" \
    "im = pyheif.read(data)"
3 loops, best of 10: 386 msec per loop
```

I'm using `taskset 0x1` for more consistent benchmarks results.