### PR TITLE
CMake: Fix build on macOS (with Homebrew packages)

### DIFF
--- a/gdk-pixbuf/CMakeLists.txt
+++ b/gdk-pixbuf/CMakeLists.txt
@@ -13,6 +13,11 @@ if(UNIX)
                                    ${GDKPIXBUF2_INCLUDE_DIRS}
                                    ${libheif_BINARY_DIR}
                                    ${libheif_SOURCE_DIR})
+
+    target_link_directories(pixbufloader-heif
+                            PRIVATE
+                                ${GDKPIXBUF2_LIBRARY_DIRS})
+
     target_link_libraries(pixbufloader-heif PUBLIC ${GDKPIXBUF2_LIBRARIES} heif)
 
     install(TARGETS pixbufloader-heif LIBRARY DESTINATION ${GDKPIXBUF2_MODULE_DIR})


### PR DESCRIPTION
Add L dirs of gdk-pixbuf-2.0 and its dependencies, so the shared libraries are found:
```
$ make
[..]
[ 46%] Built target heif
[ 65%] Built target heif-convert
[ 69%] Built target heif-info
[ 79%] Built target heif-enc
[ 83%] Built target heif-test
[ 95%] Built target heif-thumbnailer
[ 97%] Linking C shared module libpixbufloader-heif.so
ld: library not found for -lgdk_pixbuf-2.0
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [gdk-pixbuf/libpixbufloader-heif.so] Error 1
make[1]: *** [gdk-pixbuf/CMakeFiles/pixbufloader-heif.dir/all] Error 2
make: *** [all] Error 2
```

**`pkg-config` output:**
```
$ pkg-config --libs-only-L gdk-pixbuf-2.0
-L/opt/homebrew/Cellar/gdk-pixbuf/2.42.10/lib -L/opt/homebrew/Cellar/glib/2.74.0/lib -L/opt/homebrew/opt/gettext/lib
```