### PR TITLE
Handle infe items of type "uri "

### DIFF
--- a/libheif/box.h
+++ b/libheif/box.h
@@ -463,8 +463,14 @@ namespace heif {
     const std::string& get_item_type() const
     { return m_item_type; }
 
+    const std::string& get_item_uri_type() const
+    { return m_item_uri_type; }
+
     void set_item_type(const std::string& type)
     { m_item_type = type; }
+
+    void set_item_uri_type(const std::string& uri_type)
+    { m_item_uri_type = uri_type; }
 
     void set_item_name(const std::string& name)
     { m_item_name = name; }

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1274,6 +1274,18 @@ const char* heif_image_handle_get_metadata_content_type(const struct heif_image_
   return nullptr;
 }
 
+const char* heif_image_handle_get_metadata_uri_type(const struct heif_image_handle* handle,
+                                           heif_item_id metadata_id) 
+{
+  for (auto& metadata : handle->image->get_metadata()) {
+    if (metadata->item_id == metadata_id) {
+      std::cout << metadata->item_uri_type.c_str() << std::endl;
+      return metadata->item_uri_type.c_str();
+    }
+  }
+
+  return nullptr;
+}
 
 size_t heif_image_handle_get_metadata_size(const struct heif_image_handle* handle,
                                            heif_item_id metadata_id)
@@ -2457,6 +2469,19 @@ struct heif_error heif_context_add_XMP_metadata(struct heif_context* ctx,
   }
 }
 
+struct heif_error heif_context_add_uri_metadata(struct heif_context* ctx,
+                                                const struct heif_image_handle* image_handle,
+                                                const void* data, int size,
+                                                const char* item_uri_type) 
+{
+  Error error = ctx->context->add_uri_metadata(image_handle->image, data, size, item_uri_type);
+  if (error != Error::Ok) {
+    return error.error_struct(ctx->context.get());
+  }
+  else {
+    return error_Ok;
+  }
+}
 
 struct heif_error heif_context_add_generic_metadata(struct heif_context* ctx,
                                                     const struct heif_image_handle* image_handle,

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -693,7 +693,7 @@ struct heif_error heif_image_handle_get_auxiliary_image_handle(const struct heif
                                                                struct heif_image_handle** out_auxiliary_handle);
 
 
-// ------------------------- metadata (Exif / XMP) -------------------------
+// ------------------------- metadata (Exif / XMP / URI) -------------------------
 
 // How many metadata blocks are attached to an image. Usually, the only metadata is
 // an "Exif" block.
@@ -719,6 +719,13 @@ const char* heif_image_handle_get_metadata_type(const struct heif_image_handle* 
 LIBHEIF_API
 const char* heif_image_handle_get_metadata_content_type(const struct heif_image_handle* handle,
                                                         heif_item_id metadata_id);
+
+// infe items of type "uri " contain customized metadata
+// The uri_type is a 16-byte key that indicates how to parse the raw out_data
+// A list of some registered uri keys can be found here: https://registry.smpte-ra.org/view/published/groups_view.html
+LIBHEIF_API
+const char* heif_image_handle_get_metadata_uri_type(const struct heif_image_handle* handle,
+                                           heif_item_id metadata_id);
 
 // Get the size of the raw metadata, as stored in the HEIF file.
 LIBHEIF_API
@@ -1441,6 +1448,13 @@ LIBHEIF_API
 struct heif_error heif_context_add_XMP_metadata(struct heif_context*,
                                                 const struct heif_image_handle* image_handle,
                                                 const void* data, int size);
+
+// Add URI metadata to an image.
+LIBHEIF_API
+struct heif_error heif_context_add_uri_metadata(struct heif_context*,
+                                                const struct heif_image_handle* image_handle,
+                                                const void* data, int size,
+                                                const char* item_uri_type);
 
 // Add generic, proprietary metadata to an image. You have to specify an 'item_type' that will
 // identify your metadata. 'content_type' can be an additional type, or it can be NULL.

--- a/libheif/heif_context.h
+++ b/libheif/heif_context.h
@@ -55,6 +55,7 @@ namespace heif {
   public:
     heif_item_id item_id;
     std::string item_type;  // e.g. "Exif"
+    std::string item_uri_type; //16-byte key indicating how to parse the data when item_type is "uri "
     std::string content_type;
     std::vector<uint8_t> m_data;
   };
@@ -387,6 +388,8 @@ namespace heif {
     Error add_exif_metadata(const std::shared_ptr<Image>& master_image, const void* data, int size);
 
     Error add_XMP_metadata(const std::shared_ptr<Image>& master_image, const void* data, int size);
+
+    Error add_uri_metadata(const std::shared_ptr<Image>& master_image, const void* data, int size, const char* item_uri_type);
 
     Error add_generic_metadata(const std::shared_ptr<Image>& master_image, const void* data, int size,
                                const char* item_type, const char* content_type);

--- a/libheif/heif_file.cc
+++ b/libheif/heif_file.cc
@@ -356,6 +356,16 @@ std::string HeifFile::get_item_type(heif_item_id ID) const
 }
 
 
+std::string HeifFile::get_item_uri_type(heif_item_id ID) const 
+{
+  auto infe_box = get_infe(ID);
+  if (!infe_box) {
+    return "";
+  }
+
+  return infe_box->get_item_uri_type();
+}
+
 std::string HeifFile::get_content_type(heif_item_id ID) const
 {
   auto infe_box = get_infe(ID);

--- a/libheif/heif_file.h
+++ b/libheif/heif_file.h
@@ -76,6 +76,8 @@ namespace heif {
 
     std::string get_item_type(heif_item_id ID) const;
 
+    std::string get_item_uri_type(heif_item_id ID) const;
+
     std::string get_content_type(heif_item_id ID) const;
 
     Error get_compressed_image_data(heif_item_id ID, std::vector<uint8_t>* out_data) const;


### PR DESCRIPTION
infe items of type "uri " contain customized metadata
The uri_type is a 16-byte key that indicates how to parse the raw out_data
A list of some registered uri keys can be found here: https://registry.smpte-ra.org/view/published/groups_view.html

Added API Functions:
  1. heif_context_add_uri_metadata()
  2. heif_image_handle_get_metadata_uri_type()
