### PR TITLE
Explicitly use std::pow.

### DIFF
--- a/libheif/hevc.cc
+++ b/libheif/hevc.cc
@@ -43,10 +43,10 @@ static double read_depth_rep_info_element(BitReader& reader)
   //printf("sign:%d exponent:%d mantissa_len:%d mantissa:%d\n",sign_flag,exponent,mantissa_len,mantissa);
 
   if (exponent > 0) {
-    value = pow(2, exponent - 31) * (1.0 + mantissa / pow(2, mantissa_len));
+    value = pow(2.0, exponent - 31) * (1.0 + mantissa / pow(2.0, mantissa_len));
   }
   else {
-    value = pow(2, -(30 + mantissa_len)) * mantissa;
+    value = pow(2.0, -(30 + mantissa_len)) * mantissa;
   }
 
   if (sign_flag) {


### PR DESCRIPTION
This fixes a build failure on SmartOS, see
https://us-central.manta.mnx.io/pkgsrc/public/reports/upstream-trunk/20230514.2249/libheif-1.16.1/build.log
```
/home/pbulk/build/graphics/libheif/work/libheif-1.16.1/libheif/hevc.cc: In function 'double read_depth_rep_info_element(BitReader&)':
/home/pbulk/build/graphics/libheif/work/libheif-1.16.1/libheif/hevc.cc:46:16: error: call of overloaded 'pow(int, int)' is ambiguous
   46 |     value = pow(2, exponent - 31) * (1.0 + mantissa / pow(2, mantissa_len));
      |             ~~~^~~~~~~~~~~~~~~~~~
```