### PR TITLE
Fix resolution reporting for odd-sized images with a `clap` box

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -2462,18 +2462,18 @@ int Box_clap::bottom_rounded(int image_height) const
   return bottom.round();
 }
 
-int Box_clap::get_width_rounded() const
+int Box_clap::get_width_rounded(int image_width) const
 {
-  int left = (Fraction(0, 1) - (m_clean_aperture_width - 1) / 2).round();
-  int right = ((m_clean_aperture_width - 1) / 2).round();
+  int left = left_rounded(image_width);
+  int right = right_rounded(image_width);
 
   return right + 1 - left;
 }
 
-int Box_clap::get_height_rounded() const
+int Box_clap::get_height_rounded(int image_height) const
 {
-  int top = (Fraction(0, 1) - (m_clean_aperture_height - 1) / 2).round();
-  int bottom = ((m_clean_aperture_height - 1) / 2).round();
+  int top = top_rounded(image_height);
+  int bottom = bottom_rounded(image_height);
 
   return bottom + 1 - top;
 }

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -790,9 +790,9 @@ namespace heif {
     int top_rounded(int image_height) const;   // first row
     int bottom_rounded(int image_height) const; // last row included in the cropped image
 
-    int get_width_rounded() const;
+    int get_width_rounded(int image_width) const;
 
-    int get_height_rounded() const;
+    int get_height_rounded(int image_height) const;
 
     void set(uint32_t clap_width, uint32_t clap_height,
              uint32_t image_width, uint32_t image_height);

--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -604,8 +604,10 @@ Error HeifContext::interpret_heif_file()
       if (ispe_read) {
         auto clap = std::dynamic_pointer_cast<Box_clap>(prop.property);
         if (clap) {
-          image->set_resolution(clap->get_width_rounded(),
-                                clap->get_height_rounded());
+          auto width = image->get_width();
+          auto height = image->get_height();
+          image->set_resolution(clap->get_width_rounded(width),
+                                clap->get_height_rounded(height));
         }
 
         auto irot = std::dynamic_pointer_cast<Box_irot>(prop.property);


### PR DESCRIPTION
A 15x15 sample image:
[15x15.heic.zip](https://github.com/strukturag/libheif/files/10398878/15x15.heic.zip)
