### PR TITLE
kvazaar: ensure input pucture dimensions are divisible by 8

### DIFF
--- a/libheif/plugins/encoder_kvazaar.cc
+++ b/libheif/plugins/encoder_kvazaar.cc
@@ -510,7 +510,17 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
   }
 */
 
-  kvz_picture* pic = api->picture_alloc_csp(kvzChroma, config->width, config->height);
+  uint32_t pic_width = config->width;
+  if (pic_width % 8 != 0) {
+    pic_width += 8 - (pic_width % 8);
+  }
+
+  uint32_t pic_height = config->height;
+  if (pic_height % 8 != 0) {
+    pic_height += 8 - (pic_height % 8);
+  }
+
+  kvz_picture* pic = api->picture_alloc_csp(kvzChroma, pic_width, pic_height);
   if (!pic) {
     api->config_destroy(config);
     return heif_error{


### PR DESCRIPTION
Hey there 👋

Kvazaar requires dimensions of the input `kvz_picture` to be divisible by 8. Otherwise, encoding fails and aborts the whole program. Unfortunately, Kvazaar's API doesn't do this for us.