### PR TITLE
CI: use Ubuntu 20.04 for the mingw build to get a newer toolchain

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -14,7 +14,7 @@ jobs:
           - { MINGW: 32 }
           - { MINGW: 64 }
     env: ${{ matrix.env }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 

--- a/scripts/install-ci-linux.sh
+++ b/scripts/install-ci-linux.sh
@@ -110,6 +110,8 @@ fi
 
 if [ "$MINGW" == "32" ]; then
     sudo dpkg --add-architecture i386
+    # https://github.com/actions/virtual-environments/issues/4589
+    sudo apt install -y --allow-downgrades libpcre2-8-0=10.34-7
     INSTALL_PACKAGES="$INSTALL_PACKAGES \
         binutils-mingw-w64-i686 \
         g++-mingw-w64-i686 \

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -71,14 +71,14 @@ if [ "$MINGW" == "32" ]; then
     unset CXX
     BIN_SUFFIX=.exe
     BIN_WRAPPER=wine
-    export WINEPATH="/usr/lib/gcc/i686-w64-mingw32/7.3-posix/;/usr/i686-w64-mingw32/lib"
+    export WINEPATH="/usr/lib/gcc/i686-w64-mingw32/9.3-posix/;/usr/i686-w64-mingw32/lib"
 elif [ "$MINGW" == "64" ]; then
     # Make sure the correct compiler will be used.
     unset CC
     unset CXX
     BIN_SUFFIX=.exe
     BIN_WRAPPER=wine64
-    export WINEPATH="/usr/lib/gcc/x86_64-w64-mingw32/7.3-posix/;/usr/x86_64-w64-mingw32/lib"
+    export WINEPATH="/usr/lib/gcc/x86_64-w64-mingw32/9.3-posix/;/usr/x86_64-w64-mingw32/lib"
 elif [ ! -z "$FUZZER" ]; then
     export CC="$BUILD_ROOT/clang/bin/clang"
     export CXX="$BUILD_ROOT/clang/bin/clang++"


### PR DESCRIPTION
Needed a workaround for installing wine32 due to the GHA image being
broken (see https://github.com/actions/virtual-environments/issues/4589) (could also be worked around by using a docker image).

Might help #569