### PR TITLE
Fix examples building with pkg-config being present on llvm-mingw

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,19 +15,15 @@ set (additional_link_directories)
 set (additional_libraries)
 set (additional_includes)
 
-include (${CMAKE_ROOT}/Modules/FindJPEG.cmake)
+find_package(JPEG)
+find_package(PNG)
 
 if(JPEG_FOUND)
 add_definitions(-DHAVE_LIBJPEG=1)
-include_directories(SYSTEM ${JPEG_INCLUDE_DIR})
 
-include (${CMAKE_ROOT}/Modules/CheckCXXSourceCompiles.cmake)
+include (CheckCXXSourceCompiles)
 
-set(CMAKE_REQUIRED_LIBRARIES ${JPEG_LIBRARIES})
-
-# while the docs say JPEG_INCLUDE_DIRS, my FindJPEG.cmake script returns it in JPEG_INCLUDE_DIR
-set(CMAKE_REQUIRED_INCLUDES ${JPEG_INCLUDE_DIRS} ${JPEG_INCLUDE_DIR})
-
+set(CMAKE_REQUIRED_LIBRARIES JPEG::JPEG)
 check_cxx_source_compiles("
 #include <stddef.h>
 #include <stdio.h>
@@ -38,6 +34,7 @@ int main() {
   return 0;
 }
 " HAVE_JPEG_WRITE_ICC_PROFILE)
+unset(CMAKE_REQUIRED_LIBRARIES)
 if(HAVE_JPEG_WRITE_ICC_PROFILE)
   add_definitions(-DHAVE_JPEG_WRITE_ICC_PROFILE=1)
 endif()
@@ -49,38 +46,21 @@ set (heif_convert_sources
 )
 set (additional_libraries
   ${additional_libraries}
-  ${JPEG_LIBRARIES}
-)
-set (additional_includes
-  ${additional_includes}
-  ${JPEG_INCLUDE_DIRS}
-  ${JPEG_INCLUDE_DIR}
+  JPEG::JPEG
 )
 endif()
 
-if(UNIX OR MINGW)
-  include (${CMAKE_ROOT}/Modules/FindPkgConfig.cmake)
-  pkg_check_modules (LIBPNG libpng)
-  if(LIBPNG_FOUND)
-    add_definitions(-DHAVE_LIBPNG=1)
-    set (heif_convert_sources
+if(PNG_FOUND)
+  add_definitions(-DHAVE_LIBPNG=1)
+  set (heif_convert_sources
       ${heif_convert_sources}
       encoder_png.cc
       encoder_png.h
             benchmark.h benchmark.cc)
-    set (additional_link_directories
-      ${additional_link_directories}
-      ${LIBPNG_LIBRARY_DIRS}
-    )
-    set (additional_libraries
-      ${additional_libraries}
-      ${LIBPNG_LINK_LIBRARIES} ${LIBPNG_LIBRARIES}
-    )
-    set (additional_includes
-      ${additional_includes}
-      ${LIBPNG_INCLUDE_DIRS}
-    )
-  endif()
+  set (additional_libraries
+    ${additional_libraries}
+    PNG::PNG
+  )
 endif()
 
 set (heif_info_sources
@@ -131,7 +111,7 @@ add_executable (heif-test ${heif_test_sources} ${getopt_sources})
 target_link_libraries (heif-test heif)
 
 
-if(LIBPNG_FOUND)
+if(PNG_FOUND)
   set (heif_thumbnailer_sources
     encoder.cc
     encoder.h
@@ -143,9 +123,7 @@ if(LIBPNG_FOUND)
     )
 
   add_executable (heif-thumbnailer ${heif_thumbnailer_sources})
-  target_link_directories (heif-thumbnailer PRIVATE ${LIBPNG_LIBRARY_DIRS})
-  target_link_libraries (heif-thumbnailer heif ${LIBPNG_LINK_LIBRARIES} ${LIBPNG_LIBRARIES})
-  target_include_directories(heif-thumbnailer PRIVATE ${LIBPNG_INCLUDE_DIRS})
+  target_link_libraries (heif-thumbnailer heif PNG::PNG)
   install(TARGETS heif-thumbnailer RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   install(FILES heif-thumbnailer.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 endif()


### PR DESCRIPTION
By using CMake's official Find Modules and sidestepping pkg-config altogether, we're able to use imported targets without further complexity.