### PR TITLE
heif_decoder_*.cc: use a num_planes variable

### DIFF
--- a/libheif/plugins/heif_decoder_aom.cc
+++ b/libheif/plugins/heif_decoder_aom.cc
@@ -239,11 +239,9 @@ struct heif_error aom_decode_image(void* decoder_raw, struct heif_image** out_im
   };
 
 
-  for (int c = 0; c < 3; c++) {
-    if (chroma == heif_chroma_monochrome && c > 0) {
-      break;
-    }
+  int num_planes = (chroma == heif_chroma_monochrome ? 1 : 3);
 
+  for (int c = 0; c < num_planes; c++) {
     int bpp = img->bit_depth;
 
     const uint8_t* data = img->planes[c];

--- a/libheif/plugins/heif_decoder_dav1d.cc
+++ b/libheif/plugins/heif_decoder_dav1d.cc
@@ -255,11 +255,9 @@ struct heif_error dav1d_decode_image(void* decoder_raw, struct heif_image** out_
 
   // --- copy image data
 
-  for (int c = 0; c < 3; c++) {
-    if (chroma == heif_chroma_monochrome && c > 0) {
-      break;
-    }
+  int num_planes = (chroma == heif_chroma_monochrome ? 1 : 3);
 
+  for (int c = 0; c < num_planes; c++) {
     int bpp = frame.p.bpc;
 
     const uint8_t* data = (uint8_t*) frame.data[c];

--- a/libheif/plugins/heif_decoder_libde265.cc
+++ b/libheif/plugins/heif_decoder_libde265.cc
@@ -113,9 +113,9 @@ static struct heif_error convert_libde265_image_to_heif_image(struct libde265_de
 
   int bpp = de265_get_bits_per_pixel(de265img, 0);
 
-  int nPlanes = (is_mono ? 1 : 3);
+  int num_planes = (is_mono ? 1 : 3);
 
-  for (int c = 0; c < nPlanes; c++) {
+  for (int c = 0; c < num_planes; c++) {
     if (de265_get_bits_per_pixel(de265img, c) != bpp) {
       struct heif_error err = {heif_error_Unsupported_feature,
                                heif_suberror_Unsupported_color_conversion,


### PR DESCRIPTION
Use a num_planes variable (1 for monochrome, 3 otherwise) to control the number of iterations of a for loop.