### PR TITLE
Fix build warnings and errors in Visual Studio 2022

### DIFF
--- a/extra/getopt_long.c
+++ b/extra/getopt_long.c
@@ -73,7 +73,7 @@ __progname(char * nargv0)
  *	Parse argc/argv argument vector.
  */
 int
-getopt_internal(int nargc, char ** nargv, const char *ostr)
+getopt_internal(int nargc, char * const* nargv, const char *ostr)
 {
 	static char *place = EMSG;		/* option letter processing */
 	const char *oli;				/* option letter list index */
@@ -142,7 +142,7 @@ getopt2(int nargc, char * nargv, const char *ostr)
 
 	if ((retval = getopt_internal(nargc, nargv, ostr)) == -2) {
 		retval = -1;
-		++optind; 
+		++optind;
 	}
 	return(retval);
 }
@@ -175,11 +175,11 @@ getopt_long(int nargc, char ** nargv, char * options, struct option * long_optio
 		} else
 			current_argv_len = strlen(current_argv);
 
-		for (i = 0; long_options[i].name; i++) { 
+		for (i = 0; long_options[i].name; i++) {
 			if (strncmp(current_argv, long_options[i].name, current_argv_len))
 				continue;
 
-			if (strlen(long_options[i].name) == (unsigned)current_argv_len) { 
+			if (strlen(long_options[i].name) == (unsigned)current_argv_len) {
 				match = i;
 				break;
 			}
@@ -215,7 +215,7 @@ getopt_long(int nargc, char ** nargv, char * options, struct option * long_optio
 		if (long_options[match].flag) {
 			*long_options[match].flag = long_options[match].val;
 			retval = 0;
-		} else 
+		} else
 			retval = long_options[match].val;
 		if (index)
 			*index = match;

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -2411,7 +2411,7 @@ static bool nclx_profile_matches_spec(heif_colorspace colorspace,
     image_nclx = std::make_shared<color_profile_nclx>();
   }
 
-  if (image_nclx->get_full_range_flag() != spec_nclx->full_range_flag) {
+  if (image_nclx->get_full_range_flag() != ( spec_nclx->full_range_flag == 0 ? false : true ) ) {
     return false;
   }
 
@@ -2938,9 +2938,9 @@ Error HeifContext::encode_image_as_jpeg2000(const std::shared_ptr<HeifPixelImage
   for (;;) {
     uint8_t* data;
     int size;
-    
+
     encoder->plugin->get_compressed_data(encoder->encoder, &data, &size, nullptr);
-    
+
     if (data == NULL) {
       break;
     }
@@ -2954,7 +2954,7 @@ Error HeifContext::encode_image_as_jpeg2000(const std::shared_ptr<HeifPixelImage
 
 
 
-  //Add 'ispe' Property 
+  //Add 'ispe' Property
   m_heif_file->add_ispe_property(image_id, image->get_width(), image->get_height());
 
   //Add 'colr' Property

--- a/libheif/plugins/encoder_svt.cc
+++ b/libheif/plugins/encoder_svt.cc
@@ -674,7 +674,7 @@ struct heif_error svt_encode_image(void* encoder_raw, const struct heif_image* i
   svt_config.logical_processors = encoder->threads;
 
   // disable 2-pass
-  svt_config.rc_stats_buffer = (SvtAv1FixedBuf) {nullptr, 0};
+  svt_config.rc_stats_buffer = {nullptr, 0};
 
   svt_config.rate_control_mode = 0; // constant rate factor
   //svt_config.enable_adaptive_quantization = 0;   // 2 is CRF (the default), 0 would be CQP


### PR DESCRIPTION
Made the implementation of getopt_internal match the declaration
Fix warning about the unsafe use of int as bool
Remove unnecessary cast (SvtAv1FixedBuf) causing compiler error