### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ There is also an experimental Go API, but this is not stable yet.
 
 This library uses either a standard autoconf/automake build system or CMake.
 
-Using autoconf/automake for compilation is deprectated.
+Using autoconf/automake for compilation is deprecated.
 Starting with v1.14.0, CMake is the preferred build tool.
 While autoconf/automake might still work for some time to come, not all options are available for it.
 

--- a/cmake/modules/LibFindMacros.cmake
+++ b/cmake/modules/LibFindMacros.cmake
@@ -1,7 +1,7 @@
 # Version 2.3
 # Public Domain, originally written by Lasse Kärkkäinen <tronic>
 # Maintained at https://github.com/Tronic/cmake-modules
-# Please send your improvements as pull requests on Github.
+# Please send your improvements as pull requests on GitHub.
 
 # Find another package and make it a dependency of the current package.
 # This also automatically forwards the "REQUIRED" argument.

--- a/examples/heif_convert.cc
+++ b/examples/heif_convert.cc
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
         break;
       case '?':
         std::cerr << "\n";
-        // falltrough
+        // fallthrough
       case 'h':
         show_help(argv[0]);
         return 0;

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -1422,7 +1422,7 @@ int main(int argc, char** argv)
     //heif_image_set_nclx_color_profile(image.get(), &nclx);
 
     if (lossless) {
-      if (heif_encoder_descriptor_supportes_lossless_compression(active_encoder_descriptor)) {
+      if (heif_encoder_descriptor_supports_lossless_compression(active_encoder_descriptor)) {
         heif_encoder_set_lossless(encoder, lossless);
       }
       else {

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1769,14 +1769,14 @@ int heif_encoder_descriptor_supports_lossless_compression(const struct heif_enco
 }
 
 
-// DEPRECATED: typo in functino name
+// DEPRECATED: typo in function name
 int heif_encoder_descriptor_supportes_lossy_compression(const struct heif_encoder_descriptor* descriptor)
 {
   return descriptor->plugin->supports_lossy_compression;
 }
 
 
-// DEPRECATED: typo in functino name
+// DEPRECATED: typo in function name
 int heif_encoder_descriptor_supportes_lossless_compression(const struct heif_encoder_descriptor* descriptor)
 {
   return descriptor->plugin->supports_lossless_compression;

--- a/libheif/heif_cxx.h
+++ b/libheif/heif_cxx.h
@@ -383,14 +383,19 @@ namespace heif {
 
     enum heif_compression_format get_compression_format() const noexcept;
 
+    // DEPRECATED: typo in function name
     bool supportes_lossy_compression() const noexcept;
 
+    // DEPRECATED: typo in function name
     bool supportes_lossless_compression() const noexcept;
 
 
     // throws Error
     Encoder get_encoder() const;
 
+    bool supports_lossy_compression() const noexcept;
+
+    bool supports_lossless_compression() const noexcept;
 
   private:
     EncoderDescriptor(const struct heif_encoder_descriptor* descr) : m_descriptor(descr)
@@ -1031,12 +1036,22 @@ namespace heif {
 
   inline bool EncoderDescriptor::supportes_lossy_compression() const noexcept
   {
-    return heif_encoder_descriptor_supportes_lossy_compression(m_descriptor);
+    return heif_encoder_descriptor_supports_lossy_compression(m_descriptor);
+  }
+
+  inline bool EncoderDescriptor::supports_lossy_compression() const noexcept
+  {
+    return heif_encoder_descriptor_supports_lossy_compression(m_descriptor);
   }
 
   inline bool EncoderDescriptor::supportes_lossless_compression() const noexcept
   {
-    return heif_encoder_descriptor_supportes_lossless_compression(m_descriptor);
+    return heif_encoder_descriptor_supports_lossless_compression(m_descriptor);
+  }
+
+  inline bool EncoderDescriptor::supports_lossless_compression() const noexcept
+  {
+    return heif_encoder_descriptor_supports_lossless_compression(m_descriptor);
   }
 
   inline Encoder EncoderDescriptor::get_encoder() const

--- a/libheif/heif_cxx.h
+++ b/libheif/heif_cxx.h
@@ -284,7 +284,7 @@ namespace heif {
 
     bool is_full_range() const;
 
-    void set_color_primaties(heif_color_primaries cp);
+    void set_color_primaries(heif_color_primaries cp);
 
     void set_transfer_characteristics(heif_transfer_characteristics tc);
 
@@ -806,7 +806,7 @@ namespace heif {
   inline bool ColorProfile_nclx::is_full_range() const
   { return mProfile->full_range_flag; }
 
-  inline void ColorProfile_nclx::set_color_primaties(heif_color_primaries cp)
+  inline void ColorProfile_nclx::set_color_primaries(heif_color_primaries cp)
   { mProfile->color_primaries = cp; }
 
   inline void ColorProfile_nclx::set_transfer_characteristics(heif_transfer_characteristics tc)

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -3237,7 +3237,7 @@ def CheckOperatorSpacing(filename, clean_lines, linenum, error):
   elif not Match(r'#.*include', line):
     # Look for < that is not surrounded by spaces.  This is only
     # triggered if both sides are missing spaces, even though
-    # technically should should flag if at least one side is missing a
+    # technically it should flag if at least one side is missing a
     # space.  This is done to avoid some false positives with shifts.
     match = Match(r'^(.*[^\s<])<[^\s=<,]', line)
     if match:

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -577,7 +577,7 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
                 'Unknown NOLINT error category: %s' % category)
 
 
-def ProcessGlobalSuppresions(lines):
+def ProcessGlobalSuppressions(lines):
   """Updates the list of global error suppressions.
 
   Parses any lint directives in the file that have global effect.
@@ -605,7 +605,7 @@ def IsErrorSuppressedByNolint(category, linenum):
   """Returns true if the specified error category is suppressed on this line.
 
   Consults the global error_suppressions map populated by
-  ParseNolintSuppressions/ProcessGlobalSuppresions/ResetNolintSuppressions.
+  ParseNolintSuppressions/ProcessGlobalSuppressions/ResetNolintSuppressions.
 
   Args:
     category: str, the category of the error.
@@ -5784,7 +5784,7 @@ def ProcessFileData(filename, file_extension, lines, error,
   ResetNolintSuppressions()
 
   CheckForCopyright(filename, lines, error)
-  ProcessGlobalSuppresions(lines)
+  ProcessGlobalSuppressions(lines)
   RemoveMultiLineComments(filename, lines, error)
   clean_lines = CleansedLines(lines)
 

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -7779,7 +7779,7 @@ namespace Catch {
                 result = -erfc_inv(2.0 * p);
                 // result *= normal distribution standard deviation (1.0) * sqrt(2)
                 result *= /*sd * */ ROOT_TWO;
-                // result += normal disttribution mean (0)
+                // result += normal distribution mean (0)
                 return result;
             }
 

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -11313,7 +11313,7 @@ namespace Catch {
     std::string TagInfo::all() const {
         size_t size = 0;
         for (auto const& spelling : spellings) {
-            // Add 2 for the brackes
+            // Add 2 for the brackets
             size += spelling.size() + 2;
         }
 

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -7447,7 +7447,7 @@ namespace Catch {
         using storage_for = Detail::ObjectStorage<T, true>;
 
         template <typename T>
-        using destructable_object = Detail::ObjectStorage<T, false>;
+        using destructible_object = Detail::ObjectStorage<T, false>;
     }
 }
 


### PR DESCRIPTION
I'm following up on a PR I sent to a downstream consumer (and then accidentally to the wrong fork of libheif...).

A few notable bits:

commit | notes |
-|-
9238834373c07c162668c0a7d3962483083c34c2 | `heif_encoder_descriptor_supportes_lossless_compression` is deprecated, but it still appears to be used internally. I've included changes to update the internal uses.
d9dedde4d860cb13c233001826a4a7fc4230b154 | I didn't include deprecation bits here. I did for `supports` to show that I could. I'm not quite sure what the preferences are for this repository, so I'm using this pair as a point for discussion.

---

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/libheif/commit/65da0de0791f07ce9a7472ff7d150feb70a96b87#commitcomment-90537659

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/libheif/commit/8772000ff91d4c39a3d4111e49964352d20900da

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.