### PR TITLE
heif_encoder_aom.cc: Get image bit depth correctly

### DIFF
--- a/libheif/plugins/heif_encoder_aom.cc
+++ b/libheif/plugins/heif_encoder_aom.cc
@@ -858,7 +858,7 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
     return err;
   }
 
-  int seq_profile = compute_avif_profile(heif_image_get_bits_per_pixel(image, heif_channel_Y),
+  int seq_profile = compute_avif_profile(heif_image_get_bits_per_pixel_range(image, heif_channel_Y),
                                      heif_image_get_chroma_format(image));
 
   cfg.g_w = source_width;


### PR DESCRIPTION
Call heif_image_get_bits_per_pixel_range(), not
heif_image_get_bits_per_pixel(), to get the bit depth of the image. The bug was introduced in commit 135f4ba0e2f13bedff4c81fc62bb49ae4bc61181.

Fix https://github.com/strukturag/libheif/issues/788.