### PR TITLE
Add ICC extraction to gdk-pixbuf loader

### DIFF
--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -136,6 +136,17 @@ static gboolean stop_load(gpointer context, GError** error)
   pixbuf = gdk_pixbuf_new_from_data(data, GDK_COLORSPACE_RGB, has_alpha, 8, width, height, stride, release_heif_image,
                                     img);
 
+  size_t profile_size = heif_image_handle_get_raw_color_profile_size(hdl);
+  if(profile_size)
+  {
+    guchar *profile_data = (guchar *)g_malloc0(profile_size);
+    heif_image_handle_get_raw_color_profile(hdl, profile_data);
+    gchar *profile_base64 = g_base64_encode(profile_data, profile_size);
+    gdk_pixbuf_set_option(pixbuf, "icc-profile", profile_base64);
+    g_free(profile_data);
+    g_free(profile_base64);
+  }
+  
   if (hpc->prepare_func) {
     (*hpc->prepare_func)(pixbuf, NULL, hpc->user_data);
   }

--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -140,11 +140,14 @@ static gboolean stop_load(gpointer context, GError** error)
   if(profile_size)
   {
     guchar *profile_data = (guchar *)g_malloc0(profile_size);
-    heif_image_handle_get_raw_color_profile(hdl, profile_data);
-    gchar *profile_base64 = g_base64_encode(profile_data, profile_size);
-    gdk_pixbuf_set_option(pixbuf, "icc-profile", profile_base64);
-    g_free(profile_data);
-    g_free(profile_base64);
+    if(profile_data)
+    {
+      heif_image_handle_get_raw_color_profile(hdl, profile_data);
+      gchar *profile_base64 = g_base64_encode(profile_data, profile_size);
+      gdk_pixbuf_set_option(pixbuf, "icc-profile", profile_base64);
+      g_free(profile_data);
+      g_free(profile_base64);
+    }
   }
   
   if (hpc->prepare_func) {

--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -139,12 +139,15 @@ static gboolean stop_load(gpointer context, GError** error)
   size_t profile_size = heif_image_handle_get_raw_color_profile_size(hdl);
   if(profile_size) {
     guchar *profile_data = (guchar *)g_malloc0(profile_size);
-    if(profile_data) {
-      heif_image_handle_get_raw_color_profile(hdl, profile_data);
+    err = heif_image_handle_get_raw_color_profile(hdl, profile_data);
+    if (err.code == heif_error_Ok) {
       gchar *profile_base64 = g_base64_encode(profile_data, profile_size);
       gdk_pixbuf_set_option(pixbuf, "icc-profile", profile_base64);
       g_free(profile_base64);
       g_free(profile_data);
+    }
+    else {
+      g_warning("%s", err.message);
     }
   }
   

--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -137,16 +137,14 @@ static gboolean stop_load(gpointer context, GError** error)
                                     img);
 
   size_t profile_size = heif_image_handle_get_raw_color_profile_size(hdl);
-  if(profile_size)
-  {
+  if(profile_size) {
     guchar *profile_data = (guchar *)g_malloc0(profile_size);
-    if(profile_data)
-    {
+    if(profile_data) {
       heif_image_handle_get_raw_color_profile(hdl, profile_data);
       gchar *profile_base64 = g_base64_encode(profile_data, profile_size);
       gdk_pixbuf_set_option(pixbuf, "icc-profile", profile_base64);
-      g_free(profile_data);
       g_free(profile_base64);
+      g_free(profile_data);
     }
   }
   


### PR DESCRIPTION
See e.g. the default JPEG, [PNG](https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/blob/aeda644f9690b346de77c8f7fae68f5661801833/gdk-pixbuf/io-png.c#L357-365) and TIFF loaders.