### PR TITLE
add property by reference

### DIFF
--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -986,7 +986,7 @@ void HeifFile::add_clap_property(heif_item_id id, uint32_t clap_width, uint32_t 
 }
 
 
-heif_property_id HeifFile::add_property(heif_item_id id, std::shared_ptr<Box> property, bool essential)
+heif_property_id HeifFile::add_property(heif_item_id id, const std::shared_ptr<Box>& property, bool essential)
 {
   int index = m_ipco_box->append_child_box(property);
 

--- a/libheif/file.h
+++ b/libheif/file.h
@@ -170,7 +170,7 @@ public:
 
   void add_pixi_property(heif_item_id id, uint8_t c1, uint8_t c2 = 0, uint8_t c3 = 0);
 
-  heif_property_id add_property(heif_item_id id, std::shared_ptr<Box> property, bool essential);
+  heif_property_id add_property(heif_item_id id, const std::shared_ptr<Box>& property, bool essential);
 
   Result<heif_item_id> add_infe(const char* item_type, const uint8_t* data, size_t size);
 


### PR DESCRIPTION
This is a tentative PR to resolve a clang-tidy recommendation - "The parameter 'property' is copied for each invocation but only used as a const reference; consider making it a const reference"

In some ways it feels like a micro-optimisation, but an easy change and also useful to keep the IDE "noise" down so that real issues are easier to see.