### PR TITLE
CI: Pin Ubuntu Linux to 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           - { NAME: "libde265 (1) / x265 / dav1d / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_DAV1D: 1, WITH_LIBDE265: 1 }
           - { NAME: "libde265 (1) / x265 / aom / rav1e / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_RAV1E: 1, WITH_LIBDE265: 1 }
     env: ${{ matrix.env }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,7 +2,7 @@ name: CIFuzz
 on: [pull_request]
 jobs:
   Fuzzing:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Build Fuzzers
       id: build

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -15,7 +15,7 @@ jobs:
           - { NAME: "libde265 (1) / x265 / aom / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_LIBDE265: 1 }
           - { NAME: "libde265 (2) / x265 / aom / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_LIBDE265: 2 }
     env: ${{ matrix.env }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
       WITH_AOM: 1

--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   get_data:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -10,7 +10,7 @@ jobs:
   emscripten:
     env:
       EMSCRIPTEN_VERSION: 1.37.26
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       WITH_X265: 1
       WITH_GRAPHICS: 1
       GO: 1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   cpplint:
     env:
       CPPLINT: 1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 
@@ -29,7 +29,7 @@ jobs:
   licenses:
     env:
       CHECK_LICENSES: 1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     env:
       TESTS: 1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
GitHub Actions is starting to default to 22.04, which doesn't currently have the relevant PPAs etc.

https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/