### PR TITLE
examples: update heif-info manual page

### DIFF
--- a/examples/heif-info.1
+++ b/examples/heif-info.1
@@ -5,6 +5,7 @@ heif-info \- show information on HEIC/HEIF file
 .B heif-info
 [\fB\-d\fR|\fB--dump-boxes\fR]
 [\fB\-h\fR|\fB--help\fR]
+[\fB\-v\fR|\fB--version\fR]
 .IR filename
 .SH DESCRIPTION
 .B heif-info
@@ -14,8 +15,11 @@ Show information on HEIC/HEIF file.
 .BR \-d ", " \-\-dump-boxes\fR
 Show a low-level dump of all MP4 file boxes.
 .TP
-.BR \-help ", " \-\-help\fR
-Show help.
+.BR \-h ", " \-\-help\fR
+Show help. A filename is not required or used.
+.TP
+.BR \-v ", " \-\-version\fR
+Show version information for the tool, library version, and the plugin path. A filename is not required or used.
 .SH EXIT STATUS
 .PP
 \fB0\fR


### PR DESCRIPTION
This updates the documentation to reflect the new version option. It also fixes a duplication in the descriptive part for help (was `-help` and `--help`, instead of `-h` and `--help`).