### PR TITLE
regions: add polyline to regions API

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -3224,7 +3224,8 @@ struct heif_error heif_region_get_ellipse_scaled(const struct heif_region* regio
   return heif_error_invalid_parameter_value;
 }
 
-int heif_region_get_polygon_num_points(const struct heif_region* region)
+
+static int heif_region_get_poly_num_points(const struct heif_region* region)
 {
   const std::shared_ptr<RegionGeometry_Polygon> polygon = std::dynamic_pointer_cast<RegionGeometry_Polygon>(region->region);
   if (polygon) {
@@ -3234,51 +3235,80 @@ int heif_region_get_polygon_num_points(const struct heif_region* region)
 }
 
 
-void heif_region_get_polygon_points(const struct heif_region* region, int32_t* pts)
+int heif_region_get_polygon_num_points(const struct heif_region* region)
 {
-  if (pts == nullptr) {
-    return;
-  }
-
-  const std::shared_ptr<RegionGeometry_Polygon> polygon = std::dynamic_pointer_cast<RegionGeometry_Polygon>(region->region);
-  if (polygon) {
-    for (int i = 0; i < (int) polygon->points.size(); i++) {
-      pts[2 * i + 0] = polygon->points[i].x;
-      pts[2 * i + 1] = polygon->points[i].y;
-    }
-  }
+  return heif_region_get_poly_num_points(region);
 }
 
 
-void heif_region_get_polygon_points_scaled(const struct heif_region* region, double* pts, heif_item_id image_id)
+int heif_region_get_polyline_num_points(const struct heif_region* region)
+{
+  return heif_region_get_poly_num_points(region);
+}
+
+
+static struct heif_error heif_region_get_poly_points(const struct heif_region* region, int32_t* pts)
 {
   if (pts == nullptr) {
-    return;
+    return heif_error_invalid_parameter_value;
   }
 
-  const std::shared_ptr<RegionGeometry_Polygon> polygon = std::dynamic_pointer_cast<RegionGeometry_Polygon>(region->region);
-  if (polygon) {
+  const std::shared_ptr<RegionGeometry_Polygon> poly = std::dynamic_pointer_cast<RegionGeometry_Polygon>(region->region);
+  if (poly) {
+    for (int i = 0; i < (int) poly->points.size(); i++) {
+      pts[2 * i + 0] = poly->points[i].x;
+      pts[2 * i + 1] = poly->points[i].y;
+    }
+    return heif_error_ok;
+  }
+  return heif_error_invalid_parameter_value;
+}
+
+
+struct heif_error heif_region_get_polygon_points(const struct heif_region* region, int32_t* pts)
+{
+  return heif_region_get_poly_points(region, pts);
+}
+
+
+struct heif_error heif_region_get_polyline_points(const struct heif_region* region, int32_t* pts)
+{
+  return heif_region_get_poly_points(region, pts);
+}
+
+
+static struct heif_error heif_region_get_poly_points_scaled(const struct heif_region* region, double* pts, heif_item_id image_id)
+{
+  if (pts == nullptr) {
+    return heif_error_invalid_parameter_value;
+  }
+
+  const std::shared_ptr<RegionGeometry_Polygon> poly = std::dynamic_pointer_cast<RegionGeometry_Polygon>(region->region);
+  if (poly) {
     auto t = RegionCoordinateTransform::create(region->context->get_heif_file(), image_id,
                                                region->region_item->reference_width,
                                                region->region_item->reference_height);
 
-    for (int i = 0; i < (int) polygon->points.size(); i++) {
-      RegionCoordinateTransform::Point p = t.transform_point({(double) polygon->points[i].x,
-                                                              (double) polygon->points[i].y});
+    for (int i = 0; i < (int) poly->points.size(); i++) {
+      RegionCoordinateTransform::Point p = t.transform_point({(double) poly->points[i].x,
+                                                              (double) poly->points[i].y});
 
       pts[2 * i + 0] = p.x;
       pts[2 * i + 1] = p.y;
     }
+    return heif_error_ok;
   }
+  return heif_error_invalid_parameter_value;
 }
 
 
-uint8_t heif_region_get_polygon_closed(const struct heif_region* region)
+struct heif_error heif_region_get_polygon_points_scaled(const struct heif_region* region, double* pts, heif_item_id image_id)
 {
-  const std::shared_ptr<RegionGeometry_Polygon> polygon = std::dynamic_pointer_cast<RegionGeometry_Polygon>(region->region);
-  if (polygon) {
-    return polygon->closed;
-  }
-
-  return false;
+  return heif_region_get_poly_points_scaled(region, pts, image_id);
 }
+
+struct heif_error heif_region_get_polyline_points_scaled(const struct heif_region* region, double* pts, heif_item_id image_id)
+{
+  return heif_region_get_poly_points_scaled(region, pts, image_id);
+}
+

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -1832,8 +1832,9 @@ enum heif_region_type
   heif_region_type_point,
   heif_region_type_rectangle,
   heif_region_type_ellipse,
-  heif_region_type_polygon,  // also includes polyline (as a non-closed polygon)
-  heif_region_type_mask
+  heif_region_type_polygon,
+  heif_region_type_mask,
+  heif_region_type_polyline
 };
 
 struct heif_region;
@@ -1910,19 +1911,28 @@ struct heif_error heif_region_get_ellipse_scaled(const struct heif_region* regio
 LIBHEIF_API
 int heif_region_get_polygon_num_points(const struct heif_region* region);
 
+LIBHEIF_API
+int heif_region_get_polyline_num_points(const struct heif_region* region);
+
 // Point coordinates are stored in the output array 'pts'. This must have twice as many entries as there are points.
 // Each point is stored as consecutive x and y positions.
 LIBHEIF_API
-void heif_region_get_polygon_points(const struct heif_region* region,
-                                    int32_t* pts);
+struct heif_error heif_region_get_polygon_points(const struct heif_region* region,
+                                                 int32_t* pts);
 
 LIBHEIF_API
-void heif_region_get_polygon_points_scaled(const struct heif_region* region,
-                                           double* pts,
-                                           heif_item_id image_id);
+struct heif_error heif_region_get_polygon_points_scaled(const struct heif_region* region,
+                                                        double* pts,
+                                                        heif_item_id image_id);
 
 LIBHEIF_API
-uint8_t heif_region_get_polygon_closed(const struct heif_region* region);
+struct heif_error heif_region_get_polyline_points(const struct heif_region* region,
+                                                  int32_t* pts);
+
+LIBHEIF_API
+struct heif_error heif_region_get_polyline_points_scaled(const struct heif_region* region,
+                                                         double* pts,
+                                                         heif_item_id image_id);
 
 #if 0
 struct heif_region_annotation;

--- a/libheif/region.h
+++ b/libheif/region.h
@@ -103,7 +103,10 @@ class RegionGeometry_Polygon : public RegionGeometry
 public:
   Error parse(const std::vector<uint8_t>& data, int field_size, unsigned int* dataOffset) override;
 
-  heif_region_type getRegionType() override { return heif_region_type_polygon; }
+  heif_region_type getRegionType() override
+  {
+    return closed ? heif_region_type_polygon : heif_region_type_polyline;
+  }
 
   struct Point
   {


### PR DESCRIPTION
This proposes two somewhat related changed to the region API.

The first is to represent polyline as distinct from polygon in the API. That avoids the need for checking if its closed, and more closely represents the way the standard describes it (and hopefully the way the user thinks about it). The underlying implementation is still shared - the API change just avoids exposing that implementation detail.

The second change is to switch both polygon and polyline to returning `heif_error`, rather than just not filling in any data in the points array. That should be checked, and also makes the API more consistent with the equivalent calls for point, rectangle and ellipse.

This should be seen as a proposal towards a final API, still subject to discussion.