### PR TITLE
Enable GdkPixbuf loader for mingw as well

### DIFF
--- a/gdk-pixbuf/CMakeLists.txt
+++ b/gdk-pixbuf/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(UNIX)
+if(UNIX OR MINGW)
   find_package(PkgConfig)
   find_package(Threads)
   pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
@@ -15,6 +15,6 @@ if(UNIX)
                                    ${libheif_SOURCE_DIR})
     target_link_libraries(pixbufloader-heif PUBLIC ${GDKPIXBUF2_LIBRARIES} heif)
 
-    install(TARGETS pixbufloader-heif LIBRARY DESTINATION ${GDKPIXBUF2_MODULE_DIR})
+    install(TARGETS pixbufloader-heif DESTINATION ${GDKPIXBUF2_MODULE_DIR})
   endif()
 endif()


### PR DESCRIPTION
Also, a DLL is not a "LIBRARY" type on Windows, let CMake handle this automatically.