### PR TITLE
examples: fix typo in heif-convert help text

### DIFF
--- a/examples/heif_convert.cc
+++ b/examples/heif_convert.cc
@@ -74,7 +74,7 @@ static void show_help(const char* argv0)
                "Usage: heif-convert [options]  <input-image> <output-image>\n"
                "\n"
                "The program determines the output file format from the output filename suffix.\n"
-               "These suffices are recognized: jpg, jpeg, png, y4m."
+               "These suffixes are recognized: jpg, jpeg, png, y4m."
                "\n"
                "Options:\n"
                "  -h, --help                     show help\n"


### PR DESCRIPTION
Trivial fix for a typo I noted during work on #877, but isn't really related to that.