### PR TITLE
cmake-format gdk-pixbuf folder

### DIFF
--- a/gdk-pixbuf/CMakeLists.txt
+++ b/gdk-pixbuf/CMakeLists.txt
@@ -4,19 +4,16 @@ if(UNIX)
   pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
 
   if(GDKPIXBUF2_FOUND)
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} gdk-pixbuf-2.0 --variable gdk_pixbuf_moduledir --define-variable=prefix=${CMAKE_INSTALL_PREFIX} OUTPUT_VARIABLE GDKPIXBUF2_MODULE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+      COMMAND ${PKG_CONFIG_EXECUTABLE} gdk-pixbuf-2.0 --variable gdk_pixbuf_moduledir
+              --define-variable=prefix=${CMAKE_INSTALL_PREFIX} OUTPUT_VARIABLE GDKPIXBUF2_MODULE_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     add_library(pixbufloader-heif MODULE pixbufloader-heif.c)
 
-    target_include_directories(pixbufloader-heif
-                               PRIVATE
-                                   ${GDKPIXBUF2_INCLUDE_DIRS}
-                                   ${libheif_BINARY_DIR}
-                                   ${libheif_SOURCE_DIR})
+    target_include_directories(pixbufloader-heif PRIVATE ${GDKPIXBUF2_INCLUDE_DIRS} ${libheif_BINARY_DIR} ${libheif_SOURCE_DIR})
 
-    target_link_directories(pixbufloader-heif
-                            PRIVATE
-                                ${GDKPIXBUF2_LIBRARY_DIRS})
+    target_link_directories(pixbufloader-heif PRIVATE ${GDKPIXBUF2_LIBRARY_DIRS})
 
     target_link_libraries(pixbufloader-heif PUBLIC ${GDKPIXBUF2_LIBRARIES} heif)
 


### PR DESCRIPTION
@dloebl Used

```
cmake-format -i --line-width=130 --max-subgroups-hwrap 3 --max-pargs-hwrap 10 gdk-pixbuf/CMakeLists.txt
```

@farindk Please also include w/ https://github.com/strukturag/libheif/pull/647