### PR TITLE
examples: add -v version command line options

### DIFF
--- a/examples/heif-enc.1
+++ b/examples/heif-enc.1
@@ -38,8 +38,8 @@ Do not save alpha channel in thumbnail image.
 .BR \-o\fR\ \fIFILENAME\fR ", " \-\-output\fR\ \fIFILENAME\fR
 Output filename (optional).
 .TP
-.BR \-v ", "\-\-verbose\fR
-Enable logging output (more \fB\-v\fR will increase logging level).
+.BR \-\-verbose\fR
+Enable logging output (more will increase logging level).
 .TP
 .BR \-P ", "\-\-params\fR
 Show all encoder parameters.

--- a/examples/heif_convert.cc
+++ b/examples/heif_convert.cc
@@ -78,6 +78,7 @@ static void show_help(const char* argv0)
                "\n"
                "Options:\n"
                "  -h, --help                     show help\n"
+               "  -v, --version                  show version\n"
                "  -q, --quality                  quality (for JPEG output)\n"
                "  -d, --decoder ID               use a specific decoder (see --list-decoders)\n"
                "      --with-aux                 also write auxiliary images (e.g. depth images)\n"
@@ -135,7 +136,8 @@ static struct option long_options[] = {
     {(char* const) "list-decoders",    no_argument,       &option_list_decoders,    1},
     {(char* const) "help",             no_argument,       0,                        'h'},
     {(char* const) "chroma-upsampling", required_argument, 0,                     'C'},
-    {(char* const) "png-compression-level", required_argument, 0,  OPTION_PNG_COMPRESSION_LEVEL}
+    {(char* const) "png-compression-level", required_argument, 0,  OPTION_PNG_COMPRESSION_LEVEL},
+    {(char* const) "version",          no_argument,       0,                        'v'}
 };
 
 
@@ -223,7 +225,7 @@ int main(int argc, char** argv)
   //while ((opt = getopt(argc, argv, "q:s")) != -1) {
   while (true) {
     int option_index = 0;
-    int c = getopt_long(argc, argv, "hq:sd:C:", long_options, &option_index);
+    int c = getopt_long(argc, argv, "hq:sd:C:v", long_options, &option_index);
     if (c == -1) {
       break;
     }
@@ -267,6 +269,9 @@ int main(int argc, char** argv)
           exit(5);
         }
         break;
+      case 'v':
+        std::cout << LIBHEIF_VERSION << std::endl;
+        return 0;
     }
   }
 

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -93,14 +93,17 @@ const int OPTION_NCLX_FULL_RANGE_FLAG = 1003;
 const int OPTION_PLUGIN_DIRECTORY = 1004;
 const int OPTION_PITM_DESCRIPTION = 1005;
 const int OPTION_USE_JPEG_COMPRESSION = 1006;
+const int OPTION_VERBOSE = 1007;
+
 
 static struct option long_options[] = {
     {(char* const) "help",                    no_argument,       0,              'h'},
+    {(char* const) "version",                 no_argument,       0,              'v'},
     {(char* const) "quality",                 required_argument, 0,              'q'},
     {(char* const) "output",                  required_argument, 0,              'o'},
     {(char* const) "lossless",                no_argument,       0,              'L'},
     {(char* const) "thumb",                   required_argument, 0,              't'},
-    {(char* const) "verbose",                 no_argument,       0,              'v'},
+    {(char* const) "verbose",                 no_argument,       0,              OPTION_VERBOSE},
     {(char* const) "params",                  no_argument,       0,              'P'},
     {(char* const) "no-alpha",                no_argument,       &master_alpha,  0},
     {(char* const) "no-thumb-alpha",          no_argument,       &thumb_alpha,   0},
@@ -142,13 +145,14 @@ void show_help(const char* argv0)
             << "\n"
             << "Options:\n"
             << "  -h, --help        show help\n"
+            << "  -v, --version     show version\n"
             << "  -q, --quality     set output quality (0-100) for lossy compression\n"
             << "  -L, --lossless    generate lossless output (-q has no effect)\n"
             << "  -t, --thumb #     generate thumbnail with maximum size # (default: off)\n"
             << "      --no-alpha    do not save alpha channel\n"
             << "      --no-thumb-alpha  do not save alpha channel in thumbnail image\n"
             << "  -o, --output          output filename (optional)\n"
-            << "  -v, --verbose         enable logging output (more -v will increase logging level)\n"
+            << "  --verbose             enable logging output (more will increase logging level)\n"
             << "  -P, --params          show all encoder parameters\n"
             << "  -b, --bit-depth #     bit-depth of generated HEIF/AVIF file when using 16-bit PNG input (default: 10 bit)\n"
             << "  -p                    set encoder parameter (NAME=VALUE)\n"
@@ -449,6 +453,9 @@ int main(int argc, char** argv)
       case 'h':
         show_help(argv[0]);
         return 0;
+      case 'v':
+        std::cout << LIBHEIF_VERSION <<  std::endl;
+        return 0;
       case 'q':
         quality = atoi(optarg);
         break;
@@ -458,7 +465,7 @@ int main(int argc, char** argv)
       case 'o':
         output_filename = optarg;
         break;
-      case 'v':
+      case OPTION_VERBOSE:
         logging_level++;
         break;
       case 'P':

--- a/examples/heif_info.cc
+++ b/examples/heif_info.cc
@@ -46,6 +46,7 @@
 #include <memory>
 #include <getopt.h>
 #include <assert.h>
+#include <stdio.h>
 
 
 /*
@@ -68,6 +69,7 @@ static struct option long_options[] = {
     //{"output",    required_argument, 0, 'o' },
     {(char* const) "dump-boxes", no_argument, 0, 'd'},
     {(char* const) "help",       no_argument, 0, 'h'},
+    {(char* const) "version",    no_argument, 0, 'v'},
     {0, 0,                                    0, 0}
 };
 
@@ -93,6 +95,7 @@ void show_help(const char* argv0)
   //fprintf(stderr,"  -o, --output NAME    output file name for image selected by -w\n");
   fprintf(stderr, "  -d, --dump-boxes     show a low-level dump of all MP4 file boxes\n");
   fprintf(stderr, "  -h, --help           show help\n");
+  fprintf(stderr, "  -v, --version        show version\n");
 }
 
 
@@ -118,7 +121,7 @@ int main(int argc, char** argv)
 
   while (true) {
     int option_index = 0;
-    int c = getopt_long(argc, argv, "dh", long_options, &option_index);
+    int c = getopt_long(argc, argv, "dhv", long_options, &option_index);
     if (c == -1)
       break;
 
@@ -136,6 +139,9 @@ int main(int argc, char** argv)
       case 'o':
         output_filename = optarg;
         break;
+      case 'v':
+        printf("%s\n", LIBHEIF_VERSION);
+        return 0;
     }
   }
 

--- a/examples/heif_test.cc
+++ b/examples/heif_test.cc
@@ -52,6 +52,7 @@ static struct option long_options[] = {
     //{"output",    required_argument, 0, 'o' },
     {(char* const) "decode-img", required_argument, 0, 'd'},
     {(char* const) "metadata",   required_argument, 0, 'm'},
+    {(char* const) "version",    required_argument, 0, 'v'},
     {0, 0,                                          0, 0}
 };
 
@@ -65,6 +66,7 @@ void show_help(const char* argv0)
   fprintf(stderr, "  -d, --decode-img ID  decode image and output raw pixel data of all planes\n");
   fprintf(stderr, "  -m, --metadata ID    output metadata\n");
   fprintf(stderr, "  -h, --help           show help\n");
+  fprintf(stderr, "  -v, --version        show version\n");
 }
 
 
@@ -90,7 +92,7 @@ int main(int argc, char** argv)
 
   while (true) {
     int option_index = 0;
-    int c = getopt_long(argc, argv, "d:m:h", long_options, &option_index);
+    int c = getopt_long(argc, argv, "d:m:hv", long_options, &option_index);
     if (c == -1)
       break;
 
@@ -103,6 +105,9 @@ int main(int argc, char** argv)
         break;
       case 'h':
         show_help(argv[0]);
+        return 0;
+      case 'v':
+      printf("%s\n", LIBHEIF_VERSION);
         return 0;
     }
   }

--- a/examples/heif_thumbnailer.cc
+++ b/examples/heif_thumbnailer.cc
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
   int size = 512; // default thumbnail size
   bool thumbnail_from_primary_image_only = false;
 
-  while ((opt = getopt(argc, argv, "s:hp")) != -1) {
+  while ((opt = getopt(argc, argv, "s:hpv")) != -1) {
     switch (opt) {
       case 's':
         size = atoi(optarg);
@@ -79,6 +79,9 @@ int main(int argc, char** argv)
       case 'p':
         thumbnail_from_primary_image_only = true;
         break;
+      case 'v':
+        std::cout << LIBHEIF_VERSION << std::endl;
+        return 0;
       case 'h':
       default:
         return usage(argv[0]);

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -193,7 +193,7 @@ if [ -z "$EMSCRIPTEN_VERSION" ] && [ -z "$CHECK_LICENSES" ] && [ -z "$TARBALL" ]
         fi
         if [ ! -z "$WITH_GRAPHICS" ] && [ ! -z "$WITH_HEIF_ENCODER" ]; then
             echo "Converting single JPEG file to heif ..."
-            ${BIN_WRAPPER} ./examples/heif-enc${BIN_SUFFIX} -o output-single.heic -v -v -v --thumb 320x240 example-1.jpg
+            ${BIN_WRAPPER} ./examples/heif-enc${BIN_SUFFIX} -o output-single.heic --verbose --verbose --verbose --thumb 320x240 example-1.jpg
             echo "Checking generated file ..."
             [ -s "output-single.heic" ] || exit 1
             echo "Converting back generated heif to JPEG ..."
@@ -201,7 +201,7 @@ if [ -z "$EMSCRIPTEN_VERSION" ] && [ -z "$CHECK_LICENSES" ] && [ -z "$TARBALL" ]
             echo "Checking generated file ..."
             [ -s "output-single.jpg" ] || exit 1
             echo "Converting multiple JPEG files to heif ..."
-            ${BIN_WRAPPER} ./examples/heif-enc${BIN_SUFFIX} -o output-multi.heic -v -v -v --thumb 320x240 example-1.jpg example-2.jpg
+            ${BIN_WRAPPER} ./examples/heif-enc${BIN_SUFFIX} -o output-multi.heic --verbose --verbose --verbose --thumb 320x240 example-1.jpg example-2.jpg
             echo "Checking generated file ..."
             [ -s "output-multi.heic" ] || exit 1
             ${BIN_WRAPPER} ./examples/heif-convert${BIN_SUFFIX} output-multi.heic output-multi.jpg
@@ -212,7 +212,7 @@ if [ -z "$EMSCRIPTEN_VERSION" ] && [ -z "$CHECK_LICENSES" ] && [ -z "$TARBALL" ]
         fi
         if [ ! -z "$WITH_GRAPHICS" ] && [ ! -z "$WITH_AVIF_ENCODER" ]; then
             echo "Converting JPEG file to AVIF ..."
-            ${BIN_WRAPPER} ./examples/heif-enc${BIN_SUFFIX} -o output-jpeg.avif -v -v -v -A --thumb 320x240 example.jpg
+            ${BIN_WRAPPER} ./examples/heif-enc${BIN_SUFFIX} -o output-jpeg.avif --verbose --verbose --verbose -A --thumb 320x240 example.jpg
             echo "Checking generated file ..."
             [ -s "output-jpeg.avif" ] || exit 1
             echo "Converting back generated AVIF to JPEG ..."


### PR DESCRIPTION
This is a simplified (reduced scope) version of #856, just adding the version, and not attempting to do the configuration status.

Resolves #571