### PR TITLE
Crash on assigning error_msg to std::string

### DIFF
--- a/libheif/heif_cxx.h
+++ b/libheif/heif_cxx.h
@@ -46,7 +46,8 @@ namespace heif {
     {
       m_code = err.code;
       m_subcode = err.subcode;
-      m_message = err.message;
+      if (err.message)
+        m_message = err.message;
     }
 
     Error(heif_error_code code, heif_suberror_code subcode, const std::string& msg)


### PR DESCRIPTION
In my project i use heif_cxx.h api. And caught crash inside heif_cxx.h.
It happence while assigning err.message to m_message
`    Error(const heif_error& err)
    {
      m_code = err.code;
      m_subcode = err.subcode;
      m_message = err.message;
    }`
Attach debug screen with callStack.
![image](https://github.com/strukturag/libheif/assets/28383004/71d6b3df-fc0a-4777-bdb4-e8c078d3e344)
I can't show the fields in the structure, because Qt debugger is stupid, but I hope it's clear.
I read in heif.h file that message in heif_error struct always defined, but apparently not always)
