### PR TITLE
tests: enable testing where practical

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ endif (DOXYGEN_FOUND)
 
 # --- Testing
 
-option(BUILD_TESTING "" OFF)
+option(BUILD_TESTING "" ON)
 include(CTest)
 if(BUILD_TESTING)
     # TODO: fix tests on windows.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,16 +212,11 @@ endif (DOXYGEN_FOUND)
 
 # --- Testing
 
-# Disable testing by default because this requires building with full symbol visibility (switched off WITH_REDUCED_VISIBILITY).
 option(BUILD_TESTING "" OFF)
 include(CTest)
 if(BUILD_TESTING)
     # TODO: fix tests on windows.
     add_subdirectory (tests)
-endif()
-
-if (BUILD_TESTING AND WITH_REDUCED_VISIBILITY)
-    message(FATAL_ERROR "Tests can only be compiled with full symbol visibility (WITH_REDUCED_VISIBILITY=OFF)")
 endif()
 
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -109,6 +109,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "BUILD_SHARED_LIBS": "OFF",
+        "BUILD_TESTING" : "OFF",
         "WITH_FUZZERS" : "ON",
         "WITH_EXAMPLES" : "OFF",
         "ENABLE_PLUGIN_LOADING" : "OFF",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,13 +14,13 @@ macro(add_libheif_test TEST_FILE)
 endmacro()
 
 if (WITH_REDUCED_VISIBILITY)
-    message("Conversion tests can only be compiled with full symbol visibility (WITH_REDUCED_VISIBILITY=OFF)")
+    message("Conversion and JPEG 2000 box unit tests can only be compiled with full symbol visibility (WITH_REDUCED_VISIBILITY=OFF)")
 else()
     add_libheif_test(conversion)
+    add_libheif_test(jpeg2000)
 endif()
 
 add_libheif_test(encode)
-add_libheif_test(jpeg2000)
 add_libheif_test(region)
 add_libheif_test(uncompressed_decode)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,12 @@ macro(add_libheif_test TEST_FILE)
     add_test(NAME ${TEST_NAME} COMMAND ./${TEST_NAME})
 endmacro()
 
-add_libheif_test(conversion)
+if (WITH_REDUCED_VISIBILITY)
+    message("Conversion tests can only be compiled with full symbol visibility (WITH_REDUCED_VISIBILITY=OFF)")
+else()
+    add_libheif_test(conversion)
+endif()
+
 add_libheif_test(encode)
 add_libheif_test(jpeg2000)
 add_libheif_test(region)

--- a/tests/encode.cc
+++ b/tests/encode.cc
@@ -29,6 +29,8 @@
 #include "libheif/pixelimage.h"
 #include "libheif/api_structs.h"
 
+#include <string.h>
+
 
 struct heif_image* createImage_RRGGBB_BE() {
   struct heif_image* image;
@@ -104,6 +106,20 @@ TEST_CASE( "Encode HDR", "[heif_encoder]" ) {
 }
 #endif
 
+static void fill_new_plane(heif_image* img, heif_channel channel, int w, int h)
+{
+  struct heif_error err;
+
+  err = heif_image_add_plane(img, channel, w, h, 8);
+  REQUIRE(err.code == heif_error_Ok);
+
+  int stride;
+  uint8_t* p = heif_image_get_plane(img, channel, &stride);
+
+  for (int y = 0; y < h; y++) {
+    memset(p + y * stride, 128, w);
+  }
+}
 
 static void test_ispe_size(heif_compression_format compression,
                            heif_orientation orientation,
@@ -114,9 +130,9 @@ static void test_ispe_size(heif_compression_format compression,
 
   heif_image* img;
   heif_image_create(input_width,input_height, heif_colorspace_YCbCr, heif_chroma_420, &img);
-  img->image->fill_new_plane(heif_channel_Y, 128, input_width,input_height, 8);
-  img->image->fill_new_plane(heif_channel_Cb, 128, (input_width+1)/2,(input_height+1)/2, 8);
-  img->image->fill_new_plane(heif_channel_Cr, 128, (input_width+1)/2,(input_height+1)/2, 8);
+  fill_new_plane(img, heif_channel_Y, input_width, input_height);
+  fill_new_plane(img, heif_channel_Cb, (input_width+1)/2, (input_height+1)/2);
+  fill_new_plane(img, heif_channel_Cr, (input_width+1)/2, (input_height+1)/2);
 
   heif_context* ctx = heif_context_alloc();
   heif_encoder* enc;


### PR DESCRIPTION
[This is a somewhat speculative change - could see the case for backing some of it out]

Prior to this change, tests were only available if reduced symbol visibility was disabled.

That wasn't needed for the uncompressed codec tests. With a small change, it also isn't really needed for the encode tests.