### PR TITLE
idat: protect against trying to output negative size

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -2854,7 +2854,11 @@ std::string Box_idat::dump(Indent& indent) const
   std::ostringstream sstr;
   sstr << Box::dump(indent);
 
-  sstr << indent << "number of data bytes: " << get_box_size() - get_header_size() << "\n";
+  if (get_box_size() >= get_header_size()) {
+    sstr << indent << "number of data bytes: " << get_box_size() - get_header_size() << "\n";
+  } else {
+     sstr << indent << "number of data bytes is invalid\n";
+  }
 
   return sstr.str();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,9 +16,10 @@ endmacro()
 # --- tests that require access to internal symbols
 
 if (WITH_REDUCED_VISIBILITY)
-    message(WARNING "Conversion and JPEG 2000 box unit tests can only be compiled with full symbol visibility (WITH_REDUCED_VISIBILITY=OFF)")
+    message(WARNING "Conversion and box unit tests can only be compiled with full symbol visibility (WITH_REDUCED_VISIBILITY=OFF)")
 else()
     add_libheif_test(conversion)
+    add_libheif_test(idat)
     add_libheif_test(jpeg2000)
 endif()
 

--- a/tests/idat.cc
+++ b/tests/idat.cc
@@ -1,0 +1,51 @@
+/*
+  libheif Item Data Box (idat) unit tests
+
+  MIT License
+
+  Copyright (c) 2023 Brad Hards <bradh@frogmouth.net>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include "catch.hpp"
+#include "libheif/box.h"
+#include <cstdint>
+#include <iostream>
+
+TEST_CASE("idat bad") {
+  std::vector<uint8_t> testData{0x00, 0x00, 0x00, 0x00, 'i',
+                                'd',  'a',  't',  0x65};
+  auto reader = std::make_shared<StreamReader_memory>(testData.data(),
+                                                      testData.size(), false);
+
+  BitstreamRange range(reader, testData.size());
+  for (;;) {
+    std::shared_ptr<Box> box;
+    Error error = Box::read(range, &box);
+    if (error != Error::Ok || range.error()) {
+      break;
+    }
+
+    box->get_type();
+    box->get_type_string();
+    Indent indent;
+    box->dump(indent);
+  }
+}


### PR DESCRIPTION
This one showed up in box fuzzing.

I wasn't sure about creating a new unit test - can drop that part if you would prefer.