### PR TITLE
Fix a comment error: aom_image_t => Dav1dPicture

### DIFF
--- a/libheif/heif_decoder_dav1d.cc
+++ b/libheif/heif_decoder_dav1d.cc
@@ -243,7 +243,7 @@ struct heif_error dav1d_decode_image(void* decoder_raw, struct heif_image** out_
 
 
 
-  // --- transfer data from aom_image_t to HeifPixelImage
+  // --- transfer data from Dav1dPicture to HeifPixelImage
 
   heif_channel channel2plane[3] = {
       heif_channel_Y,


### PR DESCRIPTION
This is a copy-and-paste error (copied from heif_decoder_aom.cc).