### PR TITLE
Some C++ cleanup

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -95,12 +95,9 @@ void encoder_struct_aom::add_custom_option(const custom_option& p)
 {
   // if there is already a parameter of that name, remove it from list
 
-  for (size_t i = 0; i < custom_options.size(); i++) {
-    if (custom_options[i].name == p.name) {
-      for (size_t k = i + 1; k < custom_options.size(); k++) {
-        custom_options[k - 1] = custom_options[k];
-      }
-      custom_options.pop_back();
+  for (auto iter = custom_options.begin(); iter != custom_options.end(); ++iter) {
+    if (iter->name == p.name) {
+      custom_options.erase(iter);
       break;
     }
   }

--- a/libheif/heif_init.cc
+++ b/libheif/heif_init.cc
@@ -87,8 +87,8 @@ void heif_unregister_encoder_plugin(const heif_encoder_plugin* plugin)
     (*plugin->cleanup_plugin)();
   }
 
-  for (auto iter = heif::s_encoder_descriptors.begin() ; iter != heif::s_encoder_descriptors.end(); iter++) {
-    if (iter->get()->plugin == plugin) {
+  for (auto iter = heif::s_encoder_descriptors.begin() ; iter != heif::s_encoder_descriptors.end(); ++iter) {
+    if ((*iter)->plugin == plugin) {
       heif::s_encoder_descriptors.erase(iter);
       return;
     }


### PR DESCRIPTION
heif_encoder_aom.cc: In encoder_struct_aom::add_custom_option(), use the erase() method to remove an element from a std::vector.

heif_init.cc: In heif_unregister_encoder_plugin(), pre-increment the iterator, which does slightly less work than the post-increment operator (although compiler optimization is likely to take care of this for us). Also the get() method of std::unique_ptr can be avoided.