### PR TITLE
Change AOM_USAGE_GOOD_QUALITY back to 0

### DIFF
--- a/libheif/plugins/heif_encoder_aom.cc
+++ b/libheif/plugins/heif_encoder_aom.cc
@@ -838,7 +838,7 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
   }
 
 
-  unsigned int aomUsage = AOM_USAGE_GOOD_QUALITY;
+  unsigned int aomUsage = 0;
 #if defined(AOM_USAGE_ALL_INTRA)
   // aom 3.1.0
   aomUsage = (encoder->realtime_mode ? AOM_USAGE_REALTIME : AOM_USAGE_ALL_INTRA);


### PR DESCRIPTION
Undo a cosmetic change in
https://github.com/strukturag/libheif/pull/691.

The AOM_USAGE_GOOD_QUALITY macro was not defined in libaom v1.0.0-errata1. heif_encoder_aom.cc apparently tries to support libaom releases older than v2.0.0, so change AOM_USAGE_GOOD_QUALITY back to 0.