### PR TITLE
Added pillow_heif for python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ When running `cmake` or `configure`, make sure that the environment variable
 * Go: part of libheif
 * JavaScript: by compilation with emscripten (see below)
 * NodeJS module: [libheif-js](https://www.npmjs.com/package/libheif-js)
-* Python: [pyheif](https://pypi.org/project/pyheif/) [pillow_heif](https://pypi.org/project/pillow-heif/)
+* Python: [pyheif](https://pypi.org/project/pyheif/), [pillow_heif](https://pypi.org/project/pillow-heif/)
 * Rust: [libheif-sys](https://github.com/Cykooz/libheif-sys)
 * Swift: [libheif-Xcode](https://swiftpackageregistry.com/SDWebImage/libheif-Xcode)
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ When running `cmake` or `configure`, make sure that the environment variable
 * Go: part of libheif
 * JavaScript: by compilation with emscripten (see below)
 * NodeJS module: [libheif-js](https://www.npmjs.com/package/libheif-js)
-* Python: [pyheif](https://pypi.org/project/pyheif/)
+* Python: [pyheif](https://pypi.org/project/pyheif/) [pillow_heif](https://pypi.org/project/pillow-heif/)
 * Rust: [libheif-sys](https://github.com/Cykooz/libheif-sys)
 * Swift: [libheif-Xcode](https://swiftpackageregistry.com/SDWebImage/libheif-Xcode)
 


### PR DESCRIPTION
Difference from pyheif:
1. Builds publicly on GitHub
2. Wheels for Linux, Alpine, macOS - x64, aarch64(arm64)
3. read_color_profile/read_metadata differs from pyheif(see 4)
4. Use it myself in public project(Nextcloud), heavily tested by admins, fast bug reports.
5. Contains some features that pyheif still hasn't.