### PR TITLE
Fix a mem leak when `heif_deinit()` was not called

### DIFF
--- a/fuzzing/box_fuzzer.cc
+++ b/fuzzing/box_fuzzer.cc
@@ -26,8 +26,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-  heif_init(nullptr);
-
   auto reader = std::make_shared<StreamReader_memory>(data, size, false);
 
   BitstreamRange range(reader, size);
@@ -43,8 +41,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     Indent indent;
     box->dump(indent);
   }
-
-  heif_deinit();
 
   return 0;
 }

--- a/fuzzing/color_conversion_fuzzer.cc
+++ b/fuzzing/color_conversion_fuzzer.cc
@@ -103,7 +103,7 @@ static bool read_plane_interleaved(BitstreamRange* range,
   return true;
 }
 
-static int test(const uint8_t* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
   auto reader = std::make_shared<StreamReader_memory>(data, size, false);
   BitstreamRange range(reader, size);
@@ -264,13 +264,4 @@ static int test(const uint8_t* data, size_t size)
   assert(out_image->get_colorspace() ==
          static_cast<heif_colorspace>(out_colorspace));
   return 0;
-}
-
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
-{
-  heif_init(nullptr);
-  int retVal = test(data, size);
-  heif_deinit();
-
-  return retVal;
 }

--- a/fuzzing/encoder_fuzzer.cc
+++ b/fuzzing/encoder_fuzzer.cc
@@ -132,7 +132,7 @@ static struct heif_error writer_write(struct heif_context* ctx, const void* data
   return err;
 }
 
-static int test(const uint8_t* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
   struct heif_error err;
   std::shared_ptr<heif_context> context(heif_context_alloc(),
@@ -196,14 +196,4 @@ static int test(const uint8_t* data, size_t size)
   heif_context_write(context.get(), &w, &writer);
   assert(writer.size() > 0);
   return 0;
-}
-
-
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
-{
-  heif_init(nullptr);
-  int retVal = test(data, size);
-  heif_deinit();
-
-  return retVal;
 }

--- a/fuzzing/file_fuzzer.cc
+++ b/fuzzing/file_fuzzer.cc
@@ -85,8 +85,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
   struct heif_image_handle* primary_handle = nullptr;
   int images_count;
   heif_item_id* image_IDs = NULL;
+  bool explicit_init = data[size - 1] & 1;
 
-  heif_init(nullptr);
+  if (explicit_init) {
+    heif_init(nullptr);
+  }
 
   heif_check_filetype(data, clip_int(size));
   heif_main_brand(data, clip_int(size));
@@ -151,7 +154,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
   heif_context_free(ctx);
   free(image_IDs);
 
-  heif_deinit();
+  if (explicit_init) {
+    heif_deinit();
+  }
 
   return 0;
 }

--- a/fuzzing/file_fuzzer.cc
+++ b/fuzzing/file_fuzzer.cc
@@ -85,7 +85,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
   struct heif_image_handle* primary_handle = nullptr;
   int images_count;
   heif_item_id* image_IDs = NULL;
-  bool explicit_init = size > 0 ? data[size - 1] & 1 : true;
+  bool explicit_init = size == 0 || data[size - 1] & 1;
 
   if (explicit_init) {
     heif_init(nullptr);

--- a/fuzzing/file_fuzzer.cc
+++ b/fuzzing/file_fuzzer.cc
@@ -85,7 +85,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
   struct heif_image_handle* primary_handle = nullptr;
   int images_count;
   heif_item_id* image_IDs = NULL;
-  bool explicit_init = data[size - 1] & 1;
+  bool explicit_init = size > 0 ? data[size - 1] & 1 : true;
 
   if (explicit_init) {
     heif_init(nullptr);

--- a/libheif/color-conversion/colorconversion.cc
+++ b/libheif/color-conversion/colorconversion.cc
@@ -151,7 +151,7 @@ struct Node
 {
   Node() = default;
 
-  Node(int prev, const ColorConversionOperation* _op, const ColorStateWithCost& state)
+  Node(int prev, const std::shared_ptr<ColorConversionOperation>& _op, const ColorStateWithCost& state)
   {
     prev_processed_idx = prev;
     op = _op;
@@ -159,7 +159,7 @@ struct Node
   }
 
   int prev_processed_idx = -1;
-  const ColorConversionOperation* op;
+  std::shared_ptr<ColorConversionOperation> op;
   ColorStateWithCost color_state;
 };
 
@@ -170,7 +170,7 @@ std::ostream& operator<<(std::ostream& ostr, const ColorState& state) {
               << " nclx=" << (state.nclx_profile ? "yes" : "no");
 }
 
-std::vector<ColorConversionOperation*> ColorConversionPipeline::m_operation_pool;
+std::vector<std::shared_ptr<ColorConversionOperation>> ColorConversionPipeline::m_operation_pool;
 
 
 void ColorConversionPipeline::init_ops()
@@ -179,42 +179,38 @@ void ColorConversionPipeline::init_ops()
     return;
   }
 
-  std::vector<ColorConversionOperation*>& ops = m_operation_pool;
-  ops.push_back(new Op_RGB_to_RGB24_32());
-  ops.push_back(new Op_RGB24_32_to_RGB());
-  ops.push_back(new Op_YCbCr_to_RGB<uint16_t>());
-  ops.push_back(new Op_YCbCr_to_RGB<uint8_t>());
-  ops.push_back(new Op_YCbCr420_to_RGB24());
-  ops.push_back(new Op_YCbCr420_to_RGB32());
-  ops.push_back(new Op_YCbCr420_to_RRGGBBaa());
-  ops.push_back(new Op_RGB_HDR_to_RRGGBBaa_BE());
-  ops.push_back(new Op_RGB_to_RRGGBBaa_BE());
-  ops.push_back(new Op_mono_to_YCbCr420());
-  ops.push_back(new Op_mono_to_RGB24_32());
-  ops.push_back(new Op_RRGGBBaa_swap_endianness());
-  ops.push_back(new Op_RRGGBBaa_BE_to_RGB_HDR());
-  ops.push_back(new Op_RGB24_32_to_YCbCr());
-  ops.push_back(new Op_RGB_to_YCbCr<uint8_t>());
-  ops.push_back(new Op_RGB_to_YCbCr<uint16_t>());
-  ops.push_back(new Op_RRGGBBxx_HDR_to_YCbCr420());
-  ops.push_back(new Op_RGB24_32_to_YCbCr444_GBR());
-  ops.push_back(new Op_drop_alpha_plane());
-  ops.push_back(new Op_to_hdr_planes());
-  ops.push_back(new Op_to_sdr_planes());
-  ops.push_back(new Op_YCbCr420_bilinear_to_YCbCr444<uint8_t>());
-  ops.push_back(new Op_YCbCr420_bilinear_to_YCbCr444<uint16_t>());
-  ops.push_back(new Op_YCbCr444_to_YCbCr420_average<uint8_t>());
-  ops.push_back(new Op_YCbCr444_to_YCbCr420_average<uint16_t>());
-  ops.push_back(new Op_Any_RGB_to_YCbCr_420_Sharp());
+  std::vector<std::shared_ptr<ColorConversionOperation>>& ops = m_operation_pool;
+  ops.push_back(std::make_shared<Op_RGB_to_RGB24_32>());
+  ops.push_back(std::make_shared<Op_RGB24_32_to_RGB>());
+  ops.push_back(std::make_shared<Op_YCbCr_to_RGB<uint16_t>>());
+  ops.push_back(std::make_shared<Op_YCbCr_to_RGB<uint8_t>>());
+  ops.push_back(std::make_shared<Op_YCbCr420_to_RGB24>());
+  ops.push_back(std::make_shared<Op_YCbCr420_to_RGB32>());
+  ops.push_back(std::make_shared<Op_YCbCr420_to_RRGGBBaa>());
+  ops.push_back(std::make_shared<Op_RGB_HDR_to_RRGGBBaa_BE>());
+  ops.push_back(std::make_shared<Op_RGB_to_RRGGBBaa_BE>());
+  ops.push_back(std::make_shared<Op_mono_to_YCbCr420>());
+  ops.push_back(std::make_shared<Op_mono_to_RGB24_32>());
+  ops.push_back(std::make_shared<Op_RRGGBBaa_swap_endianness>());
+  ops.push_back(std::make_shared<Op_RRGGBBaa_BE_to_RGB_HDR>());
+  ops.push_back(std::make_shared<Op_RGB24_32_to_YCbCr>());
+  ops.push_back(std::make_shared<Op_RGB_to_YCbCr<uint8_t>>());
+  ops.push_back(std::make_shared<Op_RGB_to_YCbCr<uint16_t>>());
+  ops.push_back(std::make_shared<Op_RRGGBBxx_HDR_to_YCbCr420>());
+  ops.push_back(std::make_shared<Op_RGB24_32_to_YCbCr444_GBR>());
+  ops.push_back(std::make_shared<Op_drop_alpha_plane>());
+  ops.push_back(std::make_shared<Op_to_hdr_planes>());
+  ops.push_back(std::make_shared<Op_to_sdr_planes>());
+  ops.push_back(std::make_shared<Op_YCbCr420_bilinear_to_YCbCr444<uint8_t>>());
+  ops.push_back(std::make_shared<Op_YCbCr420_bilinear_to_YCbCr444<uint16_t>>());
+  ops.push_back(std::make_shared<Op_YCbCr444_to_YCbCr420_average<uint8_t>>());
+  ops.push_back(std::make_shared<Op_YCbCr444_to_YCbCr420_average<uint16_t>>());
+  ops.push_back(std::make_shared<Op_Any_RGB_to_YCbCr_420_Sharp>());
 }
 
 
 void ColorConversionPipeline::release_ops()
 {
-  for (auto& op : m_operation_pool) {
-    delete op;
-  }
-
   m_operation_pool.clear();
 }
 
@@ -238,7 +234,7 @@ bool ColorConversionPipeline::construct_pipeline(const ColorState& input_state,
 
   init_ops(); // to be sure these are initialized even without heif_init()
 
-  std::vector<ColorConversionOperation*>& ops = m_operation_pool;
+  std::vector<std::shared_ptr<ColorConversionOperation>>& ops = m_operation_pool;
 
   // --- Dijkstra search for the minimum-cost conversion pipeline
 

--- a/libheif/color-conversion/colorconversion.h
+++ b/libheif/color-conversion/colorconversion.h
@@ -101,10 +101,10 @@ public:
   std::string debug_dump_pipeline() const;
 
 private:
-  static std::vector<ColorConversionOperation*> m_operation_pool;
+  static std::vector<std::shared_ptr<ColorConversionOperation>> m_operation_pool;
 
   struct ConversionStep {
-    const ColorConversionOperation* operation;
+    std::shared_ptr<ColorConversionOperation> operation;
     ColorState output_state;
   };
 


### PR DESCRIPTION
By switching to `std::shared_ptr` we ensure that these smart pointers' lifetimes persist throughout the entire execution time of the program, eliminating the requirement of calling `heif_deinit()`.

This is especially useful in fuzzer environments where calling `heif_deinit()` is not always feasible.

Regressed since commit 8f9ac3d6db58d91ebb36f68244cdc534253b889b.

---
Context (in chronological order, none of them would appease OSS-Fuzz):
https://github.com/libvips/libvips/pull/3481
https://github.com/libvips/libvips/pull/3489
https://github.com/libvips/libvips/pull/3498
