### PR TITLE
configure.ac: fix bashism

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,7 @@ AS_IF([test "x$enable_tests" = "xyes"], [
     HAVE_VISIBILITY=0
     CFLAG_VISIBILITY=
 ])
-AM_CONDITIONAL([HAVE_TESTS], [test "x$HAVE_TESTS" == "x1"])
+AM_CONDITIONAL([HAVE_TESTS], [test "x$HAVE_TESTS" = "x1"])
 
 AM_CONDITIONAL([HAVE_VISIBILITY], [test "x$HAVE_VISIBILITY" != "x0"])
 if eval "test x$enable_visibility = x" ; then enable_visibility=yes ; fi


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors
like this aren't spotted. Notably Debian defaults to /bin/sh provided
by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Fixes errors/warnings like:
```
checking for pthread_create in -lpthread... yes
checking for simple visibility declarations... yes
/var/tmp/portage/media-libs/libheif-1.12.0-r2/work/libheif-1.12.0/configure: 18821: test: x: unexpected operator
checking pkg-config is at least version 0.9.0... yes
checking for aom... yes
```

Signed-off-by: Sam James <sam@gentoo.org>