### PR TITLE
Added extra check to prevent recursion that could result in a stack overflow.

### DIFF
--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -963,7 +963,7 @@ Error HeifContext::get_id_of_non_virtual_child_image(heif_item_id id, heif_item_
 
     // TODO: check whether this really can be recursive (e.g. overlay of grid images)
 
-    if (image_references.empty()) {
+    if (image_references.empty() || image_references[0] == id) {
       return Error(heif_error_Invalid_input,
                    heif_suberror_No_item_data,
                    "Derived image does not reference any other image items");


### PR DESCRIPTION
This PR adds an extra check to prevent a possible stack overflow when the first value of `image_references` is the same as the `id` argument. I did not add an extra error message but if this is required then please let me know what the error message should be.