### PR TITLE
Allow callers to get the number of properties

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1838,10 +1838,6 @@ int heif_item_get_properties_of_type(const struct heif_context* context,
     return 0;
   }
 
-  if (out_list == nullptr) {
-    return 0;
-  }
-
   int out_idx = 0;
   int property_id = 1;
 
@@ -1882,10 +1878,6 @@ int heif_item_get_transformation_properties(const struct heif_context* context,
   Error err = file->get_properties(id, properties);
   if (err) {
     // We do not pass the error, because a missing ipco should have been detected already when reading the file.
-    return 0;
-  }
-
-  if (out_list == nullptr) {
     return 0;
   }
 

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -999,6 +999,8 @@ enum heif_item_property_type
 // Get the heif_property_id for a heif_item_id.
 // You may specify which property 'type' you want to receive.
 // If you specify 'heif_item_property_type_invalid', all properties associated to that item are returned.
+// The number of properties is returned, which are not more than 'count' if (out_list != nullptr).
+// By setting out_list==nullptr, you can query the number of properties, 'count' is ignored.
 LIBHEIF_API
 int heif_item_get_properties_of_type(const struct heif_context* context,
                                      heif_item_id id,
@@ -1008,6 +1010,8 @@ int heif_item_get_properties_of_type(const struct heif_context* context,
 
 // Returns all transformative properties in the correct order.
 // This includes "irot", "imir", "clap".
+// The number of properties is returned, which are not more than 'count' if (out_list != nullptr).
+// By setting out_list==nullptr, you can query the number of properties, 'count' is ignored.
 LIBHEIF_API
 int heif_item_get_transformation_properties(const struct heif_context* context,
                                             heif_item_id id,


### PR DESCRIPTION
The code to count the number of properties when out_list == nullptr was being skipped due to a null pointer check on that parameter.

Updated the header documentation for heif_item_get_properties_of_type and heif_item_get_transformation_properties to reflect this change.