### PR TITLE
Refactor sharp yuv conversion to be a separate conversion step.

### DIFF
--- a/tests/conversion.cc
+++ b/tests/conversion.cc
@@ -103,7 +103,19 @@ TEST_CASE( "Color conversion", "[heif_image]" ) {
                                          { heif_colorspace_YCbCr, heif_chroma_420, false, 8 },
                                          sharp_yuv_options);
 
+#ifdef HAVE_LIBSHARPYUV
   REQUIRE( success );
+#else
+  REQUIRE( !success );  // Should fail if libsharpyuv is not compiled in.
+#endif
+
+  printf("--- interleaved RGBA -> YCbCr 422 with sharp yuv (not supported!)\n");
+
+  success = pipeline.construct_pipeline( { heif_colorspace_RGB, heif_chroma_interleaved_RGBA, true, 8 },
+                                         { heif_colorspace_YCbCr, heif_chroma_422, false, 8 },
+                                         sharp_yuv_options);
+
+  REQUIRE( !success );  // Should fail!
 
   printf("--- RGB planes 10bit -> interleaved RGB 10 bitlittle endain\n");
 


### PR DESCRIPTION
If sharp yuv is requested but is not supported or fails, the whole encode fails rather than falling back to regular RGB->YUV conversion.

Reverts changes to Op_RGB24_32_to_YCbCr and adds
Op_RGB24_32_to_YCbCr_Sharp instead.