### PR TITLE
plugins: only build plugin code when plugins loading is enabled

### DIFF
--- a/libheif/plugins_unix.cc
+++ b/libheif/plugins_unix.cc
@@ -18,6 +18,7 @@
  * along with libheif.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if ENABLE_PLUGIN_LOADING
 
 #include "plugins_unix.h"
 #include "heif_plugin.h"
@@ -116,4 +117,6 @@ void PluginLibrary_Unix::release()
     m_library_handle = nullptr;
   }
 }
+
+#endif
 

--- a/libheif/plugins_unix.h
+++ b/libheif/plugins_unix.h
@@ -21,6 +21,8 @@
 #ifndef LIBHEIF_PLUGINS_UNIX_H
 #define LIBHEIF_PLUGINS_UNIX_H
 
+#if ENABLE_PLUGIN_LOADING
+
 #include <vector>
 #include <string>
 #include "init.h"
@@ -47,5 +49,7 @@ private:
   void* m_library_handle = nullptr;
   heif_plugin_info* m_plugin_info = nullptr;
 };
+
+#endif // ENABLE_PLUGIN_LOADING
 
 #endif //LIBHEIF_PLUGINS_UNIX_H

--- a/libheif/plugins_windows.cc
+++ b/libheif/plugins_windows.cc
@@ -19,6 +19,8 @@
  */
 
 
+#if ENABLE_PLUGIN_LOADING
+
 #include "plugins_windows.h"
 #include "heif_plugin.h"
 #include <sstream>
@@ -107,3 +109,5 @@ void PluginLibrary_Windows::release()
     m_library_handle = nullptr;
   }
 }
+
+#endif

--- a/libheif/plugins_windows.h
+++ b/libheif/plugins_windows.h
@@ -22,6 +22,8 @@
 #ifndef LIBHEIF_PLUGINS_WINDOWS_H
 #define LIBHEIF_PLUGINS_WINDOWS_H
 
+#if ENABLE_PLUGIN_LOADING
+
 #include <vector>
 #include <string>
 #include "init.h"
@@ -50,5 +52,7 @@ private:
   HMODULE m_library_handle = nullptr;
   heif_plugin_info* m_plugin_info = nullptr;
 };
+
+#endif //ENABLE_PLUGIN_LOADING
 
 #endif //LIBHEIF_PLUGINS_WINDOWS_H


### PR DESCRIPTION
While working on static build at #767, I noted that we get warnings that look like this:

```
[ 60%] Linking CXX executable heif-info
/usr/bin/ld: ../libheif/libheif.a(plugins_unix.cc.o): in function `PluginLibrary_Unix::load_from_file(char const*)':
plugins_unix.cc:(.text+0x4ad): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
[ 60%] Built target heif-info
```

Clearly it isn't very likely you'd be doing static linking on the application, then using plugins - not absolutely out of the question, but unusual.

We do have an option to disable plugin loading (the CMake `ENABLE_PLUGIN_LOADING` directive), however that currently isn't enough to avoid this (compile-time) warning. This PR extends the current use of that option to wrap the plugin loading code (for Linux and Windows) in an `#if ENABLE_PLUGIN_LOADING` stanza.