### PR TITLE
iloc: fix parsing with version == 1

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -939,7 +939,7 @@ Error Box_iloc::parse(BitstreamRange& range)
   int base_offset_size = (values4 >> 4) & 0xF;
   int index_size = 0;
 
-  if (get_version() > 1) {
+  if (get_version() >= 1) {
     index_size = (values4 & 0xF);
   }
 
@@ -1003,14 +1003,12 @@ Error Box_iloc::parse(BitstreamRange& range)
     for (int e = 0; e < extent_count; e++) {
       Extent extent;
 
-      if (get_version() > 1 && index_size > 0) {
-        if (index_size == 4) {
-          extent.index = range.read32();
-        }
-        else if (index_size == 8) {
-          extent.index = ((uint64_t) range.read32()) << 32;
-          extent.index |= range.read32();
-        }
+      if (index_size == 4) {
+        extent.index = range.read32();
+      }
+      else if (index_size == 8) {
+        extent.index = ((uint64_t) range.read32()) << 32;
+        extent.index |= range.read32();
       }
 
       extent.offset = 0;


### PR DESCRIPTION
The current ItemLocationBox (iloc) parsing produces incorrect results when `version == 1`.

There are two problems, with the initial parsing of `index_size` which occurs in
```
if ((version == 1) || (version == 2)) {
    unsigned int(4) index_size;
} else {
    unsigned int(4) reserved;
}
```

and then in the extent parsing part:
```
if (((version == 1) || (version == 2)) && (index_size > 0)) {
```

(see ISO/IEC 14496-12:2015 Section 8.11.3.2).

The existing code does > 1, instead of >= 1 for both of those. That causes incorrect parsing of the `extent_offset` and `extent_length`.

The PR attached corrects the first case, and removes the second case (because its redundant - we already skip the case where `index_size` == 0). It would be equally valid to just make them both >= 1 though.