### PR TITLE
uncompressed: initial work on encoder

### DIFF
--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -111,7 +111,7 @@ static struct option long_options[] = {
     {(char* const) "even-size",               no_argument,       0,              'E'},
     {(char* const) "avif",                    no_argument,       0,              'A'},
     {(char* const) "jpeg",                    no_argument,       0,              OPTION_USE_JPEG_COMPRESSION},
-#if false && WITH_UNCOMPRESSED_CODEC
+#if WITH_UNCOMPRESSED_CODEC
     {(char* const) "uncompressed",                no_argument,       0,                     'U'},
 #endif
     {(char* const) "matrix_coefficients",     required_argument, 0,              OPTION_NCLX_MATRIX_COEFFICIENTS},
@@ -156,7 +156,7 @@ void show_help(const char* argv0)
             << "  -p                    set encoder parameter (NAME=VALUE)\n"
             << "  -A, --avif            encode as AVIF (not needed if output filename with .avif suffix is provided)\n"
             << "      --jpeg            encode as JPEG\n"
-#if false && WITH_UNCOMPRESSED_CODEC
+#if WITH_UNCOMPRESSED_CODEC
             << "  -U, --uncompressed    encode as uncompressed image (according to ISO 23001-17) (EXPERIMENTAL)\n"
 #endif
             << "      --list-encoders         list all available encoders for all compression formats\n"
@@ -347,8 +347,8 @@ static void show_list_of_encoders(const heif_encoder_descriptor* const* encoder_
 static void show_list_of_all_encoders()
 {
   for (auto compression_format : {heif_compression_HEVC, heif_compression_AV1, heif_compression_JPEG
-#if false && WITH_UNCOMPRESSED_CODEC
-      , heif_compression_uncompressed
+#if WITH_UNCOMPRESSED_CODEC
+, heif_compression_uncompressed
 #endif
   }) {
 
@@ -361,6 +361,9 @@ static void show_list_of_all_encoders()
         break;
       case heif_compression_JPEG:
         std::cout << "JPEG";
+        break;
+      case heif_compression_uncompressed:
+        std::cout << "Uncompressed";
         break;
       default:
         assert(false);
@@ -440,7 +443,7 @@ int main(int argc, char** argv)
   while (true) {
     int option_index = 0;
     int c = getopt_long(argc, argv, "hq:Lo:vPp:t:b:AEe:C:"
-#if false && WITH_UNCOMPRESSED_CODEC
+#if WITH_UNCOMPRESSED_CODEC
         "U"
 #endif
         , long_options, &option_index);
@@ -481,7 +484,7 @@ int main(int argc, char** argv)
       case 'A':
         force_enc_av1f = true;
         break;
-#if false && WITH_UNCOMPRESSED_CODEC
+#if WITH_UNCOMPRESSED_CODEC
         case 'U':
         force_enc_uncompressed = true;
         break;

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -2874,7 +2874,7 @@ Error HeifContext::encode_image_as_uncompressed(const std::shared_ptr<HeifPixelI
                                                 struct heif_encoder* encoder,
                                                 const struct heif_encoding_options& options,
                                                 enum heif_image_input_class input_class,
-                                                std::shared_ptr<Image> out_image)
+                                                std::shared_ptr<Image>& out_image)
 {
 #if WITH_UNCOMPRESSED_CODEC
   heif_item_id image_id = m_heif_file->add_new_image("unci");

--- a/libheif/context.h
+++ b/libheif/context.h
@@ -409,7 +409,7 @@ public:
                                      struct heif_encoder* encoder,
                                      const struct heif_encoding_options& options,
                                      enum heif_image_input_class input_class,
-                                     std::shared_ptr<Image> out_image);
+                                     std::shared_ptr<Image>& out_image);
 
   Error encode_image_as_mask(const std::shared_ptr<HeifPixelImage>& src_image,
                              struct heif_encoder* encoder,

--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -172,6 +172,13 @@ void HeifFile::set_brand(heif_compression_format format, bool miaf_compatible)
       m_ftyp_box->add_compatible_brand(heif_brand2_mif1);
       break;
 
+    case heif_compression_uncompressed:
+      // Not clear what the correct major brand should be
+      m_ftyp_box->set_major_brand(heif_brand2_mif2);
+      m_ftyp_box->set_minor_version(0);
+      m_ftyp_box->add_compatible_brand(heif_brand2_mif1);
+      break;
+
     default:
       break;
   }
@@ -1126,7 +1133,6 @@ void HeifFile::set_hdlr_library_info(const std::string& encoder_plugin_version)
   sstr << "libheif (" << LIBHEIF_VERSION << ") / " << encoder_plugin_version;
   m_hdlr_box->set_name(sstr.str());
 }
-
 
 #if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
 std::wstring HeifFile::convert_utf8_path_to_utf16(std::string str)

--- a/libheif/uncompressed_image.cc
+++ b/libheif/uncompressed_image.cc
@@ -922,9 +922,11 @@ Error UncompressedImageCodec::encode_uncompressed_image(const std::shared_ptr<He
     {
       int src_stride;
       uint8_t* src_data = src_image->get_plane(channel, &src_stride);
-      uint64_t out_size = src_image->get_height() * src_stride;
+      uint64_t out_size = src_image->get_height() * src_image->get_width();
       data.resize(data.size() + out_size);
-      memcpy(data.data() + offset, src_data, out_size);
+      for (int y = 0; y < src_image->get_height(); y++) {
+        memcpy(data.data() + offset + y * src_image->get_width(), src_data + src_stride * y, src_image->get_width());
+      }
       offset += out_size;
     }
     heif_file->append_iloc_data(out_image->get_id(), data, 0);

--- a/libheif/uncompressed_image.h
+++ b/libheif/uncompressed_image.h
@@ -28,6 +28,7 @@
 #include "file.h"
 #include "context.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>
@@ -53,6 +54,11 @@ public:
 
   const std::vector<Component>& get_components() const { return m_components; }
 
+  void add_component(Component component)
+  {
+    m_components.push_back(component);
+  }
+
 protected:
   Error parse(BitstreamRange& range) override;
 
@@ -64,6 +70,7 @@ class Box_uncC : public FullBox
 public:
   Box_uncC()
   {
+    m_profile = 0;
     set_short_type(fourcc("uncC"));
   }
 
@@ -83,31 +90,108 @@ public:
 
   const std::vector<Component>& get_components() const { return m_components; }
 
-  uint8_t get_sampling_type() { return m_sampling_type; }
+  void add_component(Component component)
+  {
+    m_components.push_back(component);
+  }
 
-  uint8_t get_interleave_type() { return m_interleave_type; }
+  uint32_t get_profile() const { return m_profile; }
 
-  uint8_t get_block_size() { return m_block_size; }
+  void set_profile(const uint32_t profile)
+  {
+    m_profile = profile;
+  }
 
-  bool is_components_little_endian() { return m_components_little_endian; }
+  uint8_t get_sampling_type() const { return m_sampling_type; }
 
-  bool is_block_pad_lsb() { return m_block_pad_lsb; }
+  void set_sampling_type(const uint8_t sampling_type)
+  {
+    m_sampling_type = sampling_type;
+  }
 
-  bool is_block_little_endian() { return m_block_little_endian; }
+  uint8_t get_interleave_type() const { return m_interleave_type; }
 
-  bool is_block_reversed() { return m_block_reversed; }
+  void set_interleave_type(const uint8_t interleave_type)
+  {
+    m_interleave_type = interleave_type;
+  }
 
-  bool is_pad_unknown() { return m_pad_unknown; }
+  uint8_t get_block_size() const { return m_block_size; }
 
-  uint8_t get_pixel_size() { return m_pixel_size; }
+  void set_block_size(const uint8_t block_size)
+  {
+    m_block_size = block_size;
+  }
 
-  uint32_t get_row_align_size() { return m_row_align_size; }
+  bool is_components_little_endian() const { return m_components_little_endian; }
 
-  uint32_t get_tile_align_size() { return m_tile_align_size; }
+  void set_components_little_endian (const bool components_little_endian)
+  {
+    m_components_little_endian = components_little_endian;
+  }
 
-  uint32_t get_number_of_tile_columns() { return m_num_tile_cols_minus_one + 1; }
+  bool is_block_pad_lsb() const { return m_block_pad_lsb; }
 
-  uint32_t get_number_of_tile_rows() { return m_num_tile_rows_minus_one + 1; }
+  void set_block_pad_lsb(const bool block_pad_lsb)
+  {
+    m_block_pad_lsb = block_pad_lsb;
+  }
+
+  bool is_block_little_endian() const { return m_block_little_endian; }
+
+  void set_block_little_endian(const bool block_little_endian)
+  {
+    m_block_little_endian = block_little_endian;
+  }
+
+  bool is_block_reversed() const { return m_block_reversed; }
+
+  void set_block_reversed(const bool block_reversed)
+  {
+    m_block_reversed = block_reversed;
+  }
+
+  bool is_pad_unknown() const { return m_pad_unknown; }
+
+  void set_pad_unknown(const bool pad_unknown)
+  {
+    m_pad_unknown = pad_unknown;
+  }
+
+  uint8_t get_pixel_size() const { return m_pixel_size; }
+
+  void set_pixel_size(const uint8_t pixel_size)
+  {
+    m_pixel_size = pixel_size;
+  }
+
+  uint32_t get_row_align_size() const { return m_row_align_size; }
+
+  void set_row_align_size(const uint32_t row_align_size)
+  {
+    m_row_align_size = row_align_size;
+  }
+
+  uint32_t get_tile_align_size() const { return m_tile_align_size; }
+
+  void set_tile_align_size(const uint32_t tile_align_size)
+  {
+    m_tile_align_size = tile_align_size;
+  }
+
+  uint32_t get_number_of_tile_columns() const { return m_num_tile_cols_minus_one + 1; }
+
+  void set_number_of_tile_columns(const uint32_t num_tile_cols)
+  {
+    m_num_tile_cols_minus_one = num_tile_cols - 1;
+  }
+
+  uint32_t get_number_of_tile_rows() const { return m_num_tile_rows_minus_one + 1; }
+
+  void set_number_of_tile_rows(const uint32_t num_tile_rows)
+  {
+    m_num_tile_rows_minus_one = num_tile_rows - 1;
+  }
 
 protected:
   Error parse(BitstreamRange& range) override;
@@ -147,7 +231,7 @@ public:
                                          const std::shared_ptr<HeifPixelImage>& src_image,
                                          void* encoder_struct,
                                          const struct heif_encoding_options& options,
-                                         std::shared_ptr<HeifContext::Image> out_image);
+                                         std::shared_ptr<HeifContext::Image>& out_image);
 };
 
 #endif //LIBHEIF_UNCOMPRESSED_IMAGE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,4 +27,5 @@ endif()
 add_libheif_test(encode)
 add_libheif_test(region)
 add_libheif_test(uncompressed_decode)
+add_libheif_test(uncompressed_encode)
 

--- a/tests/uncompressed_encode.cc
+++ b/tests/uncompressed_encode.cc
@@ -1,0 +1,836 @@
+/*
+  libheif integration tests for uncompressed encoder
+
+  MIT License
+
+  Copyright (c) 2023 Brad Hards <bradh@frogmouth.net>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include "catch.hpp"
+#include "libheif/api_structs.h"
+#include "libheif/heif.h"
+#include <cstdint>
+#include <string.h>
+#include "test_utils.h"
+
+TEST_CASE("check have uncompressed")
+{
+  struct heif_error err;
+  heif_context *ctx = heif_context_alloc();
+  heif_encoder *enc;
+  err = heif_context_get_encoder_for_format(ctx, heif_compression_uncompressed,
+                                            &enc);
+  REQUIRE(err.code == heif_error_Ok);
+
+  const char *name = heif_encoder_get_name(enc);
+  REQUIRE(strcmp(name, "uncompressed") == 0);
+
+  heif_encoder_release(enc);
+
+  heif_context_free(ctx);
+}
+
+
+struct heif_image *createImage_Mono()
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_monochrome,
+                          heif_chroma_monochrome, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_Y, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+  int stride;
+  uint8_t *p = heif_image_get_plane(image, heif_channel_Y, &stride);
+
+  int y = 0;
+  for (; y < h / 2; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + x] = 255;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + x] = 127;
+    }
+    for (; x < w; x++) {
+      p[y * stride + x] = 1;
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + x] =  (uint8_t) (x % 256);
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + x] = (uint8_t) ((255 - x) % 256);
+    }
+    for (; x < w; x++) {
+      p[y * stride + x] =  (uint8_t) ((x + y) % 256);
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+
+struct heif_image *createImage_YCbCr()
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_YCbCr,
+                          heif_chroma_444, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_Y, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_Cb, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_Cr, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+  int stride;
+  uint8_t *p = heif_image_get_plane(image, heif_channel_Y, &stride);
+  uint8_t *cb = heif_image_get_plane(image, heif_channel_Cb, &stride);
+  uint8_t *cr = heif_image_get_plane(image, heif_channel_Cr, &stride);
+
+  int y = 0;
+  for (; y < h / 2; y++)
+  {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + x] = 255;
+      cb[y * stride + x] = 0;
+      cr[y * stride + x] = 0;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + x] = 127;
+      cb[y * stride + x] = 0;
+      cr[y * stride + x] = 0;
+    }
+    for (; x < w; x++) {
+      p[y * stride + x] = 1;
+      cb[y * stride + x] = 0;
+      cr[y * stride + x] = 0;
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + x] =  255;
+      cb[y * stride + x] = 255;
+      cr[y * stride + x] = 0;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + x] = 255;
+      cb[y * stride + x] = 255;
+      cr[y * stride + x] = 255;
+    }
+    for (; x < w; x++) {
+      p[y * stride + x] =  255;
+      cb[y * stride + x] = 0;
+      cr[y * stride + x] = 255;
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+struct heif_image* createImage_Mono_plus_alpha()
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_monochrome,
+                          heif_chroma_monochrome, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_Y, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_Alpha, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+  int stride;
+  uint8_t *p = heif_image_get_plane(image, heif_channel_Y, &stride);
+  uint8_t *a = heif_image_get_plane(image, heif_channel_Alpha, &stride);
+  int y = 0;
+  for (; y < h / 2; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + x] = 255;
+      a[y * stride + x] = 250;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + x] = 127;
+      a[y * stride + x] = 25;
+    }
+    for (; x < w; x++) {
+      p[y * stride + x] = 1;
+      a[y * stride + x] = 252;
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + x] =  (uint8_t) (x % 256);
+      a[y * stride + x] = 253;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + x] = (uint8_t) ((255 - x) % 256);
+      a[y * stride + x] = 254;
+    }
+    for (; x < w; x++) {
+      p[y * stride + x] =  (uint8_t) ((x + y) % 256);
+      a[y * stride + x] = 255;
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+struct heif_image *createImage_RGB_interleaved()
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_RGB,
+                          heif_chroma_interleaved_RGB, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_interleaved, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+  int stride;
+  uint8_t *p = heif_image_get_plane(image, heif_channel_interleaved, &stride);
+
+  int y = 0;
+  for (; y < h / 2; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + 3 * x] = 1;
+      p[y * stride + 3 * x + 1] = 255;
+      p[y * stride + 3 * x + 2] = 2;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + 3 * x] = 4;
+      p[y * stride + 3 * x + 1] = 5;
+      p[y * stride + 3 * x + 2] = 255;
+    }
+    for (; x < w; x++) {
+      p[y * stride + 3 * x] = 255;
+      p[y * stride + 3 * x + 1] = 6;
+      p[y * stride + 3 * x + 2] = 7;
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + 3 * x] = 8;
+      p[y * stride + 3 * x + 1] = 9;
+      p[y * stride + 3 * x + 2] = 255;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + 3 * x] = 253;
+      p[y * stride + 3 * x + 1] = 10;
+      p[y * stride + 3 * x + 2] = 11;
+    }
+    for (; x < w; x++) {
+      p[y * stride + 3 * x] = 13;
+      p[y * stride + 3 * x + 1] = 252;
+      p[y * stride + 3 * x + 2] = 12;
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+
+void set_pixel_on_48bpp(uint8_t* p, int y, int stride, int x, int red, int green, int blue, bool little_endian, int alpha)
+{
+  uint8_t red_low_byte = (uint8_t)(red & 0xFF);
+  uint8_t red_high_byte = (uint8_t)(red >> 8);
+  uint8_t green_low_byte = (uint8_t)(green & 0xFF);
+  uint8_t green_high_byte = (uint8_t)(green >> 8);
+  uint8_t blue_low_byte = (uint8_t)(blue & 0xFF);
+  uint8_t blue_high_byte = (uint8_t)(blue >> 8);
+  uint8_t alpha_low_byte = (uint8_t)(alpha & 0xFF);
+  uint8_t alpha_high_byte = (uint8_t)(alpha >> 8);
+  int bytes_per_pixel = 6;
+  if (alpha != 0)
+  {
+    bytes_per_pixel = 8;
+  }
+  if (little_endian)
+  {
+    p[y * stride + x * bytes_per_pixel + 0] = red_low_byte;
+    p[y * stride + x * bytes_per_pixel + 1] = red_high_byte;
+    p[y * stride + x * bytes_per_pixel + 2] = green_low_byte;
+    p[y * stride + x * bytes_per_pixel + 3] = green_high_byte;
+    p[y * stride + x * bytes_per_pixel + 4] = blue_low_byte;
+    p[y * stride + x * bytes_per_pixel + 5] = blue_high_byte;
+    if (alpha != 0)
+    {
+      p[y * stride + x * bytes_per_pixel + 6] = alpha_low_byte;
+      p[y * stride + x * bytes_per_pixel + 7] = alpha_high_byte;
+    }
+  }
+  else
+  {
+    p[y * stride + x * bytes_per_pixel + 0] = red_high_byte;
+    p[y * stride + x * bytes_per_pixel + 1] = red_low_byte;
+    p[y * stride + x * bytes_per_pixel + 2] = green_high_byte;
+    p[y * stride + x * bytes_per_pixel + 3] = green_low_byte;
+    p[y * stride + x * bytes_per_pixel + 4] = blue_high_byte;
+    p[y * stride + x * bytes_per_pixel + 5] = blue_low_byte;
+    if (alpha != 0)
+    {
+      p[y * stride + x * bytes_per_pixel + 6] = alpha_high_byte;
+      p[y * stride + x * bytes_per_pixel + 7] = alpha_low_byte;
+    }
+  }
+}
+
+struct heif_image *createImage_RRGGBB_interleaved(heif_chroma chroma, int bit_depth, bool little_endian, bool with_alpha)
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_RGB, chroma, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  int max_value = 0;
+  for (int i = 0; i < bit_depth; i++)
+  {
+    max_value |= (1 << i);
+  }
+  int mid_value = max_value / 2;
+  int alpha = 0;
+  int alpha_mid = 0;
+  if (with_alpha)
+  {
+    alpha = max_value;
+    alpha_mid = mid_value;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_interleaved, w, h, bit_depth);
+  REQUIRE(err.code == heif_error_Ok);
+
+  int stride;
+  uint8_t *p = heif_image_get_plane(image, heif_channel_interleaved, &stride);
+
+  int y = 0;
+  for (; y < h / 2; y++) {
+    int x = 0;
+    for (; x < w / 4; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, 0x0000, 0x0000, max_value, little_endian, alpha);
+    }
+    for (; x < 2 * w / 4; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, 0x0000, max_value, 0x0000, little_endian, alpha);
+    }
+    for (; x < 3 * w / 4; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, max_value, 0x0000, 0x0000, little_endian, alpha);
+    }
+    for (; x < w; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, max_value - 2, max_value - 1, max_value, little_endian, alpha);
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 4; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, 0x0000, max_value, 0x0000, little_endian, alpha_mid);
+    }
+    for (; x < 2 * w / 4; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, max_value, 0x0000, 0x0000, little_endian, alpha_mid);
+    }
+    for (; x < 3 * w / 4; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, 0x0000, 0x0000, max_value, little_endian, alpha_mid);
+    }
+    for (; x < w; x++)
+    {
+      set_pixel_on_48bpp(p, y, stride, x, mid_value - 2, mid_value -1, mid_value, little_endian, alpha_mid);
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+struct heif_image *createImage_RGBA_interleaved()
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_RGB,
+                          heif_chroma_interleaved_RGBA, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_interleaved, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+  int stride;
+  uint8_t *p = heif_image_get_plane(image, heif_channel_interleaved, &stride);
+
+  int y = 0;
+  for (; y < h / 2; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + 4 * x] = 1;
+      p[y * stride + 4 * x + 1] = 255;
+      p[y * stride + 4 * x + 2] = 2;
+      p[y * stride + 4 * x + 3] = 255;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + 4 * x] = 4;
+      p[y * stride + 4 * x + 1] = 5;
+      p[y * stride + 4 * x + 2] = 255;
+      p[y * stride + 4 * x + 3] = 128;
+    }
+    for (; x < w; x++) {
+      p[y * stride + 4 * x] = 255;
+      p[y * stride + 4 * x + 1] = 6;
+      p[y * stride + 4 * x + 2] = 7;
+      p[y * stride + 4 * x + 3] = 200;
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      p[y * stride + 4 * x] = 8;
+      p[y * stride + 4 * x + 1] = 9;
+      p[y * stride + 4 * x + 2] = 255;
+      p[y * stride + 4 * x + 3] = 254;
+    }
+    for (; x < 2 * w / 3; x++) {
+      p[y * stride + 4 * x] = 253;
+      p[y * stride + 4 * x + 1] = 10;
+      p[y * stride + 4 * x + 2] = 11;
+      p[y * stride + 4 * x + 3] = 253;
+    }
+    for (; x < w; x++) {
+      p[y * stride + 4 * x] = 13;
+      p[y * stride + 4 * x + 1] = 252;
+      p[y * stride + 4 * x + 2] = 12;
+      p[y * stride + 4 * x + 3] = 250;
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+
+struct heif_image *createImage_RGB_planar()
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_RGB,
+                          heif_chroma_444, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_R, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_G, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_B, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+
+  int stride;
+  uint8_t *r = heif_image_get_plane(image, heif_channel_R, &stride);
+  uint8_t *g = heif_image_get_plane(image, heif_channel_G, &stride);
+  uint8_t *b = heif_image_get_plane(image, heif_channel_B, &stride);
+
+  int y = 0;
+  for (; y < h / 2; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      r[y * stride + x] = 1;
+      g[y * stride + x] = 255;
+      b[y * stride + x] = 2;
+    }
+    for (; x < 2 * w / 3; x++) {
+      r[y * stride + x] = 4;
+      g[y * stride + x] = 5;
+      b[y * stride + x] = 255;
+    }
+    for (; x < w; x++) {
+      r[y * stride + x] = 255;
+      g[y * stride + x] = 6;
+      b[y * stride + x] = 7;
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      r[y * stride + x]= 8;
+      g[y * stride + x] = 9;
+      b[y * stride + x] = 255;
+    }
+    for (; x < 2 * w / 3; x++) {
+      r[y * stride + x] = 253;
+      g[y * stride + x] = 10;
+      b[y * stride + x] = 11;
+    }
+    for (; x < w; x++) {
+      r[y * stride + x] = 13;
+      g[y * stride + x] = 252;
+      b[y * stride + x] = 12;
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+
+struct heif_image *createImage_RGBA_planar()
+{
+  struct heif_image *image;
+  struct heif_error err;
+  int w = 1024;
+  int h = 768;
+  err = heif_image_create(w, h, heif_colorspace_RGB,
+                          heif_chroma_444, &image);
+  if (err.code) {
+    return nullptr;
+  }
+
+  err = heif_image_add_plane(image, heif_channel_R, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_G, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_B, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_image_add_plane(image, heif_channel_Alpha, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+
+  int stride;
+  uint8_t *r = heif_image_get_plane(image, heif_channel_R, &stride);
+  uint8_t *g = heif_image_get_plane(image, heif_channel_G, &stride);
+  uint8_t *b = heif_image_get_plane(image, heif_channel_B, &stride);
+  uint8_t *a = heif_image_get_plane(image, heif_channel_Alpha, &stride);
+
+  int y = 0;
+  for (; y < h / 2; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      r[y * stride + x] = 1;
+      g[y * stride + x] = 255;
+      b[y * stride + x] = 2;
+      a[y * stride + x] = 240;
+    }
+    for (; x < 2 * w / 3; x++) {
+      r[y * stride + x] = 4;
+      g[y * stride + x] = 5;
+      b[y * stride + x] = 255;
+      a[y * stride + x] = 128;
+    }
+    for (; x < w; x++) {
+      r[y * stride + x] = 255;
+      g[y * stride + x] = 6;
+      b[y * stride + x] = 7;
+      a[y * stride + x] = 241;
+    }
+  }
+  for (; y < h; y++) {
+    int x = 0;
+    for (; x < w / 3; x++) {
+      r[y * stride + x]= 8;
+      g[y * stride + x] = 9;
+      b[y * stride + x] = 255;
+      a[y * stride + x] = 242;
+    }
+    for (; x < 2 * w / 3; x++) {
+      r[y * stride + x] = 253;
+      g[y * stride + x] = 10;
+      b[y * stride + x] = 11;
+      a[y * stride + x] = 243;
+    }
+    for (; x < w; x++) {
+      r[y * stride + x] = 13;
+      g[y * stride + x] = 252;
+      b[y * stride + x] = 12;
+      a[y * stride + x] = 244;
+    }
+  }
+  if (err.code) {
+    heif_image_release(image);
+    return nullptr;
+  }
+
+  return image;
+}
+
+static void do_encode(heif_image* input_image, const char* filename, bool check_decode)
+{
+  REQUIRE(input_image != nullptr);
+
+  heif_context *ctx = heif_context_alloc();
+  heif_encoder *encoder;
+  struct heif_error err;
+  err = heif_context_get_encoder_for_format(ctx, heif_compression_uncompressed, &encoder);
+  REQUIRE(err.code == heif_error_Ok);
+
+  struct heif_encoding_options *options;
+  options = heif_encoding_options_alloc();
+  options->macOS_compatibility_workaround = false;
+  options->macOS_compatibility_workaround_no_nclx_profile = true;
+  options->image_orientation = heif_orientation_normal;
+  heif_image_handle *output_image_handle;
+
+  err = heif_context_encode_image(ctx, input_image, encoder, options, &output_image_handle);
+  REQUIRE(err.code == heif_error_Ok);
+  err = heif_context_write_to_file(ctx, filename);
+  REQUIRE(err.code == heif_error_Ok);
+
+  if (check_decode)
+  {
+    // read file back in
+    struct heif_context* decode_context;
+    decode_context = heif_context_alloc();
+    err = heif_context_read_from_file(decode_context, filename, NULL);
+    REQUIRE(err.code == heif_error_Ok);
+    heif_image_handle *decode_image_handle = get_primary_image_handle(decode_context);
+    int ispe_width = heif_image_handle_get_ispe_width(decode_image_handle);
+    // TODO: check against input_image ispe width and height if we can
+    REQUIRE(ispe_width == 1024);
+    int ispe_height = heif_image_handle_get_ispe_height(decode_image_handle);
+    REQUIRE(ispe_height == 768);
+    int width = heif_image_handle_get_width(decode_image_handle);
+    REQUIRE(width == heif_image_get_primary_width(input_image));
+    int height = heif_image_handle_get_height(decode_image_handle);
+    REQUIRE(height == heif_image_get_primary_height(input_image));
+    heif_image* decode_image;
+    err = heif_decode_image(decode_image_handle, &decode_image, heif_colorspace_undefined, heif_chroma_undefined, NULL);
+    REQUIRE(err.code == heif_error_Ok);
+    // REQUIRE(heif_image_has_channel(input_image, heif_channel_Y) == heif_image_has_channel(decode_image, heif_channel_Y));
+    REQUIRE(heif_image_has_channel(input_image, heif_channel_Cb) == heif_image_has_channel(decode_image, heif_channel_Cb));
+    REQUIRE(heif_image_has_channel(input_image, heif_channel_Cr) == heif_image_has_channel(decode_image, heif_channel_Cr));
+    // REQUIRE(heif_image_has_channel(input_image, heif_channel_R) == heif_image_has_channel(decode_image, heif_channel_R));
+    // REQUIRE(heif_image_has_channel(input_image, heif_channel_G) == heif_image_has_channel(decode_image, heif_channel_G));
+    // REQUIRE(heif_image_has_channel(input_image, heif_channel_B) == heif_image_has_channel(decode_image, heif_channel_B));
+    // REQUIRE(heif_image_has_channel(input_image, heif_channel_Alpha) == heif_image_has_channel(decode_image, heif_channel_Alpha));
+    // REQUIRE(heif_image_has_channel(input_image, heif_channel_interleaved) == heif_image_has_channel(decode_image, heif_channel_interleaved));
+    // TODO: make proper test for interleave to component translation
+
+    // TODO: compare values
+    heif_image_handle_release(decode_image_handle);
+    heif_context_free(decode_context);
+  }
+
+  heif_image_handle_release(output_image_handle);
+  heif_encoding_options_free(options);
+  heif_encoder_release(encoder);
+  heif_image_release(input_image);
+
+  heif_context_free(ctx);
+}
+
+TEST_CASE("Encode RGB")
+{
+  heif_image *input_image = createImage_RGB_interleaved();
+  do_encode(input_image, "encode_rgb.heif", true);
+}
+
+
+TEST_CASE("Encode Mono")
+{
+  heif_image* input_image = createImage_Mono();
+  do_encode(input_image, "encode_mono.heif", true);
+}
+
+
+TEST_CASE("Encode Mono with alpha")
+{
+  heif_image* input_image = createImage_Mono_plus_alpha();
+  do_encode(input_image, "encode_mono_plus_alpha.heif", true);
+}
+
+
+TEST_CASE("Encode YCBCr")
+{
+  // TODO: 422 and 420
+  heif_image *input_image = createImage_YCbCr();
+  do_encode(input_image, "encode_YCbCr.heif", true);
+}
+
+
+TEST_CASE("Encode RRRGGBB_LE 10 bit")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBB_LE, 10, true, false);
+  do_encode(input_image, "encode_rrggbb_10_le.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBB_BE 10 bit ")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBB_BE, 10, false, false);
+  do_encode(input_image, "encode_rrggbb_10_be.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBB_LE 12 bit")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBB_LE, 12, true, false);
+  do_encode(input_image, "encode_rrggbb_12_le.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBB_BE 12 bit ")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBB_BE, 12, false, false);
+  do_encode(input_image, "encode_rrggbb_12_be.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBB_LE 16 bit")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBB_LE, 16, true, false);
+  do_encode(input_image, "encode_rrggbb_16_le.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBB_BE 16 bit ")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBB_BE, 16, false, false);
+  do_encode(input_image, "encode_rrggbb_16_be.heif", false);
+}
+
+
+TEST_CASE("Encode RGBA")
+{
+  heif_image *input_image = createImage_RGBA_interleaved();
+  do_encode(input_image, "encode_rgba.heif", true);
+}
+
+
+TEST_CASE("Encode RRRGGBBAA_LE 10 bit")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBBAA_LE, 10, true, true);
+  do_encode(input_image, "encode_rrggbbaa_10_le.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBBAA_BE 10 bit ")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBBAA_BE, 10, false, true);
+  do_encode(input_image, "encode_rrggbbaa_10_be.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBBAA_LE 12 bit")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBBAA_LE, 12, true, true);
+  do_encode(input_image, "encode_rrggbbaa_12_le.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBBAA_BE 12 bit ")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBBAA_BE, 12, false, true);
+  do_encode(input_image, "encode_rrggbbaa_12_be.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBBAA_LE 16 bit")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBBAA_LE, 16, true, true);
+  do_encode(input_image, "encode_rrggbbaa_16_le.heif", false);
+}
+
+
+TEST_CASE("Encode RRRGGBBAA_BE 16 bit ")
+{
+  heif_image *input_image = createImage_RRGGBB_interleaved(heif_chroma_interleaved_RRGGBBAA_BE, 16, false, true);
+  do_encode(input_image, "encode_rrggbbaa_16_be.heif", false);
+}
+
+
+TEST_CASE("Encode RGB planar")
+{
+  heif_image *input_image = createImage_RGB_planar();
+  do_encode(input_image, "encode_rgb_planar.heif", true);
+}
+
+
+TEST_CASE("Encode RGBA planar")
+{
+  heif_image *input_image = createImage_RGBA_planar();
+  do_encode(input_image, "encode_rgba_planar.heif", true);
+}


### PR DESCRIPTION
Supports a limited range of inputs. 

Mono and simple RGB pixel interleave work OK.

YCbCr doesn't work correctly - encoded files look to have chroma problems when decoded with gpac and also with my viewer.

Additional work is needed for:

 - [X] RGBA pixel interleave
 - [X] RGB planar
 - [X] RGBA planar
 - [X] Mono + alpha from PNG
 - [ ] Strange image sizes (need to find / create test data)
 - [X] Higher bit depth (need to find / create test data)
 - [X] YCbCr encoding
 - [x] Fix clang warnings

and probably other things...

@farindk would appreciate feedback on the approach if you have time.