### PR TITLE
Ensure incoming NCLX enum values are cast to integer before validation

### DIFF
--- a/libheif/plugins/heif_decoder_aom.cc
+++ b/libheif/plugins/heif_decoder_aom.cc
@@ -223,9 +223,9 @@ struct heif_error aom_decode_image(void* decoder_raw, struct heif_image** out_im
 
   heif_color_profile_nclx nclx;
   nclx.version = 1;
-  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_color_primaries(&nclx, img->cp), { heif_image_release(heif_img); });
-  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_transfer_characteristics(&nclx, img->tc), { heif_image_release(heif_img); });
-  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_matrix_coefficients(&nclx, img->mc), { heif_image_release(heif_img); });
+  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_color_primaries(&nclx, static_cast<uint16_t>(img->cp)), { heif_image_release(heif_img); });
+  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_transfer_characteristics(&nclx, static_cast<uint16_t>(img->tc)), { heif_image_release(heif_img); });
+  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_matrix_coefficients(&nclx, static_cast<uint16_t>(img->mc)), { heif_image_release(heif_img); });
   nclx.full_range_flag = (img->range == AOM_CR_FULL_RANGE);
   heif_image_set_nclx_color_profile(heif_img, &nclx);
 

--- a/libheif/plugins/heif_decoder_dav1d.cc
+++ b/libheif/plugins/heif_decoder_dav1d.cc
@@ -236,9 +236,9 @@ struct heif_error dav1d_decode_image(void* decoder_raw, struct heif_image** out_
   // --- read nclx parameters from decoded AV1 bitstream
 
   heif_color_profile_nclx nclx;
-  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_color_primaries(&nclx, frame.seq_hdr->pri), {});
-  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_transfer_characteristics(&nclx, frame.seq_hdr->trc), {});
-  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_matrix_coefficients(&nclx, frame.seq_hdr->mtrx), {});
+  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_color_primaries(&nclx, static_cast<uint16_t>(frame.seq_hdr->pri)), {});
+  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_transfer_characteristics(&nclx, static_cast<uint16_t>(frame.seq_hdr->trc)), {});
+  HEIF_WARN_OR_FAIL(decoder->strict_decoding, heif_img, heif_nclx_color_profile_set_matrix_coefficients(&nclx, static_cast<uint16_t>(frame.seq_hdr->mtrx)), {});
   nclx.full_range_flag = (frame.seq_hdr->color_range != 0);
   heif_image_set_nclx_color_profile(heif_img, &nclx);
 

--- a/libheif/plugins/heif_decoder_libde265.cc
+++ b/libheif/plugins/heif_decoder_libde265.cc
@@ -342,9 +342,9 @@ static struct heif_error libde265_v1_decode_image(void* decoder_raw,
 
       struct heif_color_profile_nclx* nclx = heif_nclx_color_profile_alloc();
 #if LIBDE265_NUMERIC_VERSION >= 0x01000700
-      HEIF_WARN_OR_FAIL(decoder->strict_decoding, *out_img, heif_nclx_color_profile_set_color_primaries(nclx, (uint16_t)de265_get_image_colour_primaries(image)), { heif_nclx_color_profile_free(nclx);});
-      HEIF_WARN_OR_FAIL(decoder->strict_decoding, *out_img, heif_nclx_color_profile_set_transfer_characteristics(nclx, (uint16_t)de265_get_image_transfer_characteristics(image)), { heif_nclx_color_profile_free(nclx);});
-      HEIF_WARN_OR_FAIL(decoder->strict_decoding, *out_img, heif_nclx_color_profile_set_matrix_coefficients(nclx, (uint16_t)de265_get_image_matrix_coefficients(image)), { heif_nclx_color_profile_free(nclx);});
+      HEIF_WARN_OR_FAIL(decoder->strict_decoding, *out_img, heif_nclx_color_profile_set_color_primaries(nclx, static_cast<uint16_t>(de265_get_image_colour_primaries(image))), { heif_nclx_color_profile_free(nclx);});
+      HEIF_WARN_OR_FAIL(decoder->strict_decoding, *out_img, heif_nclx_color_profile_set_transfer_characteristics(nclx, static_cast<uint16_t>(de265_get_image_transfer_characteristics(image))), { heif_nclx_color_profile_free(nclx);});
+      HEIF_WARN_OR_FAIL(decoder->strict_decoding, *out_img, heif_nclx_color_profile_set_matrix_coefficients(nclx, static_cast<uint16_t>(de265_get_image_matrix_coefficients(image))), { heif_nclx_color_profile_free(nclx);});
       nclx->full_range_flag = (bool)de265_get_image_full_range_flag(image);
 #endif
       heif_image_set_nclx_color_profile(*out_img, nclx);


### PR DESCRIPTION
This is a follow-up to #718 as the undefined behaviour was still being reported for some (fuzzer-found) inputs. I tracked this down to the use of a cast in the de265 decoder that is missing from the aom and dav1d decoders.

This change ensures all the decoders are consistent in their behaviour, using a `static_cast` for compile-time safety.
```
decoder enum value => uint16 => validate => libheif enum value
```