### PR TITLE
cmake: Fix OS X compatibility_version based on libtool legacy

### DIFF
--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -100,6 +100,15 @@ set_target_properties(heif
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR})
 
+# compatibility_version defaults to 1.0.0 and is never allowed to be
+# decreased for any specific SONAME. Libtool in the libheif-1.15.1
+# release had set it to 17.0.0, so force it higher here.
+if (APPLE)
+    set_target_properties(heif
+            PROPERTIES
+	    LINK_FLAGS "-Wl,-compatibility_version,18.0.0")
+endif ()
+
 target_compile_definitions(heif
         PUBLIC
         LIBHEIF_EXPORTS


### PR DESCRIPTION
Sets a darwin linker value that must be monotonic, which libtool automatically had been incrementing but cmake automatically sets to 1.0.0. Fixes  #992