### PR TITLE
API to deinitialize encders and decoders plugins

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1617,7 +1617,6 @@ struct heif_error heif_register_decoder_plugin(const heif_decoder_plugin* decode
   return error_Ok;
 }
 
-
 struct heif_error heif_register_encoder_plugin(const heif_encoder_plugin* encoder_plugin)
 {
   if (!encoder_plugin) {
@@ -1631,8 +1630,25 @@ struct heif_error heif_register_encoder_plugin(const heif_encoder_plugin* encode
   return error_Ok;
 }
 
+void heif_unregister_decoder_plugins()
+{
+  for( const auto* plugin : heif::s_decoder_plugins ) {
+    if( plugin->deinit_plugin ) {
+      (*plugin->deinit_plugin)();
+    }
+  }
+  heif::s_decoder_plugins.clear();
+}
 
-
+void heif_unregister_encoder_plugins()
+{
+  for( const auto& plugin : heif::s_encoder_descriptors ) {
+    if( plugin->plugin->cleanup_plugin ) {
+      (*plugin->plugin->cleanup_plugin)();
+    }
+  }
+  heif::s_encoder_descriptors.clear();
+}
 
 /*
 int  heif_image_get_number_of_data_chunks(heif_image* img);

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -1474,7 +1474,11 @@ struct heif_error heif_register_decoder_plugin(const struct heif_decoder_plugin*
 LIBHEIF_API
 struct heif_error heif_register_encoder_plugin(const struct heif_encoder_plugin*);
 
+LIBHEIF_API
+void heif_unregister_encoder_plugins();
 
+LIBHEIF_API
+void heif_unregister_decoder_plugins();
 
 // DEPRECATED, typo in function name
 LIBHEIF_API

--- a/libheif/heif_plugin_registry.cc
+++ b/libheif/heif_plugin_registry.cc
@@ -57,20 +57,8 @@ using namespace heif;
 
 std::set<const struct heif_decoder_plugin*> heif::s_decoder_plugins;
 
-
-struct encoder_descriptor_priority_order
-{
-  bool operator()(const std::unique_ptr<struct heif_encoder_descriptor>& a,
-                  const std::unique_ptr<struct heif_encoder_descriptor>& b) const
-  {
-    return a->plugin->priority > b->plugin->priority;  // highest priority first
-  }
-};
-
-
 std::set<std::unique_ptr<struct heif_encoder_descriptor>,
-         encoder_descriptor_priority_order> s_encoder_descriptors;
-
+         encoder_descriptor_priority_order> heif::s_encoder_descriptors;
 
 static class Register_Default_Plugins
 {

--- a/libheif/heif_plugin_registry.h
+++ b/libheif/heif_plugin_registry.h
@@ -44,10 +44,21 @@ struct heif_encoder_descriptor
   { return plugin->compression_format; }
 };
 
+struct encoder_descriptor_priority_order
+{
+  bool operator()(const std::unique_ptr<struct heif_encoder_descriptor>& a,
+                  const std::unique_ptr<struct heif_encoder_descriptor>& b) const
+  {
+    return a->plugin->priority > b->plugin->priority;  // highest priority first
+  }
+};
+
 
 namespace heif {
-
   extern std::set<const struct heif_decoder_plugin*> s_decoder_plugins;
+
+  extern std::set<std::unique_ptr<struct heif_encoder_descriptor>,
+    encoder_descriptor_priority_order> s_encoder_descriptors;
 
   void register_decoder(const heif_decoder_plugin* decoder_plugin);
 


### PR DESCRIPTION
API to manually deinitialize encoders and decoders plugins and prevent memory leaks