### PR TITLE
Enable wide chars for all Windows

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -14,7 +14,7 @@ jobs:
           - { MINGW: 32 }
           - { MINGW: 64 }
     env: ${{ matrix.env }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1513,7 +1513,7 @@ static struct heif_error heif_file_writer_write(struct heif_context* ctx,
 {
   const char* filename = static_cast<const char*>(userdata);
 
-#ifdef _MSC_VER
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
   std::ofstream ostr(HeifFile::convert_utf8_path_to_utf16(filename).c_str(), std::ios_base::binary);
 #else
   std::ofstream ostr(filename, std::ios_base::binary);

--- a/libheif/heif_file.cc
+++ b/libheif/heif_file.cc
@@ -27,13 +27,13 @@
 #include <cstring>
 #include <cassert>
 
-#ifdef _MSC_VER
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
 
 #ifndef NOMINMAX
 #define NOMINMAX 1
 #endif
 
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 using namespace heif;
@@ -66,7 +66,7 @@ std::vector<heif_item_id> HeifFile::get_item_IDs() const
 
 Error HeifFile::read_from_file(const char* input_filename)
 {
-#ifdef _MSC_VER
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
   auto input_stream_istr = std::unique_ptr<std::istream>(new std::ifstream(convert_utf8_path_to_utf16(input_filename).c_str(), std::ios_base::binary));
 #else
   auto input_stream_istr = std::unique_ptr<std::istream>(new std::ifstream(input_filename, std::ios_base::binary));
@@ -876,7 +876,7 @@ void HeifFile::set_hdlr_library_info(std::string encoder_plugin_version)
 }
 
 
-#ifdef _MSC_VER
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
 std::wstring HeifFile::convert_utf8_path_to_utf16(std::string str)
 {
   std::wstring ret;

--- a/libheif/heif_file.h
+++ b/libheif/heif_file.h
@@ -155,7 +155,7 @@ namespace heif {
     // TODO: the hdlr box is probably not the right place for this. Into which box should we write comments?
     void set_hdlr_library_info(std::string encoder_plugin_version);
 
-#ifdef _MSC_VER
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
     static std::wstring convert_utf8_path_to_utf16(std::string pathutf8);
 #endif
 

--- a/scripts/install-ci-linux.sh
+++ b/scripts/install-ci-linux.sh
@@ -110,6 +110,8 @@ fi
 
 if [ "$MINGW" == "32" ]; then
     sudo dpkg --add-architecture i386
+    # https://github.com/actions/virtual-environments/issues/4589
+    sudo apt install -y --allow-downgrades libpcre2-8-0=10.34-7
     INSTALL_PACKAGES="$INSTALL_PACKAGES \
         binutils-mingw-w64-i686 \
         g++-mingw-w64-i686 \

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -71,14 +71,14 @@ if [ "$MINGW" == "32" ]; then
     unset CXX
     BIN_SUFFIX=.exe
     BIN_WRAPPER=wine
-    export WINEPATH="/usr/lib/gcc/i686-w64-mingw32/7.3-posix/;/usr/i686-w64-mingw32/lib"
+    export WINEPATH="/usr/lib/gcc/i686-w64-mingw32/9.3-posix/;/usr/i686-w64-mingw32/lib"
 elif [ "$MINGW" == "64" ]; then
     # Make sure the correct compiler will be used.
     unset CC
     unset CXX
     BIN_SUFFIX=.exe
     BIN_WRAPPER=wine64
-    export WINEPATH="/usr/lib/gcc/x86_64-w64-mingw32/7.3-posix/;/usr/x86_64-w64-mingw32/lib"
+    export WINEPATH="/usr/lib/gcc/x86_64-w64-mingw32/9.3-posix/;/usr/x86_64-w64-mingw32/lib"
 elif [ ! -z "$FUZZER" ]; then
     export CC="$BUILD_ROOT/clang/bin/clang"
     export CXX="$BUILD_ROOT/clang/bin/clang++"


### PR DESCRIPTION
This is platform specific, not compiler specific (i.e. it is also implemented by libstdc++ and libc++ on Win32 such as MinGW).