### PR TITLE
Change "constant QP" to "constant rate factor"

### DIFF
--- a/libheif/plugins/heif_encoder_svt.cc
+++ b/libheif/plugins/heif_encoder_svt.cc
@@ -624,7 +624,7 @@ struct heif_error svt_encode_image(void* encoder_raw, const struct heif_image* i
   // disable 2-pass
   svt_config.rc_stats_buffer = (SvtAv1FixedBuf) {nullptr, 0};
 
-  svt_config.rate_control_mode = 0; // constant QP
+  svt_config.rate_control_mode = 0; // constant rate factor
   svt_config.qp = encoder->qp;
 
   svt_config.tile_rows = int_log2(encoder->tile_rows);


### PR DESCRIPTION
If rate_control_mode is set to 0 (the default), the rate control mode depends on the value of enable_adaptive_quantization. If enable_adaptive_quantization is 2 (the default), the rate control mode is constant rate factor (CRF). If enable_adaptive_quantization is 0, the rate control mode is constant QP. Since we don't set enable_adaptive_quantization, the rate control mode is CRF.