### PR TITLE
ci: attempt to fix windows build on appveyor

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -56,9 +56,11 @@
 #else
 
 #include <unistd.h>
-#include <cassert>
 
 #endif
+
+#include <cassert>
+
 
 using namespace heif;
 


### PR DESCRIPTION
Note: we use `<cassert>` in other places that aren't guarded, so it should be safe outside the windows section here.