### PR TITLE
rgan: initial work on Region Annotation

### DIFF
--- a/examples/heif_info.cc
+++ b/examples/heif_info.cc
@@ -376,6 +376,26 @@ int main(int argc, char** argv)
       printf("  none\n");
     }
 
+    int numRegionItems = heif_image_handle_get_number_of_region_items(handle);
+    printf("region annotations:\n");
+    if (numRegionItems > 0) {
+      std::vector<heif_item_id> ids(numRegionItems);
+      heif_image_handle_get_list_of_region_item_IDs(handle, ids.data(), numRegionItems);
+      for (int i = 0; i < numRegionItems; i++) {
+        unsigned int reference_width = heif_image_handle_get_region_item_reference_width(handle, ids[i]);
+        unsigned int reference_height = heif_image_handle_get_region_item_reference_height(handle, ids[i]);
+        unsigned int numRegions = heif_image_handle_get_region_item_number_of_regions(handle, ids[i]);
+        printf("  id: %u, reference_width: %u, reference_height: %u, %u regions\n", ids[i], reference_width, reference_height, numRegions);
+        for (unsigned int j = 0; j < numRegions; j++) {
+          const char* regionAsString = heif_image_handle_get_region_item_region_as_string(handle, ids[i], j);
+          printf("    %s\n", regionAsString);
+          free((void*)regionAsString);
+        }
+      }
+    }
+    else {
+      printf("  none\n");
+    }
 
     struct heif_image* image;
     err = heif_decode_image(handle,

--- a/go/heif/heif.go
+++ b/go/heif/heif.go
@@ -277,6 +277,8 @@ const (
 
 	SuberrorInvalidPixiBox = C.heif_suberror_Invalid_pixi_box
 
+	SuberrorInvalidRegionData = C.heif_suberror_Invalid_region_data
+
 	SuberrorWrongTileImagePixelDepth = C.heif_suberror_Wrong_tile_image_pixel_depth
 
 	SuberrorUnknownNCLXColorPrimaries = C.heif_suberror_Unknown_NCLX_color_primaries

--- a/libheif/error.cc
+++ b/libheif/error.cc
@@ -156,6 +156,8 @@ const char* heif::Error::get_error_string(heif_suberror_code err)
       return "Unknown NCLX transfer characteristics";
     case heif_suberror_Unknown_NCLX_matrix_coefficients:
       return "Unknown NCLX matrix coefficients";
+    case heif_suberror_Invalid_region_data:
+      return "Invalid region item data";
 
 
       // --- Memory_allocation_error ---

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1740,6 +1740,76 @@ void heif_nclx_color_profile_free(struct heif_color_profile_nclx* nclx_profile)
 }
 
 
+unsigned int heif_image_handle_get_number_of_region_items(const struct heif_image_handle* handle)
+{
+  return static_cast<unsigned int>(handle->image->get_region_items().size());
+}
+
+unsigned int heif_image_handle_get_list_of_region_item_IDs(const struct heif_image_handle* handle,
+                                                  heif_item_id* ids, unsigned int count)
+{
+  unsigned int cnt = 0;
+  for (const auto& metadata : handle->image->get_region_items()) {
+      if (cnt < count) {
+        ids[cnt] = metadata->item_id;
+        cnt++;
+      }
+    }
+
+  return cnt;
+}
+
+
+unsigned int heif_image_handle_get_region_item_reference_width(const struct heif_image_handle* handle,
+                                                               heif_item_id id)
+{
+  for (auto& region_item : handle->image->get_region_items()) {
+    if (region_item->item_id == id) {
+      return region_item->reference_width;
+    }
+  }
+  return 0;
+}
+
+
+unsigned int heif_image_handle_get_region_item_reference_height(const struct heif_image_handle* handle,
+                                                                heif_item_id id)
+{
+  for (auto& region_item : handle->image->get_region_items()) {
+    if (region_item->item_id == id) {
+      return region_item->reference_height;
+    }
+  }
+  return 0;
+}
+
+
+unsigned int heif_image_handle_get_region_item_number_of_regions(const struct heif_image_handle* handle,
+                                                                 heif_item_id id)
+{
+  for (auto& region_item : handle->image->get_region_items()) {
+    if (region_item->item_id == id) {
+      return (unsigned int)region_item->m_regions.size();
+    }
+  }
+  return 0;
+}
+
+
+const char* heif_image_handle_get_region_item_region_as_string(const struct heif_image_handle* handle,
+                                                               heif_item_id id,
+                                                               unsigned int region_index)
+{
+  for (auto& region_item : handle->image->get_region_items()) {
+    if (region_item->item_id == id) {
+      std::shared_ptr<Region> region = region_item->m_regions[region_index];
+      std::string str = region->toString();
+      return strdup(str.c_str());
+    }
+  }
+  return "";
+}
+
 // DEPRECATED
 struct heif_error heif_register_decoder(heif_context* heif, const heif_decoder_plugin* decoder_plugin)
 {

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -221,6 +221,8 @@ enum heif_suberror_code
 
   heif_suberror_Unknown_NCLX_matrix_coefficients = 135,
 
+  // Invalid specification of region item
+  heif_suberror_Invalid_region_data = 136,
 
   // --- Memory_allocation_error ---
 
@@ -1162,6 +1164,41 @@ struct heif_error heif_image_set_nclx_color_profile(struct heif_image* image,
 // TODO: this function does not make any sense yet, since we currently cannot modify existing HEIF files.
 //LIBHEIF_API
 //void heif_image_remove_color_profile(struct heif_image* image);
+
+
+// ------ region items and annotations
+// See ISO/IEC 23008-12:2022 Section 6.10 "Region items and region annotations"
+
+// How many region items are attached to an image.
+LIBHEIF_API
+unsigned int heif_image_handle_get_number_of_region_items(const struct heif_image_handle* handle);
+
+// The item IDs for the region items
+LIBHEIF_API
+unsigned int heif_image_handle_get_list_of_region_item_IDs(const struct heif_image_handle* handle,
+                                                           heif_item_id* ids, unsigned int count);
+
+// Get the reference width for the region item.
+LIBHEIF_API
+unsigned int heif_image_handle_get_region_item_reference_width(const struct heif_image_handle* handle,
+                                                               heif_item_id region_item_id);
+
+// Get the reference height for the region item.
+LIBHEIF_API
+unsigned int heif_image_handle_get_region_item_reference_height(const struct heif_image_handle* handle,
+                                                                heif_item_id region_item_id);
+
+// Get the number of regions within the region item.
+LIBHEIF_API
+unsigned int heif_image_handle_get_region_item_number_of_regions(const struct heif_image_handle* handle,
+                                                                 heif_item_id region_item_id);
+
+// Get a description of the region.
+// Caller is responsible for free()ing the returned C string.
+LIBHEIF_API
+const char* heif_image_handle_get_region_item_region_as_string(const struct heif_image_handle* handle,
+                                                               heif_item_id region_item_id,
+                                                               unsigned int region_index);
 
 // Fills the image decoding warnings into the provided 'out_warnings' array.
 // The size of the array has to be provided in max_output_buffer_entries.

--- a/libheif/heif_context.cc
+++ b/libheif/heif_context.cc
@@ -18,6 +18,7 @@
  * along with libheif.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cstdint>
 #if defined(HAVE_CONFIG_H)
 #include "config.h"
 #endif
@@ -511,6 +512,7 @@ static bool item_type_is_image(const std::string& item_type)
           item_type == "iden" ||
           item_type == "iovl" ||
           item_type == "av01" ||
+          item_type == "unci" ||
           item_type == "vvc1");
 }
 
@@ -876,6 +878,10 @@ Error HeifContext::interpret_heif_file()
 
   for (heif_item_id id : image_IDs) {
     std::string item_type = m_heif_file->get_item_type(id);
+     // skip region annotations, handled next
+    if (item_type == "rgan") {
+      continue;
+    }
     std::string content_type = m_heif_file->get_content_type(id);
 
     // we now assign all kinds of metadata to the image, not only 'Exif' and 'XMP'
@@ -926,6 +932,43 @@ Error HeifContext::interpret_heif_file()
           }
 
           img_iter->second->set_is_premultiplied_alpha(true);;
+        }
+      }
+    }
+  }
+
+  // --- read region item and assign to image(s)
+
+  for (heif_item_id id : image_IDs) {
+    std::string item_type = m_heif_file->get_item_type(id);
+    if (item_type == "rgan") {
+      std::shared_ptr<RegionItem> region_item = std::make_shared<RegionItem>();
+      region_item->item_id = id;
+      std::vector<uint8_t> region_data;
+      Error err = m_heif_file->get_compressed_image_data(id, &(region_data));
+      if (err) {
+        return err;
+      }
+      region_item->parse(region_data);
+      if (iref_box) {
+        std::vector<Box_iref::Reference> references = iref_box->get_references_from(id);
+        for (const auto& ref : references) {
+          if (ref.header.get_short_type() == fourcc("cdsc")) {
+            std::vector<uint32_t> refs = ref.to_item_ID;
+            if (refs.size() != 1) {
+              return Error(heif_error_Invalid_input,
+                           heif_suberror_Unspecified,
+                           "Region item not correctly assigned to image");
+            }
+            uint32_t image_id = refs[0];
+            auto img_iter = m_all_images.find(image_id);
+            if (img_iter == m_all_images.end()) {
+              return Error(heif_error_Invalid_input,
+                           heif_suberror_Nonexisting_item_referenced,
+                           "Region item assigned to non-existing image");
+            }
+            img_iter->second->add_region_item(region_item);
+          }
         }
       }
     }
@@ -1910,6 +1953,177 @@ Error HeifContext::decode_overlay_image(heif_item_id ID,
   return err;
 }
 
+
+Error RegionItem::parse(const std::vector<uint8_t>& data)
+{
+  if (data.size() < 8) {
+    return Error(heif_error_Invalid_input,
+                 heif_suberror_Invalid_region_data,
+                 "Less than 8 bytes of data");
+  }
+
+  uint8_t version = data[0];
+  (void) version; // version is unused
+
+  uint8_t flags = data[1];
+  int field_size = ((flags & 1) ? 32 : 16);
+
+  unsigned int dataOffset;
+  if (field_size == 32) {
+    if (data.size() < 12) {
+      return Error(heif_error_Invalid_input,
+                   heif_suberror_Invalid_region_data,
+                   "Region data incomplete");
+    }
+    reference_width = ((data[2] << 24) |
+                      (data[3] << 16) |
+                      (data[4] << 8) |
+                      (data[5]));
+
+    reference_height = ((data[6] << 24) |
+                       (data[7] << 16) |
+                       (data[8] << 8) |
+                       (data[9]));
+    dataOffset = 10;
+
+  }
+  else {
+    reference_width = ((data[2] << 8) |
+                       (data[3]));
+
+    reference_height = ((data[4] << 8) |
+                        (data[5]));
+    dataOffset = 6;
+  }
+
+  uint8_t region_count = data[dataOffset];
+  dataOffset += 1;
+  for (int i = 0; i < region_count; i++) {
+    uint8_t geometry_type = data[dataOffset];
+    dataOffset += 1;
+    
+    if (geometry_type == 0) {
+      std::shared_ptr<PointRegion> region = std::make_shared<PointRegion>();
+      region->geometry_type = geometry_type;
+      region->parse(data, field_size, &dataOffset);
+      m_regions.push_back(region);
+    }
+    else if (geometry_type == 1) {
+      std::shared_ptr<RectangleRegion> region = std::make_shared<RectangleRegion>();
+      region->geometry_type = geometry_type;
+      region->parse(data, field_size, &dataOffset);
+      m_regions.push_back(region);
+    } else {
+      std::cout << "ignoring unsupported region geometry type: " << (int) geometry_type << std::endl;
+    }
+  }
+
+  return Error::Ok;
+}
+
+Error PointRegion::parse(const std::vector<uint8_t>& data, int field_size, unsigned int *dataOffset)
+{
+  unsigned int bytesRequired = (field_size / 8) * 2;
+  if (data.size() - *dataOffset < bytesRequired) {
+    return Error(heif_error_Invalid_input,
+                 heif_suberror_Invalid_region_data,
+                 "Insufficient data remaining for point region");
+  }
+
+  if (field_size == 32) {
+    x = ((data[*dataOffset] << 24) |
+         (data[*dataOffset + 1] << 16) |
+         (data[*dataOffset + 2] << 8) |
+         (data[*dataOffset + 3]));
+    *dataOffset = *dataOffset + 4;
+    y = ((data[*dataOffset] << 24) |
+         (data[*dataOffset + 1] << 16) |
+         (data[*dataOffset + 2] << 8) |
+         (data[*dataOffset + 3]));
+    *dataOffset = *dataOffset + 4;
+  }
+  else {
+    x = ((data[*dataOffset] << 8) |
+         (data[*dataOffset + 1]));
+    *dataOffset = *dataOffset + 2;
+    y = ((data[*dataOffset] << 8) |
+         (data[*dataOffset + 1]));
+    *dataOffset = *dataOffset + 2;
+  }
+
+   return Error::Ok;
+}
+
+std::string PointRegion::toString() const {
+  std::ostringstream oss;
+  oss << "Point Region, x: ";
+  oss << x;
+  oss << ", y: ";
+  oss << y;
+  return oss.str();
+}
+
+Error RectangleRegion::parse(const std::vector<uint8_t>& data, int field_size, unsigned int *dataOffset)
+{
+  unsigned int bytesRequired = (field_size / 8) * 4;
+  if (data.size() - *dataOffset < bytesRequired) {
+    return Error(heif_error_Invalid_input,
+                 heif_suberror_Invalid_region_data,
+                 "Insufficient data remaining for rectangle region");
+  }
+
+  if (field_size == 32) {
+    x = ((data[*dataOffset] << 24) |
+         (data[*dataOffset + 1] << 16) |
+         (data[*dataOffset + 2] << 8) |
+         (data[*dataOffset + 3]));
+    *dataOffset = *dataOffset + 4;
+    y = ((data[*dataOffset] << 24) |
+         (data[*dataOffset + 1] << 16) |
+         (data[*dataOffset + 2] << 8) |
+         (data[*dataOffset + 3]));
+    *dataOffset = *dataOffset + 4;
+    width = ((data[*dataOffset] << 24) |
+             (data[*dataOffset + 1] << 16) |
+             (data[*dataOffset + 2] << 8) |
+             (data[*dataOffset + 3]));
+    *dataOffset = *dataOffset + 4;
+    height = ((data[*dataOffset] << 24) |
+              (data[*dataOffset + 1] << 16) |
+              (data[*dataOffset + 2] << 8) |
+              (data[*dataOffset + 3]));
+    *dataOffset = *dataOffset + 4;
+  }
+  else {
+    x = ((data[*dataOffset] << 8) |
+         (data[*dataOffset + 1]));
+    *dataOffset = *dataOffset + 2;
+    y = ((data[*dataOffset] << 8) |
+         (data[*dataOffset + 1]));
+    *dataOffset = *dataOffset + 2;
+    width = ((data[*dataOffset] << 8) |
+             (data[*dataOffset + 1]));
+    *dataOffset = *dataOffset + 2;
+    height = ((data[*dataOffset] << 8) |
+              (data[*dataOffset + 1]));
+    *dataOffset = *dataOffset + 2;
+  }
+
+   return Error::Ok;
+}
+
+std::string RectangleRegion::toString() const {
+  std::ostringstream oss;
+  oss << "Rectangle Region, x: ";
+  oss << x;
+  oss << ", y: ";
+  oss << y;
+  oss << ", width: ";
+  oss << width;
+  oss << ", height: ";
+  oss << height;
+  return oss.str();
+}
 
 static std::shared_ptr<HeifPixelImage>
 create_alpha_image_from_image_alpha_channel(const std::shared_ptr<HeifPixelImage>& image)

--- a/libheif/heif_context.h
+++ b/libheif/heif_context.h
@@ -65,7 +65,7 @@ namespace heif {
   public:
     virtual std::string toString() const = 0;
     
-    virtual ~Region() {};
+    virtual ~Region() = default;
 
     uint8_t geometry_type;
   };
@@ -75,7 +75,7 @@ namespace heif {
   public:
     Error parse(const std::vector<uint8_t>& data, int field_size, unsigned int *dataOffset);
     
-    std::string toString() const;
+    std::string toString() const override;
   
     int32_t x;
     int32_t y;
@@ -86,7 +86,7 @@ namespace heif {
   public:
     Error parse(const std::vector<uint8_t>& data, int field_size, unsigned int *dataOffset);
     
-    std::string toString() const;
+    std::string toString() const override;
   
     int32_t x;
     int32_t y;

--- a/libheif/heif_emscripten.h
+++ b/libheif/heif_emscripten.h
@@ -249,6 +249,7 @@ EMSCRIPTEN_BINDINGS(libheif) {
     .value("heif_suberror_Unsupported_parameter", heif_suberror_Unsupported_parameter)
     .value("heif_suberror_Invalid_parameter_value", heif_suberror_Invalid_parameter_value)
     .value("heif_suberror_Invalid_pixi_box", heif_suberror_Invalid_pixi_box)
+    .value("heif_suberror_Invalid_region_data", heif_suberror_Invalid_region_data)
     .value("heif_suberror_Unsupported_codec", heif_suberror_Unsupported_codec)
     .value("heif_suberror_Unsupported_image_type", heif_suberror_Unsupported_image_type)
     .value("heif_suberror_Unsupported_data_version", heif_suberror_Unsupported_data_version)


### PR DESCRIPTION
This is initial work on supporting parsing of RegionItem. It is the first substantive change I'm proposing for libheif, and wanted to get feedback before investing too much in the wrong direction.

Region items and region annotations are described in ISO/IEC 23008-12:2022 Section 6.10. AFAICT, it is not present in HEIF 2017 edition.

The current scope I am targeting is parsing and info display. I'm not planning writing at this stage. 

An example of what it might look like in an info display is:

```
MIME type: image/heif
main brand: mif1
compatible brands: mif1, mif2, ns01, unif

image: 1280x720 (id=6007), primary
  color profile: no
  alpha channel: no 
  depth channel: no
metadata:
  none
region annotations:
  id: 6024, reference_width: 1280, reference_height: 720, 2 regions
    Rectangle Region, x: 320, y: 480, width: 320, height: 240
    Point Region, x: 480, y: 600
```

This is a WIP. Remaining tasks include:

  - [ ] Support for polyline
  - [ ] Support for polygon
  - [ ] Support for ellipse
  - [ ] Support for inline mask (at least flagging it is not supported)
  - [ ] Support for mask item

Any additional items and general contribution guidance (e.g. recommended code formatters) would be appreciated. 