### PR TITLE
example: fix heif-enc encoder option

### DIFF
--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -104,7 +104,7 @@ static struct option long_options[] = {
     {(char* const) "no-alpha",                no_argument,       &master_alpha,  0},
     {(char* const) "no-thumb-alpha",          no_argument,       &thumb_alpha,   0},
     {(char* const) "list-encoders",           no_argument,       &list_encoders, 1},
-    {(char* const) "encoder",                 no_argument,       0,              'e'},
+    {(char* const) "encoder",                 required_argument, 0,              'e'},
     {(char* const) "bit-depth",               required_argument, 0,              'b'},
     {(char* const) "even-size",               no_argument,       0,              'E'},
     {(char* const) "avif",                    no_argument,       0,              'A'},


### PR DESCRIPTION
Using the heif-enc `--encoder ID` option (prior to this PR) produces:

```
$ ./heif-enc --encoder x265 something.png
Can't open x265
```

That is a bit confusing - its actually trying to open "x265" as an input file.

The option was missing an argument flag, which is added in this PR.