### PR TITLE
fuzzer: The box_size_without_header must be positive

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -657,7 +657,7 @@ Error Box::read(BitstreamRange& range, std::shared_ptr<Box>* result)
 
   // Box size may not be larger than remaining bytes in parent box.
 
-  if ((int64_t)range.get_remaining_bytes() < box_size_without_header) {
+  if ((int64_t)range.get_remaining_bytes() < box_size_without_header || box_size_without_header < 0) {
     return Error(heif_error_Invalid_input,
                  heif_suberror_Invalid_box_size);
   }


### PR DESCRIPTION
The fuzzer is throwing the following error:
/home/runner/work/libheif/libheif/libheif/box.cc:669:27: runtime error: implicit conversion from type 'int64_t' (aka 'long') of value -8 (64-bit, signed) to type 'size_t' (aka 'unsigned long') changed the value to 18446744073709551608 (64-bit, unsigned)

The BitstreamRange constructor expects a size_t, but an int64_t is being passed in (box.cc line 669). This is a problem when the value is negative. 