### PR TITLE
Expose transformations

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1643,8 +1643,9 @@ struct heif_error heif_image_handle_get_transformations(const struct heif_image_
     return err.error_struct(handle->image.get());
   }
 
-  handle->image->read_transformations(transformations);
-  return Error::Ok.error_struct(handle->image.get());
+  Error err = handle->image->read_transformations(transformations);
+
+  return err.error_struct(handle->image.get());
 }
 
 

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1609,6 +1609,45 @@ void heif_nclx_color_profile_free(struct heif_color_profile_nclx* nclx_profile)
 }
 
 
+struct heif_transformations* heif_transformations_alloc()
+{
+  auto transformations = (heif_transformations*) malloc(
+    sizeof(struct heif_transformations)
+  );
+
+  if (transformations) {
+    transformations->version = 1;
+    transformations->crop_left = 0;
+    transformations->crop_top = 0;
+    transformations->crop_width = 0;
+    transformations->crop_height = 0;
+    transformations->orientation_tag = 0;
+  }
+
+  return transformations;
+}
+
+
+void heif_transformations_free(struct heif_transformations* transformations)
+{
+  free(transformations);
+}
+
+
+struct heif_error heif_image_handle_get_transformations(const struct heif_image_handle* handle,
+                                                        struct heif_transformations* transformations)
+{
+  if (transformations == nullptr) {
+    Error err(heif_error_Usage_error,
+              heif_suberror_Null_pointer_argument);
+    return err.error_struct(handle->image.get());
+  }
+
+  handle->image->read_transformations(transformations);
+  return Error::Ok.error_struct(handle->image.get());
+}
+
+
 // DEPRECATED
 struct heif_error heif_register_decoder(heif_context* heif, const heif_decoder_plugin* decoder_plugin)
 {

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -927,6 +927,39 @@ struct heif_error heif_image_get_nclx_color_profile(const struct heif_image* ima
                                                     struct heif_color_profile_nclx** out_data);
 
 
+// Represents image transformation stored in irot, imir and clap boxes.
+// Unlike boxes in the file, these operations have only one proper order:
+// you always should crop the image first, then rotate according to orientation_tag.
+// imir and irot boxes stored in single orientation_tag. orientation_tag have
+// has the same meaning as orientation tag in EXIF (values from 1 to 8).
+// In general, you may transform the image according to this tag,
+// and if orientation_tag is 0, apply the value from EXIF metadata.
+struct heif_transformations
+{
+  uint8_t version;
+  
+  // version 1 fields
+
+  // Crop coords and size. If clap box is not present, coords will be (0, 0)
+  // and size will be the same as image size.
+  uint32_t crop_left, crop_top;
+  uint32_t crop_width, crop_height;
+
+  // Orientation tag: values 0-8, where 1-8 means the same values
+  // as in EXIF Orientation tag. 0 means no irot or imir boxes in the file.
+  uint8_t orientation_tag;
+};
+
+LIBHEIF_API
+struct heif_transformations* heif_transformations_alloc();
+
+LIBHEIF_API
+void heif_transformations_free(struct heif_transformations* transformations);
+
+LIBHEIF_API
+struct heif_error heif_image_handle_get_transformations(const struct heif_image_handle* handle,
+                                                        struct heif_transformations* transformations);
+
 
 // ========================= heif_image =========================
 

--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -1079,6 +1079,47 @@ int HeifContext::Image::get_chroma_bits_per_pixel() const
 }
 
 
+Error HeifContext::Image::read_transformations(struct heif_transformations* transformations) const
+{
+  std::vector<Box_ipco::Property> properties;
+  Error err = m_heif_context->m_heif_file->get_properties(m_id, properties);
+  if (err) {
+    return err;
+  }
+
+  transformations->version = 1;
+  transformations->crop_left = 0;
+  transformations->crop_top = 0;
+  transformations->crop_width = m_ispe_width;
+  transformations->crop_height = m_ispe_height;
+  transformations->orientation_tag = 0;
+
+  // Use this flag to match HeifContext::interpret_heif_file logic
+  bool ispe_read = false;
+  for (const auto& property : properties) {
+    auto ispe = std::dynamic_pointer_cast<Box_ispe>(property.property);
+    if (ispe) {
+      ispe_read = true;
+    }
+    if (!ispe_read) continue;
+
+    auto clap = std::dynamic_pointer_cast<Box_clap>(property.property);
+    if (clap) {
+    }
+
+    auto irot = std::dynamic_pointer_cast<Box_irot>(property.property);
+    if (irot) {
+    }
+
+    auto mirror = std::dynamic_pointer_cast<Box_imir>(property.property);
+    if (mirror) {
+    }
+  }
+  
+  return Error::Ok;
+}
+
+
 Error HeifContext::decode_image_user(heif_item_id ID,
                                      std::shared_ptr<HeifPixelImage>& img,
                                      heif_colorspace out_colorspace,

--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -172,8 +172,12 @@ static void transform_orientation(struct heif_transformations* transformations,
   // angle * 90 specifies the angle (counterclockwise) in degrees.
   uint8_t rotation_to_bitmask[4] = {0b000, 0b101, 0b011, 0b110};
   uint8_t operation = rotation_to_bitmask[angle & 0b011];
-  if (horizontal) operation ^= 0b001;
-  if (vertical) operation ^= 0b010;
+  if (horizontal) {
+    operation ^= 0b001;
+  }
+  if (vertical) {
+    operation ^= 0b010;
+  }
 
   uint8_t bitmask = tag_to_bitmask[transformations->orientation_tag];
 
@@ -1180,8 +1184,8 @@ Error HeifContext::Image::read_transformations(struct heif_transformations* tran
 
     auto irot = std::dynamic_pointer_cast<Box_irot>(property.property);
     if (irot) {
-      transform_orientation(transformations, (irot->get_rotation() / 90) & 0x3,
-        false, false);
+      transform_orientation(transformations,
+        (irot->get_rotation() / 90) & 0x3, false, false);
     }
 
     auto imir = std::dynamic_pointer_cast<Box_imir>(property.property);
@@ -1193,15 +1197,13 @@ Error HeifContext::Image::read_transformations(struct heif_transformations* tran
 
     auto clap = std::dynamic_pointer_cast<Box_clap>(property.property);
     if (clap) {
-      int img_width = get_ispe_width();
-      int img_height = get_ispe_height();
       transform_crop(
         transformations,
-        clap->left_rounded(img_width),
-        clap->right_rounded(img_width),
+        clap->left_rounded(m_ispe_width),
+        clap->right_rounded(m_ispe_height),
         clap->get_width_rounded(),
         clap->get_height_rounded(),
-        img_width, img_height
+        m_ispe_width, m_ispe_height
       );
     }
   }

--- a/libheif/heif_context.h
+++ b/libheif/heif_context.h
@@ -284,6 +284,8 @@ namespace heif {
         }
       };
 
+      Error read_transformations(struct heif_transformations* transformations) const;
+
     private:
       HeifContext* m_heif_context;
 


### PR DESCRIPTION
This PR introduce interface for reading transformations for given `heif_image_handle`.

# Rationale

The current rotation implementation is pretty straight and that is why inefficient on modern CPUs. For example, It could be up to 8.5 times slower than [Pillow's implementation](https://pillow.readthedocs.io/en/stable/index.html).

```python
In [2]: from HeifImagePlugin import Image, pyheif

In [3]: data = open('./full.heic', 'rb').read()

In [5]: %%timeit 
   ...: heif_file = pyheif.read(data) 
   ...: image = Image.frombytes( 
   ...:     heif_file.mode, heif_file.size, heif_file.data,
   ...:     "raw", heif_file.mode, heif_file.stride)
   ...:
683 ms ± 11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %%timeit 
   ...: heif_file = pyheif.read(data, apply_transformations=False) 
   ...: image = Image.frombytes( 
   ...:     heif_file.mode, heif_file.size, heif_file.data,
   ...:     "raw", heif_file.mode, heif_file.stride)
   ...:
387 ms ± 10.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [13]: %%timeit 
    ...: heif_file = pyheif.read(data, apply_transformations=False) 
    ...: image = Image.frombytes( 
    ...:     heif_file.mode, heif_file.size, heif_file.data,
    ...:     "raw", heif_file.mode, heif_file.stride)
    ...: image = image.transpose(Image.ROTATE_270) 
    ...:
422 ms ± 5.66 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

> Time spent to rotation in libheif: 683 - 387 ms = 296 ms.
> Time spent to rotation in Pillow: 422 - 387 ms = 35 ms.

There is already an flag `ignore_transformations` which could be used to prevent `libheif` from transforming the image. Unfortunately there was no way to get image transformation properties from the file.

So, the new struct `heif_transformations` is introduced. It describes image's transformations (information from `irot`, `imir` and `clap` boxes) in strict order (unlike in the file itself, where operations could be in arbitrary order).

In addition, for some cases, transformation from this struct could be used for EXIF construction and actual image rotation could be totally avoided.