### PR TITLE
Add reserved bits skip for NumSubLayers>1 in SPS

### DIFF
--- a/libheif/heif_hevc.cc
+++ b/libheif/heif_hevc.cc
@@ -238,6 +238,12 @@ Error heif::parse_sps_for_hvcC_configuration(const uint8_t* sps, size_t size,
     layer_level_present[i] = reader.get_bits(1);
   }
 
+  if (nMaxSubLayersMinus1 > 0) {
+    for (int i = nMaxSubLayersMinus1; i < 8; i++) {
+      reader.skip_bits(2);   
+    }
+  }
+
   for (int i = 0; i < nMaxSubLayersMinus1; i++) {
     if (layer_profile_present[i]) {
       reader.skip_bits(2 + 1 + 5);


### PR DESCRIPTION
According to H.265 7.3.3
if( maxNumSubLayersMinus1 > 0 )
    for( i = maxNumSubLayersMinus1; i < 8; i++ )
        reserved_zero_2bits[ i ]
And x265 Entropy::codeProfileTier
    if (maxTempSubLayers > 1)
    {
         WRITE_FLAG(0, "sub_layer_profile_present_flag[i]");
         WRITE_FLAG(0, "sub_layer_level_present_flag[i]");
         for (int i = maxTempSubLayers - 1; i < 8 ; i++)
             WRITE_CODE(0, 2, "reserved_zero_2bits");
    }
 Should skip reserved bits to align to byte boundary in case of maxTempSubLayers > 1
