### PR TITLE
Add image reference cycle detection

### DIFF
--- a/libheif/error.cc
+++ b/libheif/error.cc
@@ -179,6 +179,8 @@ const char* heif::Error::get_error_string(heif_suberror_code err)
       return "Unsupported parameter";
     case heif_suberror_Invalid_parameter_value:
       return "Invalid parameter value";
+    case heif_suberror_Item_reference_cycle:
+      return "Image reference cycle";
 
       // --- Unsupported_feature ---
 

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -253,6 +253,9 @@ enum heif_suberror_code
   // The value for the given parameter is not in the valid range.
   heif_suberror_Invalid_parameter_value = 2006,
 
+  // Image reference cycle found in iref
+  heif_suberror_Item_reference_cycle = 2007,
+
 
   // --- Unsupported_feature ---
 

--- a/libheif/heif_file.cc
+++ b/libheif/heif_file.cc
@@ -355,7 +355,7 @@ Error HeifFile::parse_heif_file(BitstreamRange& range)
 Error HeifFile::check_for_ref_cycle(heif_item_id ID,
                                     std::shared_ptr<Box_iref>& iref_box,
                                     std::unordered_set<heif_item_id>& parent_items) const {
-  if (parent_items.contains(ID)) {
+  if (parent_items.find(ID) != parent_items.end()) {
     return Error(heif_error_Invalid_input,
                  heif_suberror_Item_reference_cycle,
                  "Image reference cycle");

--- a/libheif/heif_file.cc
+++ b/libheif/heif_file.cc
@@ -318,6 +318,13 @@ Error HeifFile::parse_heif_file(BitstreamRange& range)
   m_idat_box = std::dynamic_pointer_cast<Box_idat>(m_meta_box->get_child_box(fourcc("idat")));
 
   m_iref_box = std::dynamic_pointer_cast<Box_iref>(m_meta_box->get_child_box(fourcc("iref")));
+  if (m_iref_box) {
+    std::unordered_set<heif_item_id> parent_items;
+    Error error = check_for_ref_cycle(get_primary_image_ID(), m_iref_box, parent_items);
+    if (error) {
+      return error;
+    }
+  }
 
   m_iinf_box = std::dynamic_pointer_cast<Box_iinf>(m_meta_box->get_child_box(fourcc("iinf")));
   if (!m_iinf_box) {
@@ -341,6 +348,29 @@ Error HeifFile::parse_heif_file(BitstreamRange& range)
     m_infe_boxes.insert(std::make_pair(infe_box->get_item_ID(), infe_box));
   }
 
+  return Error::Ok;
+}
+
+
+Error HeifFile::check_for_ref_cycle(heif_item_id ID,
+                                    std::shared_ptr<Box_iref>& iref_box,
+                                    std::unordered_set<heif_item_id>& parent_items) const {
+  if (parent_items.contains(ID)) {
+    return Error(heif_error_Invalid_input,
+                 heif_suberror_Item_reference_cycle,
+                 "Image reference cycle");
+  }
+  parent_items.insert(ID);
+
+  std::vector<heif_item_id> image_references = iref_box->get_references(ID, fourcc("dimg"));
+  for (heif_item_id reference_idx : image_references) {
+    Error error = check_for_ref_cycle(reference_idx, iref_box, parent_items);
+    if (error) {
+      return error;
+    }
+  }
+
+  parent_items.erase(ID);
   return Error::Ok;
 }
 

--- a/libheif/heif_file.h
+++ b/libheif/heif_file.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <unordered_set>
 
 #if ENABLE_PARALLEL_TILE_DECODING
 #include <mutex>
@@ -198,6 +199,10 @@ namespace heif {
 
 
     Error parse_heif_file(BitstreamRange& bitstream);
+
+    Error check_for_ref_cycle(heif_item_id ID,
+                              std::shared_ptr<Box_iref>& iref_box,
+                              std::unordered_set<heif_item_id>& parent_items) const;
 
     std::shared_ptr<Box_infe> get_infe(heif_item_id ID) const;
   };


### PR DESCRIPTION
Resolves  https://github.com/strukturag/libheif/issues/590.

Some derived images may contain cycles of image references in iref. Decoding such images leads to an out of memory error (which in turn may cause a DoS).

This PR adds an iref check, which detects cycles during image parse.
