### PR TITLE
Remove reference to "XMP" in add_generic_metadata

### DIFF
--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -2481,7 +2481,7 @@ Error HeifContext::add_generic_metadata(std::shared_ptr<Image> master_image, con
                                   fourcc("cdsc"), {master_image->get_id()});
 
 
-  // copy the XMP data into the file, store the pointer to it in an iloc box entry
+  // copy the data into the file, store the pointer to it in an iloc box entry
 
   std::vector<uint8_t> data_array;
   data_array.resize(size);


### PR DESCRIPTION
Remove a reference to "XMP" in a comment in the add_generic_metadata()
method. This method is used to add all kinds of data, not just XMP data.