### PR TITLE
kvaazar: set chroma in kvazaar_query_input_colorspace2

### DIFF
--- a/libheif/plugins/encoder_kvazaar.cc
+++ b/libheif/plugins/encoder_kvazaar.cc
@@ -302,7 +302,11 @@ static void kvazaar_query_input_colorspace2(void* encoder_raw, heif_colorspace* 
   }
   else {
     *colorspace = heif_colorspace_YCbCr;
-    //*chroma = encoder->chroma;
+    if (*chroma != heif_chroma_420 &&
+        *chroma != heif_chroma_422 &&
+        *chroma != heif_chroma_444) {
+      *chroma = heif_chroma_420;
+    }
   }
 }
 


### PR DESCRIPTION
Hey there 👋

Currently, `kvazaar_query_input_colorspace2` preserves input `chroma`, and encoding of an RGBA input fails because of this. This PR makes `kvazaar_query_input_colorspace2` rewrite `chroma` if it is incompatible with `heif_colorspace_YCbCr`.