### PR TITLE
add support for URI metadata type

### DIFF
--- a/examples/heif_info.cc
+++ b/examples/heif_info.cc
@@ -426,9 +426,13 @@ int main(int argc, char** argv)
       for (int n = 0; n < numMetadata; n++) {
         std::string itemtype = heif_image_handle_get_metadata_type(handle, ids[n]);
         std::string contenttype = heif_image_handle_get_metadata_content_type(handle, ids[n]);
+        std::string item_uri_type = heif_image_handle_get_metadata_item_uri_type(handle, ids[n]);
         std::string ID{"unknown"};
         if (itemtype == "Exif") {
           ID = itemtype;
+        }
+        else if (itemtype == "uri ") {
+          ID = itemtype + "/" + item_uri_type;
         }
         else if (contenttype == "application/rdf+xml") {
           ID = "XMP";

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -465,6 +465,8 @@ public:
 
   Error write(StreamWriter& writer) const override;
 
+  const std::string& get_item_uri_type() const { return m_item_uri_type; }
+
 protected:
   Error parse(BitstreamRange& range) override;
 

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -884,12 +884,15 @@ Error HeifContext::interpret_heif_file()
     }
     std::string content_type = m_heif_file->get_content_type(id);
 
+    std::string item_uri_type = m_heif_file->get_item_uri_type(id);
+
     // we now assign all kinds of metadata to the image, not only 'Exif' and 'XMP'
 
     std::shared_ptr<ImageMetadata> metadata = std::make_shared<ImageMetadata>();
     metadata->item_id = id;
     metadata->item_type = item_type;
     metadata->content_type = content_type;
+    metadata->item_uri_type = item_uri_type;
 
     Error err = m_heif_file->get_compressed_image_data(id, &(metadata->m_data));
     if (err) {

--- a/libheif/context.h
+++ b/libheif/context.h
@@ -53,6 +53,7 @@ public:
   heif_item_id item_id;
   std::string item_type;  // e.g. "Exif"
   std::string content_type;
+  std::string item_uri_type;
   std::vector<uint8_t> m_data;
 };
 

--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -458,6 +458,16 @@ std::string HeifFile::get_content_type(heif_item_id ID) const
   return infe_box->get_content_type();
 }
 
+std::string HeifFile::get_item_uri_type(heif_item_id ID) const
+{
+  auto infe_box = get_infe(ID);
+  if (!infe_box) {
+    return "";
+  }
+
+  return infe_box->get_item_uri_type();
+}
+
 
 Error HeifFile::get_properties(heif_item_id imageID,
                                std::vector<std::shared_ptr<Box>>& properties) const

--- a/libheif/file.h
+++ b/libheif/file.h
@@ -77,6 +77,8 @@ public:
 
   std::string get_content_type(heif_item_id ID) const;
 
+  std::string get_item_uri_type(heif_item_id ID) const;
+
   Error get_compressed_image_data(heif_item_id ID, std::vector<uint8_t>* out_data) const;
 
 

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -1533,6 +1533,19 @@ const char* heif_image_handle_get_metadata_content_type(const struct heif_image_
 }
 
 
+const char* heif_image_handle_get_metadata_item_uri_type(const struct heif_image_handle* handle,
+                                                         heif_item_id metadata_id)
+{
+  for (auto& metadata : handle->image->get_metadata()) {
+    if (metadata->item_id == metadata_id) {
+      return metadata->item_uri_type.c_str();
+    }
+  }
+
+  return nullptr;
+}
+
+
 size_t heif_image_handle_get_metadata_size(const struct heif_image_handle* handle,
                                            heif_item_id metadata_id)
 {

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -1209,6 +1209,10 @@ struct heif_error heif_image_handle_get_metadata(const struct heif_image_handle*
                                                  heif_item_id metadata_id,
                                                  void* out_data);
 
+// Only valid for item type == "uri ", an absolute URI
+LIBHEIF_API
+const char* heif_image_handle_get_metadata_item_uri_type(const struct heif_image_handle* handle,
+                                                         heif_item_id metadata_id);
 
 // ------------------------- color profiles -------------------------
 


### PR DESCRIPTION
The version 2 and 3 of the `infe` box has an `item_type` field that has special case meaning for values of `mime` and `uri `.

The box definition and parsing handles those cases, and the C API exposes the `content_type` that is present for the special case of `mime`.

This PR exposes the `item_uri_type` that is present for the special case of `uri `. This is used to indicate special metadata types for the GIMI profile.

The API and implementation for `heif_image_handle_get_metadata_item_uri_type()`  is essentially the same as `heif_image_handle_get_metadata_content_type()`.

This PR also makes use of that value (if present) in the heif_info example.