### PR TITLE
Docs: heif-converter-image added in "Software using libheif"

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ to update the gdk-pixbuf loader database.
 * [GDAL](https://gdal.org/drivers/raster/heif.html)
 * [OpenImageIO](https://sites.google.com/site/openimageio/)
 * [XnView](https://www.xnview.com)
+* [heif-converter-image](https://github.com/MaestroError/heif-converter-image) (Docker & CLI)
 
 ## Packaging status
 


### PR DESCRIPTION
I have created [heif-converter-image](https://github.com/MaestroError/heif-converter-image) project, which uses this library, so I updated the README.md and add `heif-converter-image` in "Software using libheif" section