### PR TITLE
heif_encoder_aom: change defaults of speed, min-q

### DIFF
--- a/libheif/plugins/heif_encoder_aom.cc
+++ b/libheif/plugins/heif_encoder_aom.cc
@@ -187,11 +187,10 @@ static void aom_init_parameters()
   p->version = 2;
   p->name = kParam_speed;
   p->type = heif_encoder_parameter_type_integer;
-  p->integer.default_value = 5;
+  p->integer.default_value = 6;
   p->has_default = true;
   p->integer.have_minimum_maximum = true;
   p->integer.minimum = 0;
-
   if (aom_codec_version_major() >= 3) {
     p->integer.maximum = 9;
   }
@@ -258,11 +257,11 @@ static void aom_init_parameters()
   p->version = 2;
   p->name = kParam_min_q;
   p->type = heif_encoder_parameter_type_integer;
-  p->integer.default_value = 1;
+  p->integer.default_value = 0;
   p->has_default = true;
   p->integer.have_minimum_maximum = true;
-  p->integer.minimum = 1;
-  p->integer.maximum = 62;
+  p->integer.minimum = 0;
+  p->integer.maximum = 63;
   p->integer.valid_values = NULL;
   p->integer.num_valid_values = 0;
   d[i++] = p++;
@@ -298,8 +297,8 @@ static void aom_init_parameters()
   p->type = heif_encoder_parameter_type_integer;
   p->has_default = false;
   p->integer.have_minimum_maximum = true;
-  p->integer.minimum = 1;
-  p->integer.maximum = 62;
+  p->integer.minimum = 0;
+  p->integer.maximum = 63;
   p->integer.valid_values = NULL;
   p->integer.num_valid_values = 0;
   d[i++] = p++;
@@ -324,6 +323,7 @@ static void aom_init_parameters()
   p->has_default = true;
   d[i++] = p++;
 
+  assert(i < MAX_NPARAMETERS + 1);
   d[i++] = nullptr;
 }
 


### PR DESCRIPTION
Change the default of the "speed" parameter from 5 to 6.

Change the default of the "min-q" parameter from 1 to 0 (the default of cfg.rc_min_quantizer in libaom). Also change the range of the "min-q" and "alpha-min-q" parameters from 1..62 to 0..63.

Assert that i is valid for the final "d[i++] = nullptr;" statement.