### PR TITLE
Fix installing Gnome files if examples are build.

### DIFF
--- a/gnome/CMakeLists.txt
+++ b/gnome/CMakeLists.txt
@@ -1,3 +1,3 @@
-if(WITH_EXAMPLES AND TARGET PNG::PNG)
+if(TARGET heif-thumbnailer)
   install(FILES heif.thumbnailer DESTINATION ${CMAKE_INSTALL_DATADIR}/thumbnailers)
 endif()


### PR DESCRIPTION
Regression was introduced in 060b55c93ef2338998bf8bcc542421d9f5fd99fd.

Noticed this while working on the packaging of 1.17.4.