### PR TITLE
msys problems: do not rely on an extern variable, use api instead

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -96,6 +96,28 @@ int heif_get_version_number_maintenance(void)
   return ((LIBHEIF_NUMERIC_VERSION) >> 8) & 0xFF;
 }
 
+static int use_multithreading =
+#ifdef ENABLE_PARALLEL_TILE_DECODING
+  1
+#else
+  0
+#endif
+;
+
+int heif_global_get_multithreading(void)
+{
+	return use_multithreading;
+}
+
+int heif_global_set_multithreading(int flag)
+{
+#ifdef ENABLE_PARALLEL_TILE_DECODING
+  use_multithreading = flag ? 1 : 0;
+  return use_multithreading;
+#else
+  return 0;
+#endif
+}
 
 heif_filetype_result heif_check_filetype(const uint8_t* data, int len)
 {

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -83,6 +83,11 @@ LIBHEIF_API int heif_get_version_number_maintenance(void);
 #define LIBHEIF_MAKE_VERSION(h, m, l) ((h) << 24 | (m) << 16 | (l) << 8)
 #define LIBHEIF_HAVE_VERSION(h, m, l) (LIBHEIF_NUMERIC_VERSION >= LIBHEIF_MAKE_VERSION(h, m, l))
 
+// 1 if ENABLE_PARALLEL_TILE_DECODING is defined -- can be turned off
+LIBHEIF_API int heif_global_get_multithreading(void);
+// returns new flag value or 0 if ENABLE_PARALLEL_TILE_DECODING is undefined
+LIBHEIF_API int heif_global_set_multithreading(int flag);
+
 struct heif_context;
 struct heif_image_handle;
 struct heif_image;

--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -1464,8 +1464,10 @@ Error HeifContext::decode_full_grid_image(heif_item_id ID,
 
   int y0 = 0;
   int reference_idx = 0;
+  int use_multithreading = heif_global_get_multithreading();
 
 #if ENABLE_PARALLEL_TILE_DECODING
+  
   // remember which tile to put where into the image
   struct tile_data {
     heif_item_id tileID;
@@ -1473,7 +1475,8 @@ Error HeifContext::decode_full_grid_image(heif_item_id ID,
   };
 
   std::deque<tile_data> tiles;
-  tiles.resize(grid.get_rows() * grid.get_columns() );
+  if (use_multithreading)
+    tiles.resize(grid.get_rows() * grid.get_columns() );
 
   std::deque<std::future<Error> > errs;
 #endif
@@ -1498,12 +1501,16 @@ Error HeifContext::decode_full_grid_image(heif_item_id ID,
       int src_height = tileImg->get_height();
 
 #if ENABLE_PARALLEL_TILE_DECODING
-      tiles[x+y*grid.get_columns()] = tile_data { tileID, x0,y0 };
-#else
-      Error err = decode_and_paste_tile_image(tileID, img, x0, y0);
-      if (err) {
-        return err;
-      }
+      if (use_multithreading) {
+         tiles[x+y*grid.get_columns()] = tile_data { tileID, x0,y0 };
+      } else {
+#endif
+        Error err = decode_and_paste_tile_image(tileID, img, x0, y0);
+        if (err) {
+          return err;
+        }
+#if ENABLE_PARALLEL_TILE_DECODING
+     }
 #endif
 
       x0 += src_width;
@@ -1516,14 +1523,37 @@ Error HeifContext::decode_full_grid_image(heif_item_id ID,
   }
 
 #if ENABLE_PARALLEL_TILE_DECODING
-  // Process all tiles in a set of background threads.
-  // Do not start more than the maximum number of threads.
+  if ( use_multithreading ) {
+    // Process all tiles in a set of background threads.
+    // Do not start more than the maximum number of threads.
 
-  while (tiles.empty()==false) {
+    while (tiles.empty()==false) {
 
-    // If maximum number of threads running, wait until first thread finishes
+      // If maximum number of threads running, wait until first thread finishes
 
-    if (errs.size() >= (size_t)m_max_decoding_threads) {
+      if (errs.size() >= (size_t)m_max_decoding_threads) {
+        Error e = errs.front().get();
+        if (e) {
+          return e;
+        }
+
+        errs.pop_front();
+      }
+
+
+      // Start a new decoding thread
+
+      tile_data data = tiles.front();
+      tiles.pop_front();
+
+      errs.push_back( std::async(std::launch::async,
+                                 &HeifContext::decode_and_paste_tile_image, this,
+                                 data.tileID, img, data.x_origin,data.y_origin) );
+    }
+
+    // check for decoding errors in remaining tiles
+
+    while (errs.empty() == false) {
       Error e = errs.front().get();
       if (e) {
         return e;
@@ -1531,27 +1561,6 @@ Error HeifContext::decode_full_grid_image(heif_item_id ID,
 
       errs.pop_front();
     }
-
-
-    // Start a new decoding thread
-
-    tile_data data = tiles.front();
-    tiles.pop_front();
-
-    errs.push_back( std::async(std::launch::async,
-                               &HeifContext::decode_and_paste_tile_image, this,
-                               data.tileID, img, data.x_origin,data.y_origin) );
-  }
-
-  // check for decoding errors in remaining tiles
-
-  while (errs.empty() == false) {
-    Error e = errs.front().get();
-    if (e) {
-      return e;
-    }
-
-    errs.pop_front();
   }
 #endif
 

--- a/libheif/heif_encoder_x265.cc
+++ b/libheif/heif_encoder_x265.cc
@@ -187,7 +187,8 @@ static const char* x265_plugin_name()
 {
   strcpy(plugin_name, "x265 HEVC encoder");
 
-  const char* x265_version = (x265_version_str != nullptr ? x265_version_str : "null");
+  const x265_api* api = x265_api_get(0);
+  const char* x265_version = (api != nullptr && api->version_str != nullptr ? api->version_str : "null");
 
   if (strlen(x265_version) + strlen(plugin_name) + 4 < MAX_PLUGIN_NAME_LENGTH) {
     strcat(plugin_name, " (");


### PR DESCRIPTION
Hello,

The msys/win32 problems seems to be still unsolved in 2022 when one relies on exported variables, rather than exported exported functions. There, code trying to reach char* libx265.x265_version fails with dll resolve error. I would guess one could fix that either by nudging libx265 to properly export their symbols on msys/win32, or some other way, but this fix I applied seems the cleanest.

Kindly review
Regards,
Dmitry