### PR TITLE
CMake: correctly detect `AOM_USAGE_GOOD_QUALITY`

### DIFF
--- a/cmake/modules/FindAOM.cmake
+++ b/cmake/modules/FindAOM.cmake
@@ -9,7 +9,9 @@ find_path(AOM_INCLUDE_DIR
     PATH_SUFFIXES AOM
 )
 
-check_symbol_exists(AOM_USAGE_GOOD_QUALITY ${AOM_INCLUDE_DIR}/aom/aom_encoder.h aom_usage_flag_exists)
+list(APPEND CMAKE_REQUIRED_INCLUDES ${AOM_INCLUDE_DIR})
+check_symbol_exists(AOM_USAGE_GOOD_QUALITY aom/aom_encoder.h aom_usage_flag_exists)
+unset(CMAKE_REQUIRED_INCLUDES)
 
 find_library(AOM_LIBRARY
     NAMES libaom aom


### PR DESCRIPTION
aom could be installed in a non-standard prefix, preventing the aom encoder from being used.
<details>
  <summary>Build log before</summary>

```
-- Looking for AOM_USAGE_GOOD_QUALITY
-- Looking for AOM_USAGE_GOOD_QUALITY - not found
```

```
Determining if the AOM_USAGE_GOOD_QUALITY exist passed with the following output:
Change Dir: /deps/heif/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/gmake cmTC_aa326/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_aa326.dir/build.make CMakeFiles/cmTC_aa326.dir/build
gmake[1]: Entering directory `/deps/heif/CMakeFiles/CMakeTmp'
Building C object CMakeFiles/cmTC_aa326.dir/CheckSymbolExists.c.o
/usr/bin/cc   -march=nehalem -Os -fPIC -D_GLIBCXX_USE_CXX11_ABI=1 -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections -O3  -fPIE   -o CMakeFiles/cmTC_aa326.dir/CheckSymbolExists.c.o   -c /deps/heif/CMakeFiles/CMakeTmp/CheckSymbolExists.c
In file included from /deps/heif/CMakeFiles/CMakeTmp/CheckSymbolExists.c:2:
/target/include/aom/aom_encoder.h:33:10: fatal error: aom/aom_codec.h: No such file or directory
   33 | #include "aom/aom_codec.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
gmake[1]: *** [CMakeFiles/cmTC_aa326.dir/CheckSymbolExists.c.o] Error 1
gmake[1]: Leaving directory `/deps/heif/CMakeFiles/CMakeTmp'
gmake: *** [cmTC_aa326/fast] Error 2


File /deps/heif/CMakeFiles/CMakeTmp/CheckSymbolExists.c:
/* */
#include </target/include/aom/aom_encoder.h>

int main(int argc, char** argv)
{
  (void)argv;
#ifndef AOM_USAGE_GOOD_QUALITY
  return ((int*)(&AOM_USAGE_GOOD_QUALITY))[argc];
#else
  (void)argc;
  return 0;
#endif
}
```
</details>



<details>
  <summary>Build log after</summary>

```
-- Looking for AOM_USAGE_GOOD_QUALITY
-- Looking for AOM_USAGE_GOOD_QUALITY - found
```

```
Determining if the AOM_USAGE_GOOD_QUALITY exist passed with the following output:
Change Dir: /deps/heif/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/gmake cmTC_c75f9/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_c75f9.dir/build.make CMakeFiles/cmTC_c75f9.dir/build
gmake[1]: Entering directory `/deps/heif/CMakeFiles/CMakeTmp'
Building C object CMakeFiles/cmTC_c75f9.dir/CheckSymbolExists.c.o
/usr/bin/cc  -I/target/include  -march=nehalem -Os -fPIC -D_GLIBCXX_USE_CXX11_ABI=1 -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections -O3  -fPIE   -o CMakeFiles/cmTC_c75f9.dir/CheckSymbolExists.c.o   -c /deps/heif/CMakeFiles/CMakeTmp/CheckSymbolExists.c
Linking C executable cmTC_c75f9
/usr/bin/cmake3 -E cmake_link_script CMakeFiles/cmTC_c75f9.dir/link.txt --verbose=1
/usr/bin/cc -march=nehalem -Os -fPIC -D_GLIBCXX_USE_CXX11_ABI=1 -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections -O3   -L/target/lib -Wl,--gc-sections -Wl,-rpath=$ORIGIN/  CMakeFiles/cmTC_c75f9.dir/CheckSymbolExists.c.o  -o cmTC_c75f9 
gmake[1]: Leaving directory `/deps/heif/CMakeFiles/CMakeTmp'


File /deps/heif/CMakeFiles/CMakeTmp/CheckSymbolExists.c:
/* */
#include <aom/aom_encoder.h>

int main(int argc, char** argv)
{
  (void)argv;
#ifndef AOM_USAGE_GOOD_QUALITY
  return ((int*)(&AOM_USAGE_GOOD_QUALITY))[argc];
#else
  (void)argc;
  return 0;
#endif
}
```

</details>