### PR TITLE
README: cmake parameter order

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The basic build steps are as follows:
 ````
 mkdir build
 cd build
-cmake .. --preset=release
+cmake --preset=release ..
 make
 ````
 
@@ -149,7 +149,7 @@ This can be done, for example, by calling `ccmake .` from within the `build` dir
     ```
     mkdir build
     cd build
-    cmake .. --preset=release
+    cmake --preset=release ..
     ./configure
     make
     ```


### PR DESCRIPTION
At least on my Debian Docker image the build failed with the previous parameter order. The official man page also says the options should be given first before the path.

`cmake [<options>] <path-to-source | path-to-existing-build>`

https://cmake.org/cmake/help/latest/manual/cmake.1.html