### PR TITLE
Use portable types to avoid cast warnings

### DIFF
--- a/examples/heif_info.cc
+++ b/examples/heif_info.cc
@@ -567,7 +567,7 @@ int main(int argc, char** argv)
             int32_t y;
             uint32_t w;
             uint32_t h;
-            long unsigned int data_len = heif_region_get_inline_mask_data_len(regions[j]);
+            size_t data_len = heif_region_get_inline_mask_data_len(regions[j]);
             std::vector<uint8_t> mask_data(data_len);
             heif_region_get_inline_mask_data(regions[j], &x, &y, &w, &h, mask_data.data());
             printf("      inline mask [x=%i, y=%i, w=%u, h=%u, data len=%lu]\n", x, y, w, h, mask_data.size());

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -3685,7 +3685,7 @@ struct heif_error heif_region_get_referenced_mask_ID(const struct heif_region* r
   return heif_error_invalid_parameter_value;
 }
 
-unsigned long int heif_region_get_inline_mask_data_len(const struct heif_region* region)
+size_t heif_region_get_inline_mask_data_len(const struct heif_region* region)
 {
   const std::shared_ptr<RegionGeometry_InlineMask> mask = std::dynamic_pointer_cast<RegionGeometry_InlineMask>(region->region);
   if (mask) {

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -2593,7 +2593,7 @@ struct heif_error heif_region_get_referenced_mask_ID(const struct heif_region* r
  * @return the number of bytes in the mask data, or 0 on error.
  */
 LIBHEIF_API
-unsigned long heif_region_get_inline_mask_data_len(const struct heif_region* region);
+size_t heif_region_get_inline_mask_data_len(const struct heif_region* region);
 
 
 /**

--- a/libheif/uncompressed_image.cc
+++ b/libheif/uncompressed_image.cc
@@ -705,13 +705,13 @@ Error UncompressedImageCodec::decode_uncompressed_image(const std::shared_ptr<co
       uint8_t* dst = img->get_plane(channels[c], &stride);
       for (uint32_t row = 0; row < height; row++) {
         long unsigned int tile_row_idx = row % tile_height;
-        long unsigned int tile_row_offset = tile_width * tile_row_idx * channels.size();
+        size_t tile_row_offset = tile_width * tile_row_idx * channels.size();
         uint32_t col = 0;
         for (col = 0; col < width; col++) {
           long unsigned int tile_base_offset = get_tile_base_offset(col, row, uncC, channels, width, height);
           long unsigned int tile_col = col % tile_width;
-          long unsigned int tile_offset = tile_row_offset + tile_col * pixel_stride + pixel_offset;
-          long unsigned int src_offset = tile_base_offset + tile_offset;
+          size_t tile_offset = tile_row_offset + tile_col * pixel_stride + pixel_offset;
+          size_t src_offset = tile_base_offset + tile_offset;
           uint32_t dstPixelIndex = row * stride + col;
           dst[dstPixelIndex] = src[src_offset];
         }
@@ -732,13 +732,13 @@ Error UncompressedImageCodec::decode_uncompressed_image(const std::shared_ptr<co
       uint8_t* dst = img->get_plane(channels[c], &stride);
       for (uint32_t row = 0; row < height; row++) {
         long unsigned int tile_row_idx = row % tile_height;
-        long unsigned int tile_row_offset = tile_width * (tile_row_idx * channels.size() + pixel_offset);
+        size_t tile_row_offset = tile_width * (tile_row_idx * channels.size() + pixel_offset);
         uint32_t col = 0;
         for (col = 0; col < width; col += tile_width) {
           long unsigned int tile_base_offset = get_tile_base_offset(col, row, uncC, channels, width, height);
           long unsigned int tile_col = col % tile_width;
-          long unsigned int tile_offset = tile_row_offset + tile_col;
-          long unsigned int src_offset = tile_base_offset + tile_offset;
+          size_t tile_offset = tile_row_offset + tile_col;
+          size_t src_offset = tile_base_offset + tile_offset;
           uint32_t dst_offset = row * stride + col;
           memcpy(dst + dst_offset, uncompressed_data.data() + src_offset, tile_width);
         }
@@ -965,7 +965,7 @@ Error UncompressedImageCodec::encode_uncompressed_image(const std::shared_ptr<He
   std::vector<uint8_t> data;
   if (src_image->get_colorspace() == heif_colorspace_YCbCr)
   {
-    unsigned long offset = 0;
+    uint64_t offset = 0;
     for (heif_channel channel : {heif_channel_Y, heif_channel_Cb, heif_channel_Cr})
     {
       int src_stride;
@@ -983,7 +983,7 @@ Error UncompressedImageCodec::encode_uncompressed_image(const std::shared_ptr<He
   {
     if (src_image->get_chroma_format() == heif_chroma_444)
     {
-      unsigned long offset = 0;
+      uint64_t offset = 0;
       std::vector<heif_channel> channels = {heif_channel_R, heif_channel_G, heif_channel_B};
       if (src_image->has_channel(heif_channel_Alpha))
       {
@@ -1045,7 +1045,7 @@ Error UncompressedImageCodec::encode_uncompressed_image(const std::shared_ptr<He
   }
   else if (src_image->get_colorspace() == heif_colorspace_monochrome)
   {
-    unsigned long offset = 0;
+    uint64_t offset = 0;
     std::vector<heif_channel> channels;
     if (src_image->has_channel(heif_channel_Alpha))
     {

--- a/tests/region.cc
+++ b/tests/region.cc
@@ -421,7 +421,7 @@ TEST_CASE("create inline mask region from data") {
   int num_regions_returned = heif_region_item_get_list_of_regions(in_region_item, regions.data(), (int)(regions.size()));
   REQUIRE(num_regions_returned == num_regions);
   REQUIRE(heif_region_get_type(regions[0]) == heif_region_type_inline_mask);
-  long unsigned int data_len = heif_region_get_inline_mask_data_len(regions[0]);
+  size_t data_len = heif_region_get_inline_mask_data_len(regions[0]);
   int32_t x, y;
   uint32_t width, height;
   std::vector<uint8_t> mask_data_in(data_len);


### PR DESCRIPTION
NB: Requires API version bump (at least when it comes to Windows)

Can of course be solved the other way (explicit casting to `unsigned long` where needed), if deemed safe.

This is because LLP64 on Windows vs LP64 everywhere else...