### PR TITLE
nclx: use default values that match sRGB

### DIFF
--- a/libheif/color-conversion/colorconversion.cc
+++ b/libheif/color-conversion/colorconversion.cc
@@ -446,8 +446,7 @@ std::shared_ptr<HeifPixelImage> ColorConversionPipeline::convert_image(const std
 
     // --- pass the color profiles to the new image
 
-    auto output_nclx = std::make_shared<color_profile_nclx>();
-    *output_nclx = step.output_state.nclx_profile;
+    auto output_nclx = std::make_shared<color_profile_nclx>(step.output_state.nclx_profile);
     out->set_color_profile_nclx(output_nclx);
     out->set_color_profile_icc(in->get_color_profile_icc());
 
@@ -546,7 +545,7 @@ std::shared_ptr<HeifPixelImage> convert_colorspace(const std::shared_ptr<HeifPix
     output_state.nclx_profile = *target_profile;
   }
 
-  // If some output nclx values are unspecified, set the to the same as the input.
+  // If some output nclx values are unspecified, set them to the same as the input.
 
   if (output_state.nclx_profile.get_matrix_coefficients() == heif_matrix_coefficients_unspecified) {
     output_state.nclx_profile.set_matrix_coefficients(input_state.nclx_profile.get_matrix_coefficients());

--- a/libheif/color-conversion/colorconversion.cc
+++ b/libheif/color-conversion/colorconversion.cc
@@ -520,18 +520,18 @@ std::shared_ptr<HeifPixelImage> convert_colorspace(const std::shared_ptr<HeifPix
     input_state.nclx_profile = *input->get_color_profile_nclx();
   }
 
-  // If some input nclx values are unspecified, use CCIR-601 values as default.
+  // If some input nclx values are unspecified, use values that match sRGB as default.
 
   if (input_state.nclx_profile.get_matrix_coefficients() == heif_matrix_coefficients_unspecified) {
-    input_state.nclx_profile.set_matrix_coefficients(heif_matrix_coefficients_ITU_R_BT_601_6);
+    input_state.nclx_profile.set_matrix_coefficients(heif_matrix_coefficients_ITU_R_BT_709_5);
   }
 
   if (input_state.nclx_profile.get_colour_primaries() == heif_color_primaries_unspecified) {
-    input_state.nclx_profile.set_colour_primaries(heif_color_primaries_ITU_R_BT_601_6);
+    input_state.nclx_profile.set_colour_primaries(heif_color_primaries_ITU_R_BT_709_5);
   }
 
-  if (input_state.nclx_profile.get_transfer_characteristics() == heif_color_primaries_unspecified) {
-    input_state.nclx_profile.set_transfer_characteristics(heif_transfer_characteristic_ITU_R_BT_601_6);
+  if (input_state.nclx_profile.get_transfer_characteristics() == heif_transfer_characteristic_unspecified) {
+    input_state.nclx_profile.set_transfer_characteristics(heif_transfer_characteristic_IEC_61966_2_1);
   }
 
   std::set<enum heif_channel> channels = input->get_channel_set();
@@ -555,7 +555,7 @@ std::shared_ptr<HeifPixelImage> convert_colorspace(const std::shared_ptr<HeifPix
     output_state.nclx_profile.set_colour_primaries(input_state.nclx_profile.get_colour_primaries());
   }
 
-  if (output_state.nclx_profile.get_transfer_characteristics() == heif_color_primaries_unspecified) {
+  if (output_state.nclx_profile.get_transfer_characteristics() == heif_transfer_characteristic_unspecified) {
     output_state.nclx_profile.set_transfer_characteristics(input_state.nclx_profile.get_transfer_characteristics());
   }
 

--- a/libheif/nclx.cc
+++ b/libheif/nclx.cc
@@ -294,9 +294,9 @@ struct heif_color_profile_nclx* color_profile_nclx::alloc_nclx_color_profile()
 
   if (profile) {
     profile->version = 1;
-    profile->color_primaries = heif_color_primaries_unspecified;
-    profile->transfer_characteristics = heif_transfer_characteristic_unspecified;
-    profile->matrix_coefficients = heif_matrix_coefficients_ITU_R_BT_601_6;
+    profile->color_primaries = heif_color_primaries_ITU_R_BT_709_5;
+    profile->transfer_characteristics = heif_transfer_characteristic_IEC_61966_2_1;
+    profile->matrix_coefficients = heif_matrix_coefficients_ITU_R_BT_709_5;
     profile->full_range_flag = true;
   }
 
@@ -312,9 +312,9 @@ void color_profile_nclx::free_nclx_color_profile(struct heif_color_profile_nclx*
 
 void color_profile_nclx::set_default()
 {
-  m_colour_primaries = 2;
-  m_transfer_characteristics = 2;
-  m_matrix_coefficients = 6;
+  m_colour_primaries = 1;
+  m_transfer_characteristics = 13;
+  m_matrix_coefficients = 1;
   m_full_range_flag = true;
 }
 


### PR DESCRIPTION
Since commit 062b5284216748925cdbf67f9eb8a12bbda503e1, libheif saves images with the default NCLX profile `6,6,6` (Rec. 601 aka NTSC) which is pretty far from sRGB and leads to incorrect colors in most viewers. Additionally, the `colr` HEIF box wasn't updated to reflect this.

Commit 673fb03227790cb5184c9c9aaa5c40775cb3afbf resolves the latter issue by guaranteeing the update of `target_nclx_profile` following the color conversion, thereby ensuring the propagation of any defaults specified in `ColorConversionPipeline::convert_image()`.

Commit 3bc75720f9eb686e2a674a710961422b9920d2e3 resolves the former issue by ensuring NCLX profiles defaults to `1,13,1`  (Rec. 709 with IEC 61966-2-1 transfer function).

Context: https://github.com/libvips/libvips/pull/3731

Thanks to @DarthSim for discovering this.