### PR TITLE
Add more nclx conversion tests and fix related bugs.

### DIFF
--- a/libheif/color-conversion/rgb2yuv.cc
+++ b/libheif/color-conversion/rgb2yuv.cc
@@ -44,6 +44,11 @@ Op_RGB_to_YCbCr<Pixel>::state_after_conversion(const ColorState& input_state,
     return {};
   }
 
+  int matrix = target_state.nclx_profile.get_matrix_coefficients();
+  if (matrix == 8 || matrix == 11 || matrix == 14) {
+    return {};
+  }
+
   std::vector<ColorStateWithCost> states;
 
   ColorState output_state;
@@ -492,7 +497,8 @@ Op_RGB24_32_to_YCbCr::state_after_conversion(const ColorState& input_state,
     return {};
   }
 
-  if (target_state.nclx_profile.get_matrix_coefficients() == 0) {
+  int matrix = target_state.nclx_profile.get_matrix_coefficients();
+  if (matrix == 0 || matrix == 8 || matrix == 11 || matrix == 14) {
     return {};
   }
 

--- a/libheif/color-conversion/rgb2yuv.cc
+++ b/libheif/color-conversion/rgb2yuv.cc
@@ -215,9 +215,9 @@ Op_RGB_to_YCbCr<Pixel>::convert_colorspace(const std::shared_ptr<const HeifPixel
         }
         else {
           out_cb[(y / subV) * out_cb_stride + (x / subH)] = (Pixel) clip_f_u16(
-              ((in_b[y * in_b_stride + x] * 219.0f) / 256) + limited_range_offset, fullRange);
+              ((in_b[y * in_b_stride + x] * 224.0f) / 256) + limited_range_offset, fullRange);
           out_cr[(y / subV) * out_cb_stride + (x / subH)] = (Pixel) clip_f_u16(
-              ((in_r[y * in_b_stride + x] * 219.0f) / 256) + limited_range_offset, fullRange);
+              ((in_r[y * in_b_stride + x] * 224.0f) / 256) + limited_range_offset, fullRange);
         }
       }
       else {
@@ -789,7 +789,7 @@ Op_RGB24_32_to_YCbCr444_GBR::state_after_conversion(const ColorState& input_stat
     return {};
   }
 
-  if (!input_state.nclx_profile.get_full_range_flag()) {
+  if (!target_state.nclx_profile.get_full_range_flag()) {
     return {};
   }
 

--- a/libheif/color-conversion/rgb2yuv_sharp.cc
+++ b/libheif/color-conversion/rgb2yuv_sharp.cc
@@ -99,7 +99,8 @@ Op_Any_RGB_to_YCbCr_420_Sharp::state_after_conversion(
     return {};
   }
 
-  if (target_state.nclx_profile.get_matrix_coefficients() == 0) {
+  int matrix = target_state.nclx_profile.get_matrix_coefficients();
+  if (matrix == 0 || matrix == 8 || matrix == 11 || matrix == 14) {
     return {};
   }
 

--- a/libheif/color-conversion/yuv2rgb.cc
+++ b/libheif/color-conversion/yuv2rgb.cc
@@ -47,6 +47,12 @@ Op_YCbCr_to_RGB<Pixel>::state_after_conversion(const ColorState& input_state,
     return {};
   }
 
+  int matrix = input_state.nclx_profile.get_matrix_coefficients();
+  if ( matrix == 11 || matrix == 14) {
+    return {};
+  }
+
+
   bool hdr = !std::is_same<Pixel, uint8_t>::value;
 
   if ((input_state.bits_per_pixel != 8) != hdr) {
@@ -219,7 +225,7 @@ Op_YCbCr_to_RGB<Pixel>::convert_colorspace(const std::shared_ptr<const HeifPixel
         out_g[y * out_g_stride + x] = (Pixel) (clip_int_u8(yv + cb));
         out_b[y * out_b_stride + x] = (Pixel) (clip_int_u8(yv - cb - cr));
       }
-      else { // TODO: matrix_coefficients = 10,11,13,14
+      else { // TODO: matrix_coefficients = 11,14
         float yv, cb, cr;
         yv = static_cast<float>(in_y[y * in_y_stride + x] );
         cb = static_cast<float>(in_cb[cy * in_cb_stride + cx] - halfRange);

--- a/libheif/color-conversion/yuv2rgb.cc
+++ b/libheif/color-conversion/yuv2rgb.cc
@@ -208,9 +208,10 @@ Op_YCbCr_to_RGB<Pixel>::convert_colorspace(const std::shared_ptr<const HeifPixel
           out_b[y * out_b_stride + x] = in_cb[cy * in_cb_stride + cx];
         }
         else {
-          out_r[y * out_r_stride + x] = Pixel(((in_cr[cy * in_cr_stride + cx] * 219 + 128) >> 8) + limited_range_offset_int);
-          out_g[y * out_g_stride + x] = Pixel(((in_y[y * in_y_stride + x] * 219 + 128) >> 8) + limited_range_offset_int);
-          out_b[y * out_b_stride + x] = Pixel(((in_cb[cy * in_cb_stride + cx] * 219 + 128) >> 8) + limited_range_offset_int);
+          // Convert from limited range to full range.
+          out_r[y * out_r_stride + x] = (Pixel) clip_f_u16((in_cr[cy * in_cr_stride + cx] - limited_range_offset) * 1.1429f, fullRange);
+          out_g[y * out_g_stride + x] = (Pixel) clip_f_u16((in_y[y * in_y_stride + x] - limited_range_offset) * 1.1689f, fullRange);
+          out_b[y * out_b_stride + x] = (Pixel) clip_f_u16((in_cb[cy * in_cb_stride + cx] - limited_range_offset) * 1.1429f, fullRange);
         }
       }
       else if (matrix_coeffs == 8) {

--- a/tests/conversion.cc
+++ b/tests/conversion.cc
@@ -354,9 +354,17 @@ void TestFailingConversion(const std::string& test_name,
                            const ColorState& input_state,
                            const ColorState& target_state,
                            const heif_color_conversion_options& options = {}) {
+  INFO(test_name);
+  INFO("downsampling=" << options.preferred_chroma_downsampling_algorithm
+                       << " upsampling="
+                       << options.preferred_chroma_upsampling_algorithm
+                       << " only_used_preferred="
+                       << (bool)options.only_use_preferred_chroma_algorithm);
   ColorConversionPipeline pipeline;
-  REQUIRE_FALSE(
-      pipeline.construct_pipeline(input_state, target_state, options));
+  bool construct_pipeline_res =
+      pipeline.construct_pipeline(input_state, target_state, options);
+  INFO("conversion pipeline: " << pipeline.debug_dump_pipeline());
+  REQUIRE_FALSE(construct_pipeline_res);
 }
 
 // Returns the list of valid has_alpha values for a given heif_chroma.
@@ -404,9 +412,22 @@ std::vector<int> GetValidBitsPerPixel(heif_chroma chroma) {
   }
 }
 
+// Returns a subset (to reduce the number of tests) of fully supported matrix
+// coefficients.
+const std::vector<heif_matrix_coefficients> GetSupportedMatrices() {
+  return {heif_matrix_coefficients_RGB_GBR,
+          heif_matrix_coefficients_SMPTE_240M};
+}
+
+// Returns matrix coefficients that are not currently supported by any operator.
+const std::vector<heif_matrix_coefficients> GetUnsupportedMatrices() {
+  return {heif_matrix_coefficients_SMPTE_ST_2085,
+          heif_matrix_coefficients_ICtCp};
+}
+
 // Returns of list of all valid ColorState (valid combinations
 // of a heif_colorspace/heif_chroma/has_alpha/bpp).
-std::vector<ColorState> GetAllColorStates() {
+std::vector<ColorState> GetAllColorStates(const std::vector<heif_matrix_coefficients>& matrices) {
   std::vector<ColorState> color_states;
   for (heif_colorspace colorspace : {heif_colorspace_YCbCr, heif_colorspace_RGB, heif_colorspace_monochrome}) {
     for (heif_chroma chroma : get_valid_chroma_values_for_colorspace(colorspace)) {
@@ -417,10 +438,8 @@ std::vector<ColorState> GetAllColorStates() {
           color_states.push_back(color_state);
 
           // With nclx.
-          // TODO: test more matrix values and non full range.
-          for (heif_matrix_coefficients matrix :
-               {heif_matrix_coefficients_RGB_GBR,
-                heif_matrix_coefficients_SMPTE_240M}) {
+          for (heif_matrix_coefficients matrix : matrices) {
+            // TODO: test non full range.
             color_state.nclx_profile.set_full_range_flag(true);
             color_state.nclx_profile.set_matrix_coefficients(
                 matrix);
@@ -456,8 +475,10 @@ TEST_CASE("All conversions", "[heif_image]") {
       .only_use_preferred_chroma_algorithm = only_use_preferred_chroma_algorithm};
 
   // Test all source and destination state combinations.
-  ColorState src_state = GENERATE(from_range(GetAllColorStates()));
-  ColorState dst_state = GENERATE(from_range(GetAllColorStates()));
+  ColorState src_state = GENERATE(
+      from_range(GetAllColorStates(GetSupportedMatrices())));
+  ColorState dst_state = GENERATE(
+      from_range(GetAllColorStates(GetSupportedMatrices())));
   // To debug a particular combination, hardcoe the ColorState values
   // instead:
   // ColorState src_state(heif_colorspace_YCbCr, heif_chroma_420, false, 8);
@@ -479,6 +500,43 @@ TEST_CASE("All conversions", "[heif_image]") {
   std::ostringstream os;
   os << "from: " << src_state << "\nto:   " << dst_state;
   TestConversion(os.str(), src_state, dst_state, options, require_supported);
+}
+
+TEST_CASE("Unsupported matrices", "[heif_image]") {
+  bool only_use_preferred_chroma_algorithm = GENERATE(false, true);
+  heif_chroma_downsampling_algorithm downsampling =
+      heif_chroma_downsampling_nearest_neighbor;
+  heif_chroma_upsampling_algorithm upsampling =
+      heif_chroma_upsampling_nearest_neighbor;
+  if (only_use_preferred_chroma_algorithm) {
+    downsampling = GENERATE(heif_chroma_downsampling_nearest_neighbor,
+                            heif_chroma_downsampling_average,
+                            heif_chroma_downsampling_sharp_yuv);
+    upsampling = GENERATE(heif_chroma_upsampling_nearest_neighbor,
+                          heif_chroma_upsampling_bilinear);
+  }
+  heif_color_conversion_options options = {
+      .preferred_chroma_downsampling_algorithm = downsampling,
+      .preferred_chroma_upsampling_algorithm = upsampling,
+      .only_use_preferred_chroma_algorithm = only_use_preferred_chroma_algorithm};
+
+  ColorState src_state =
+      GENERATE(from_range(GetAllColorStates(GetUnsupportedMatrices())));
+  ColorState dst_state =
+      GENERATE(from_range(GetAllColorStates(GetUnsupportedMatrices())));
+  color_profile_nclx default_nclx;
+
+  if (src_state == dst_state ||
+      NclxMatches(src_state.colorspace, src_state.nclx_profile,
+                  dst_state.nclx_profile) ||
+      (src_state.nclx_profile.get_matrix_coefficients() == default_nclx.get_matrix_coefficients() ||
+       dst_state.nclx_profile.get_matrix_coefficients() == default_nclx.get_matrix_coefficients())) {
+    return;
+  }
+
+  std::ostringstream os;
+  os << "from: " << src_state << "\nto:   " << dst_state;
+  TestFailingConversion(os.str(), src_state, dst_state, options);
 }
 
 TEST_CASE("Sharp yuv conversion", "[heif_image]") {


### PR DESCRIPTION
Some operators were not checking for matrix coefficients 0/8/11/14 even though they were not supported. It looks like the operation succeeds but get_RGB_to_YCbCr_coefficients and get_YCbCr_to_RGB_coefficients just return default values in this case (maybe this needs to be changed?)
There is only one operator that supports matrix_coefficients 8, and none of them support 11 or 14 currently.