### PR TITLE
Test all valid src/dst color state combinations in color test.

### DIFF
--- a/libheif/color-conversion/colorconversion.cc
+++ b/libheif/color-conversion/colorconversion.cc
@@ -30,6 +30,7 @@
 #include <set>
 #include <cmath>
 #include <limits>
+#include <string>
 #include "rgb2yuv.h"
 #include "rgb2yuv_sharp.h"
 #include "yuv2rgb.h"
@@ -298,7 +299,7 @@ bool ColorConversionPipeline::construct_pipeline(const ColorState& input_state,
       assert(m_conversion_steps.back().output_state == target_state);
 
 #if DEBUG_ME
-      debug_dump_pipeline();
+      std::cerr << debug_dump_pipeline();
 #endif
 
       return true;
@@ -367,13 +368,15 @@ bool ColorConversionPipeline::construct_pipeline(const ColorState& input_state,
 }
 
 
-void ColorConversionPipeline::debug_dump_pipeline() const
+std::string ColorConversionPipeline::debug_dump_pipeline() const
 {
-  std::cerr << "final pipeline has " << m_conversion_steps.size() << " steps:\n";
+  std::ostringstream ostr;
+  ostr << "final pipeline has " << m_conversion_steps.size() << " steps:\n";
   for (const auto& step : m_conversion_steps) {
     auto& op = *step.operation;
-    std::cerr << "> " << typeid(op).name() << "\n";
+    ostr << "> " << typeid(op).name() << "\n";
   }
+  return ostr.str();
 }
 
 

--- a/libheif/color-conversion/colorconversion.cc
+++ b/libheif/color-conversion/colorconversion.cc
@@ -455,8 +455,7 @@ std::shared_ptr<HeifPixelImage> convert_colorspace(const std::shared_ptr<HeifPix
   // check for valid target YCbCr chroma formats
 
   if (target_colorspace == heif_colorspace_YCbCr) {
-    if (target_chroma != heif_chroma_monochrome &&
-        target_chroma != heif_chroma_420 &&
+    if (target_chroma != heif_chroma_420 &&
         target_chroma != heif_chroma_422 &&
         target_chroma != heif_chroma_444) {
       return nullptr;

--- a/libheif/color-conversion/colorconversion.h
+++ b/libheif/color-conversion/colorconversion.h
@@ -23,6 +23,7 @@
 
 #include "libheif/heif_image.h"
 #include <memory>
+#include <string>
 #include <vector>
 
 using namespace heif;
@@ -99,7 +100,7 @@ public:
   std::shared_ptr<HeifPixelImage>
   convert_image(const std::shared_ptr<HeifPixelImage>& input);
 
-  void debug_dump_pipeline() const;
+  std::string debug_dump_pipeline() const;
 
 private:
   static std::vector<ColorConversionOperation*> m_operation_pool;

--- a/libheif/color-conversion/colorconversion.h
+++ b/libheif/color-conversion/colorconversion.h
@@ -43,6 +43,7 @@ struct ColorState
   bool operator==(const ColorState&) const;
 };
 
+std::ostream& operator<<(std::ostream& ostr, const ColorState& state);
 
 // These are some integer constants for typical color conversion Op speed costs.
 // The integer value is the speed cost. Any other integer can be assigned to the speed cost.

--- a/libheif/color-conversion/monochrome.cc
+++ b/libheif/color-conversion/monochrome.cc
@@ -27,8 +27,7 @@ Op_mono_to_YCbCr420::state_after_conversion(const ColorState& input_state,
                                             const ColorState& target_state,
                                             const heif_color_conversion_options& options) const
 {
-  if ((input_state.colorspace != heif_colorspace_monochrome &&
-       input_state.colorspace != heif_colorspace_YCbCr) ||
+  if (input_state.colorspace != heif_colorspace_monochrome ||
       input_state.chroma != heif_chroma_monochrome) {
     return {};
   }
@@ -163,8 +162,7 @@ Op_mono_to_RGB24_32::state_after_conversion(const ColorState& input_state,
 {
   // Note: no input alpha channel required. It will be filled up with 0xFF.
 
-  if ((input_state.colorspace != heif_colorspace_monochrome &&
-       input_state.colorspace != heif_colorspace_YCbCr) ||
+  if (input_state.colorspace != heif_colorspace_monochrome ||
       input_state.chroma != heif_chroma_monochrome ||
       input_state.bits_per_pixel != 8) {
     return {};

--- a/libheif/color-conversion/monochrome.cc
+++ b/libheif/color-conversion/monochrome.cc
@@ -27,7 +27,8 @@ Op_mono_to_YCbCr420::state_after_conversion(const ColorState& input_state,
                                             const ColorState& target_state,
                                             const heif_color_conversion_options& options) const
 {
-  if (input_state.colorspace != heif_colorspace_monochrome ||
+  if ((input_state.colorspace != heif_colorspace_monochrome &&
+       input_state.colorspace != heif_colorspace_YCbCr) ||
       input_state.chroma != heif_chroma_monochrome) {
     return {};
   }

--- a/libheif/color-conversion/rgb2yuv.cc
+++ b/libheif/color-conversion/rgb2yuv.cc
@@ -301,6 +301,10 @@ Op_RRGGBBxx_HDR_to_YCbCr420::state_after_conversion(const ColorState& input_stat
     }
   }
 
+  if (target_state.chroma != heif_chroma_420) {
+    return {};
+  }
+
 
   std::vector<ColorStateWithCost> states;
 
@@ -907,6 +911,10 @@ Op_YCbCr444_to_YCbCr420_average<Pixel>::state_after_conversion(const ColorState&
     if (input_state.nclx_profile->get_matrix_coefficients() == 0) {
       return {};
     }
+  }
+
+  if (target_state.chroma != heif_chroma_420) {
+    return {};
   }
 
   std::vector<ColorStateWithCost> states;

--- a/libheif/color-conversion/yuv2rgb.cc
+++ b/libheif/color-conversion/yuv2rgb.cc
@@ -39,6 +39,9 @@ Op_YCbCr_to_RGB<Pixel>::state_after_conversion(const ColorState& input_state,
       return {};
     }
   }
+  if (input_state.chroma == heif_chroma_monochrome) {
+    return {};
+  }
 
   bool hdr = !std::is_same<Pixel, uint8_t>::value;
 

--- a/libheif/color-conversion/yuv2rgb.cc
+++ b/libheif/color-conversion/yuv2rgb.cc
@@ -39,17 +39,17 @@ Op_YCbCr_to_RGB<Pixel>::state_after_conversion(const ColorState& input_state,
       return {};
     }
   }
-  if (input_state.chroma == heif_chroma_monochrome) {
+
+  if (input_state.colorspace != heif_colorspace_YCbCr ||
+      (input_state.chroma != heif_chroma_444 &&
+       input_state.chroma != heif_chroma_422 &&
+       input_state.chroma != heif_chroma_420)) {
     return {};
   }
 
   bool hdr = !std::is_same<Pixel, uint8_t>::value;
 
   if ((input_state.bits_per_pixel != 8) != hdr) {
-    return {};
-  }
-
-  if (input_state.colorspace != heif_colorspace_YCbCr) {
     return {};
   }
 

--- a/libheif/color-conversion/yuv2rgb.cc
+++ b/libheif/color-conversion/yuv2rgb.cc
@@ -610,7 +610,7 @@ Op_YCbCr420_to_RRGGBBaa::convert_colorspace(const std::shared_ptr<const HeifPixe
       }
 
       int r = clip_f_u16(y_ + coeffs.r_cr * cr, maxval);
-      int g = clip_f_u16(y_ + coeffs.g_cb * cb - coeffs.g_cr * cr, maxval);
+      int g = clip_f_u16(y_ + coeffs.g_cb * cb + coeffs.g_cr * cr, maxval);
       int b = clip_f_u16(y_ + coeffs.b_cb * cb, maxval);
 
       out_p[y * out_p_stride + bytesPerPixel * x + 0 + le] = (uint8_t) (r >> 8);

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -1077,10 +1077,10 @@ enum heif_chroma
   heif_chroma_444 = 3,
   heif_chroma_interleaved_RGB = 10,
   heif_chroma_interleaved_RGBA = 11,
-  heif_chroma_interleaved_RRGGBB_BE = 12,
-  heif_chroma_interleaved_RRGGBBAA_BE = 13,
-  heif_chroma_interleaved_RRGGBB_LE = 14,
-  heif_chroma_interleaved_RRGGBBAA_LE = 15
+  heif_chroma_interleaved_RRGGBB_BE = 12,   // HDR, big endian.
+  heif_chroma_interleaved_RRGGBBAA_BE = 13, // HDR, big endian.
+  heif_chroma_interleaved_RRGGBB_LE = 14,   // HDR, little endian.
+  heif_chroma_interleaved_RRGGBBAA_LE = 15  // HDR, little endian.
 };
 
 // DEPRECATED ENUM NAMES
@@ -1091,8 +1091,21 @@ enum heif_chroma
 enum heif_colorspace
 {
   heif_colorspace_undefined = 99,
+  // Should be used with a heif_chroma value in:
+  // * heif_chroma_444
+  // * heif_chroma_422
+  // * heif_chroma_420
   heif_colorspace_YCbCr = 0,
+  // Should be used with a heif_chroma value in:
+  // * heif_chroma_444 (for planar RGB)
+  // * heif_chroma_interleaved_RGB
+  // * heif_chroma_interleaved_RGBA
+  // * heif_chroma_interleaved_RRGGBB_BE
+  // * heif_chroma_interleaved_RRGGBBAA_BE
+  // * heif_chroma_interleaved_RRGGBB_LE
+  // * heif_chroma_interleaved_RRGGBBAA_LE
   heif_colorspace_RGB = 1,
+  // Should be used with heif_chroma value: heif_chroma_monochrome
   heif_colorspace_monochrome = 2
 };
 

--- a/tests/conversion.cc
+++ b/tests/conversion.cc
@@ -302,8 +302,7 @@ void TestFailingConversion(const std::string& test_name,
 std::vector<heif_chroma> GetValidChroma(heif_colorspace colorspace) {
   switch (colorspace) {
     case heif_colorspace_YCbCr:
-      return {heif_chroma_monochrome, heif_chroma_420, heif_chroma_422,
-              heif_chroma_444};
+      return {heif_chroma_420, heif_chroma_422, heif_chroma_444};
     case heif_colorspace_RGB:
       return {heif_chroma_444,
               heif_chroma_interleaved_RGB,

--- a/tests/conversion.cc
+++ b/tests/conversion.cc
@@ -231,6 +231,7 @@ void TestConversion(const std::string& test_name, const ColorState& input_state,
 
   ColorConversionPipeline pipeline;
   REQUIRE(pipeline.construct_pipeline(input_state, target_state, options));
+  INFO(pipeline.debug_dump_pipeline());
 
   auto in_image = std::make_shared<heif::HeifPixelImage>();
   // Width and height are multiples of 4.
@@ -301,7 +302,7 @@ void TestFailingConversion(const std::string& test_name,
 std::vector<heif_chroma> GetValidChroma(heif_colorspace colorspace) {
   switch (colorspace) {
     case heif_colorspace_YCbCr:
-      return {/*heif_chroma_monochrome, */heif_chroma_420, heif_chroma_422,
+      return {heif_chroma_monochrome, heif_chroma_420, heif_chroma_422,
               heif_chroma_444};
     case heif_colorspace_RGB:
       return {heif_chroma_444,
@@ -393,10 +394,12 @@ TEST_CASE("All conversions", "[heif_image]") {
   // To debug a particular combination, hardcoe the ColorState values
   // instead:
   // ColorState src_state(heif_colorspace_YCbCr, heif_chroma_420, false, 8);
-  // ColorState dst_state = ...
+  // ColorState dst_state(...);
 
   // Converting to monochrome is not supported at the moment.
-  if (dst_state.colorspace == heif_colorspace_monochrome) return;
+  if (dst_state.colorspace == heif_colorspace_monochrome ||
+      dst_state.chroma == heif_chroma_monochrome)
+    return;
 
   std::ostringstream os;
   os << "from: " << src_state << "\nto:   " << dst_state;

--- a/tests/conversion.cc
+++ b/tests/conversion.cc
@@ -24,10 +24,10 @@
   SOFTWARE.
 */
 
+#include <iomanip>
 #include "catch.hpp"
 #include "libheif/color-conversion/colorconversion.h"
 #include "libheif/heif_image.h"
-
 
 using namespace heif;
 
@@ -65,6 +65,50 @@ uint16_t SwapBytesIfNeeded(uint16_t v, heif_chroma chroma) {
 }
 
 template <typename T>
+std::string PrintChannel(const HeifPixelImage& image, heif_channel channel) {
+  heif_chroma chroma = image.get_chroma_format();
+  int num_interleaved = num_interleaved_pixels_per_plane(chroma);
+  bool is_interleaved = num_interleaved > 1;
+  int max_cols = is_interleaved ? 3 : 10;
+  int max_rows = 10;
+  int width = std::min(image.get_width(channel), max_cols);
+  int height = std::min(image.get_height(channel), max_rows);
+  int stride;
+  const T* p = (T*)image.get_plane(channel, &stride);
+  stride /= sizeof(T);
+  int digits = (int)std::ceil(std::log10(1 << image.get_bits_per_pixel(channel))) + 1;
+
+  std::ostringstream os;
+  os << std::string(digits, ' ');
+  int header_width = digits * num_interleaved - 1 + (is_interleaved ? 3 : 0);
+  for (int x = 0; x < width; ++x) {
+    os << "|" << std::left << std::setw(header_width) << std::to_string(x);
+  }
+  os << "\n";
+  for (int y = 0; y < height; ++y) {
+    os << std::left << std::setw(digits) << std::to_string(y) << "|";
+    for (int x = 0; x < width; ++x) {
+      if (is_interleaved) os << "(";
+      for (int k = 0; k < num_interleaved; ++k) {
+        int v = SwapBytesIfNeeded(p[y * stride + x * num_interleaved + k], chroma);
+        os << std::left << std::setw(digits) << std::to_string(v);
+      }
+      if (is_interleaved) os << ") ";
+    }
+    os << "\n";
+  }
+  return os.str();
+}
+
+std::string PrintChannel(const HeifPixelImage& image, heif_channel channel) {
+ if (image.get_bits_per_pixel(channel) <= 8) {
+    return PrintChannel<uint8_t>(image, channel);
+ } else {
+    return PrintChannel<uint16_t>(image, channel);
+ }
+}
+
+template <typename T>
 double GetPsnr(const HeifPixelImage& original, const HeifPixelImage& compressed,
                heif_channel channel, bool skip_alpha) {
   int w = original.get_width(channel);
@@ -94,7 +138,7 @@ double GetPsnr(const HeifPixelImage& original, const HeifPixelImage& compressed,
   double psnr = 10 * log10(max * max / mse);
   if (psnr < 0.) return 0.;
   if (psnr > 100.) return 100.;
- return psnr;
+  return psnr;
 }
 
 double GetPsnr(const HeifPixelImage& original, const HeifPixelImage& compressed,
@@ -172,7 +216,8 @@ bool MakeTestImage(const ColorState& state, int width, int height,
   for (size_t i = 0; i < planes.size(); ++i) {
     const Plane& plane = planes[i];
     int half_max = (1 << (plane.bit_depth -1));
-    uint16_t value = SwapBytesIfNeeded(static_cast<uint16_t>(half_max + i * 10 + i), state.chroma);
+    uint16_t value = SwapBytesIfNeeded(
+        static_cast<uint16_t>(half_max + i * 10 + i), state.chroma);
     image->fill_new_plane(plane.channel, value, plane.width, plane.height,
                           plane.bit_depth);
   }
@@ -183,7 +228,6 @@ void TestConversion(const std::string& test_name, const ColorState& input_state,
                     const ColorState& target_state,
                     const heif_color_conversion_options& options) {
   INFO(test_name);
-  printf("\n\n%s\n", test_name.c_str());
 
   ColorConversionPipeline pipeline;
   REQUIRE(pipeline.construct_pipeline(input_state, target_state, options));
@@ -202,7 +246,7 @@ void TestConversion(const std::string& test_name, const ColorState& input_state,
   CHECK(out_image->get_chroma_format() == target_state.chroma);
   CHECK(out_image->has_alpha() == target_state.has_alpha);
   for (const Plane& plane : GetPlanes(target_state, width, height)) {
-    INFO("Plane " << plane.channel);
+    INFO("Channel: " << plane.channel);
     int stride;
     CHECK(out_image->get_plane(plane.channel, &stride) != nullptr);
     CHECK(out_image->get_bits_per_pixel(plane.channel) ==
@@ -217,15 +261,30 @@ void TestConversion(const std::string& test_name, const ColorState& input_state,
         reverse_pipeline.convert_image(out_image);
     REQUIRE(recovered_image != nullptr);
     bool skip_alpha = !input_state.has_alpha || !target_state.has_alpha;
-    double expected_psnr = input_state.colorspace == target_state.colorspace ? 100. : 45.;
+    bool expect_lossless =
+        input_state.colorspace == target_state.colorspace &&
+        input_state.bits_per_pixel == target_state.bits_per_pixel &&
+        (input_state.chroma == target_state.chroma ||
+         (input_state.chroma != heif_chroma_420 &&
+          input_state.chroma != heif_chroma_422 &&
+          target_state.chroma != heif_chroma_420 &&
+          target_state.chroma != heif_chroma_422));
+    double expected_psnr = expect_lossless ? 100. : 40.;
+
     for (const Plane& plane : GetPlanes(input_state, width, height)) {
       if (skip_alpha && plane.channel == heif_channel_Alpha) continue;
-      INFO("Plane " << plane.channel);
+      INFO("Channel: " << plane.channel);
+      INFO("Original:\n" << PrintChannel(*in_image, plane.channel));
+      INFO("Recovered:\n" << PrintChannel(*recovered_image, plane.channel));
+      for (const Plane& converted_plane :
+           GetPlanes(target_state, width, height)) {
+        UNSCOPED_INFO("Converted channel "
+                      << converted_plane.channel << ":\n"
+                      << PrintChannel(*out_image, converted_plane.channel));
+      }
       double psnr = GetPsnr(*in_image, *recovered_image, plane.channel, skip_alpha);
       CHECK(psnr >= expected_psnr);
     }
-  } else {
-    WARN("no reverse conversion available to test round trip");
   }
 }
 
@@ -238,60 +297,113 @@ void TestFailingConversion(const std::string& test_name,
       pipeline.construct_pipeline(input_state, target_state, options));
 }
 
-TEST_CASE("Color conversion", "[heif_image]") {
+// Returns the list of valid heif_chroma values for a given colorspace.
+std::vector<heif_chroma> GetValidChroma(heif_colorspace colorspace) {
+  switch (colorspace) {
+    case heif_colorspace_YCbCr:
+      return {/*heif_chroma_monochrome, */heif_chroma_420, heif_chroma_422,
+              heif_chroma_444};
+    case heif_colorspace_RGB:
+      return {heif_chroma_444,
+              heif_chroma_interleaved_RGB,
+              heif_chroma_interleaved_RGBA,
+              heif_chroma_interleaved_RRGGBB_BE,
+              heif_chroma_interleaved_RRGGBBAA_BE,
+              heif_chroma_interleaved_RRGGBB_LE,
+              heif_chroma_interleaved_RRGGBBAA_LE};
+    case heif_colorspace_monochrome:
+      return {heif_chroma_monochrome};
+    default:
+      return {};
+  }
+}
+
+// Returns the list of valid has_alpha values for a given heif_chroma.
+std::vector<bool> GetValidHasAlpha(heif_chroma chroma) {
+  switch (chroma) {
+    case heif_chroma_monochrome:
+    case heif_chroma_420:
+    case heif_chroma_422:
+    case heif_chroma_444:
+      return {false, true};
+    case heif_chroma_interleaved_RGB:
+    case heif_chroma_interleaved_RRGGBB_BE:
+    case heif_chroma_interleaved_RRGGBB_LE:
+      return {false};
+    case heif_chroma_interleaved_RGBA:
+    case heif_chroma_interleaved_RRGGBBAA_BE:
+    case heif_chroma_interleaved_RRGGBBAA_LE:
+      return {true};
+    default:
+      return {};
+  }
+}
+
+// Returns some valid bits per pixels values for a given heif_chroma.
+std::vector<int> GetValidBitsPerPixel(heif_chroma chroma) {
+  const std::vector<int> sdr = {8};
+  const std::vector<int> hdr = {12};
+  const std::vector<int> both = {8, 12};
+  switch (chroma) {
+    case heif_chroma_monochrome:
+    case heif_chroma_420:
+    case heif_chroma_422:
+    case heif_chroma_444:
+      return both;
+    case heif_chroma_interleaved_RGB:
+    case heif_chroma_interleaved_RGBA:
+      return sdr;
+    case heif_chroma_interleaved_RRGGBB_BE:
+    case heif_chroma_interleaved_RRGGBB_LE:
+    case heif_chroma_interleaved_RRGGBBAA_BE:
+    case heif_chroma_interleaved_RRGGBBAA_LE:
+      return hdr;
+    default:
+      return {};
+  }
+}
+
+// Returns of list of all valid ColorState (valid combinations
+// of a heif_colorspace/heif_chroma/has_alpha/bpp).
+std::vector<ColorState> GetAllColorStates() {
+  std::vector<ColorState> color_states;
+  for (heif_colorspace colorspace : {heif_colorspace_YCbCr, heif_colorspace_RGB, heif_colorspace_monochrome}) {
+    for (heif_chroma chroma : GetValidChroma(colorspace)) {
+      for (bool has_alpha : GetValidHasAlpha(chroma)) {
+        for (int bits_per_pixel : GetValidBitsPerPixel(chroma)) {
+          ColorState color_state(colorspace, chroma, has_alpha, bits_per_pixel);
+          color_states.push_back(color_state);
+        }
+      }
+    }
+  }
+  return color_states;
+}
+
+TEST_CASE("All conversions", "[heif_image]") {
   heif_color_conversion_options basic_options = {
       .preferred_chroma_downsampling_algorithm =
           heif_chroma_downsampling_average,
       .preferred_chroma_upsampling_algorithm = heif_chroma_upsampling_bilinear,
       .only_use_preferred_chroma_algorithm = false};
 
-  TestConversion("### RGB planes -> interleaved",
-                 {heif_colorspace_RGB, heif_chroma_444, false, 8},
-                 {heif_colorspace_RGB, heif_chroma_interleaved_RGB, false, 8},
-                 basic_options);
+  // Test all source and destination state combinations.
+  ColorState src_state = GENERATE(from_range(GetAllColorStates()));
+  ColorState dst_state = GENERATE(from_range(GetAllColorStates()));
+  // To debug a particular combination, hardcoe the ColorState values
+  // instead:
+  // ColorState src_state(heif_colorspace_YCbCr, heif_chroma_420, false, 8);
+  // ColorState dst_state = ...
 
-  TestConversion("### YCbCr420 -> RGB",
-                 {heif_colorspace_YCbCr, heif_chroma_420, false, 8},
-                 {heif_colorspace_RGB, heif_chroma_interleaved_RGB, false, 8},
-                 basic_options);
+  // Converting to monochrome is not supported at the moment.
+  if (dst_state.colorspace == heif_colorspace_monochrome) return;
 
-  TestConversion("### YCbCr420 -> RGBA",
-                 {heif_colorspace_YCbCr, heif_chroma_420, false, 8},
-                 {heif_colorspace_RGB, heif_chroma_interleaved_RGBA, true, 8},
-                 basic_options);
+  std::ostringstream os;
+  os << "from: " << src_state << "\nto:   " << dst_state;
+  TestConversion(os.str(), src_state, dst_state, basic_options);
+}
 
-  TestConversion("### YCbCr420 10bit -> RGB planes 10bit",
-                 {heif_colorspace_YCbCr, heif_chroma_420, false, 10},
-                 {heif_colorspace_RGB, heif_chroma_444, false, 10},
-                 basic_options);
-
-  TestConversion(
-      "### RGB planes 10bit -> interleaved big endian",
-      {heif_colorspace_RGB, heif_chroma_444, false, 10},
-      {heif_colorspace_RGB, heif_chroma_interleaved_RRGGBBAA_BE, true, 10},
-      basic_options);
-
-  TestConversion(
-      "### RGB planes 10bit -> interleaved little endian",
-      {heif_colorspace_RGB, heif_chroma_444, false, 10},
-      {heif_colorspace_RGB, heif_chroma_interleaved_RRGGBBAA_LE, true, 10},
-      basic_options);
-
-  TestConversion("### monochrome colorspace -> interleaved RGB",
-                 {heif_colorspace_monochrome, heif_chroma_monochrome, false, 8},
-                 {heif_colorspace_RGB, heif_chroma_interleaved_RGB, false, 8},
-                 basic_options);
-
-  TestConversion("### monochrome colorspace -> RGBA",
-                 {heif_colorspace_monochrome, heif_chroma_monochrome, false, 8},
-                 {heif_colorspace_RGB, heif_chroma_interleaved_RGBA, true, 8},
-                 basic_options);
-
-  TestConversion("### interleaved RGBA -> YCbCr 420",
-                 {heif_colorspace_RGB, heif_chroma_interleaved_RGBA, true, 8},
-                 {heif_colorspace_YCbCr, heif_chroma_420, false, 8},
-                 basic_options);
-
+TEST_CASE("Sharp yuv conversion", "[heif_image]") {
   heif_color_conversion_options sharp_yuv_options{
       .preferred_chroma_downsampling_algorithm =
           heif_chroma_downsampling_sharp_yuv,
@@ -348,50 +460,4 @@ TEST_CASE("Color conversion", "[heif_image]") {
       "### interleaved RGBA -> YCbCr 422 with sharp yuv (not supported!)",
       {heif_colorspace_RGB, heif_chroma_interleaved_RGBA, true, 8},
       {heif_colorspace_YCbCr, heif_chroma_422, false, 8}, sharp_yuv_options);
-
-  TestConversion(
-      "### RGB planes 10bit -> interleaved RGB 10bit little endian",
-      {heif_colorspace_RGB, heif_chroma_444, false, 10},
-      {heif_colorspace_RGB, heif_chroma_interleaved_RRGGBB_LE, false, 10},
-      basic_options);
-
-  TestConversion(
-      "### interleaved RGB 12bit little endian -> RGB planes 12bit",
-      {heif_colorspace_RGB, heif_chroma_interleaved_RRGGBB_LE, false, 12},
-      {heif_colorspace_RGB, heif_chroma_444, false, 12}, basic_options);
-
-  TestConversion("### RGB planes 12bit -> YCbCr 420 12bit",
-                 {heif_colorspace_RGB, heif_chroma_444, false, 12},
-                 {heif_colorspace_YCbCr, heif_chroma_420, false, 12},
-                 basic_options);
-
-  TestConversion(
-      "### interleaved RGB 12bit big endian -> YCbCr 420 12bit",
-      {heif_colorspace_RGB, heif_chroma_interleaved_RRGGBB_BE, false, 12},
-      {heif_colorspace_YCbCr, heif_chroma_420, false, 12}, basic_options);
-
-  TestConversion(
-      "### interleaved RGB 12bit little endian -> YCbCr 420 12bit",
-      {heif_colorspace_RGB, heif_chroma_interleaved_RRGGBB_LE, false, 12},
-      {heif_colorspace_YCbCr, heif_chroma_420, false, 12}, basic_options);
-
-  TestConversion("### monochrome YCbCr -> interleaved RGB",
-                 {heif_colorspace_YCbCr, heif_chroma_monochrome, false, 8},
-                 {heif_colorspace_RGB, heif_chroma_interleaved_RGB, false, 8},
-                 basic_options);
-
-  TestConversion("### monochrome YCbCr -> YCbCr with alpha",
-                 {heif_colorspace_monochrome, heif_chroma_monochrome, false, 8},
-                 {heif_colorspace_YCbCr, heif_chroma_444, true, 8},
-                 basic_options);
-
-  TestConversion("### monochrome YCbCr -> YCbCr 420",
-                 {heif_colorspace_monochrome, heif_chroma_monochrome, false, 8},
-                 {heif_colorspace_YCbCr, heif_chroma_420, false, 8},
-                 basic_options);
-
-  TestConversion("### monochrome YCbCr -> YCbCr 420 with alpha",
-                 {heif_colorspace_monochrome, heif_chroma_monochrome, false, 8},
-                 {heif_colorspace_YCbCr, heif_chroma_420, true, 8},
-                 basic_options);
 }


### PR DESCRIPTION
Fix uncovered bugs/inconsistencies:
- make sure we don't downsample to 420 unless necessary
- fix sign in Op_YCbCr420_to_RRGGBBaa
- for monochrome, only accept heif_colorspace_monochrome+heif_chroma_monochrome (WARNING: behavior change, previously heif_colorspace_YCbCr+heif_chroma_monochrome was also valid)