### PR TITLE
AV1: Stop encoding if plugin returns an error

### DIFF
--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -2369,7 +2369,12 @@ Error HeifContext::encode_image_as_av1(const std::shared_ptr<HeifPixelImage>& im
   heif_image c_api_image;
   c_api_image.image = src_image;
 
-  encoder->plugin->encode_image(encoder->encoder, &c_api_image, input_class);
+  struct heif_error err = encoder->plugin->encode_image(encoder->encoder, &c_api_image, input_class);
+  if (err.code) {
+    return Error(err.code,
+                 err.subcode,
+                 err.message);
+  }
 
   for (;;) {
     uint8_t* data;


### PR DESCRIPTION
Encountered when asking svt-av1 to encode YUV444.

Similar code already exists for the equivalent HEVC code.