### PR TITLE
svt: fix c99 extension warning

### DIFF
--- a/libheif/plugins/encoder_svt.cc
+++ b/libheif/plugins/encoder_svt.cc
@@ -674,7 +674,7 @@ struct heif_error svt_encode_image(void* encoder_raw, const struct heif_image* i
   svt_config.logical_processors = encoder->threads;
 
   // disable 2-pass
-  svt_config.rc_stats_buffer = (SvtAv1FixedBuf) {nullptr, 0};
+  svt_config.rc_stats_buffer = SvtAv1FixedBuf {nullptr, 0};
 
   svt_config.rate_control_mode = 0; // constant rate factor
   //svt_config.enable_adaptive_quantization = 0;   // 2 is CRF (the default), 0 would be CQP


### PR DESCRIPTION
(Same as #1059, just this is for master and that is for develop-v1.18.0 branch)

Resolves https://github.com/strukturag/libheif/issues/956

See https://github.com/strukturag/libheif/issues/956 for the MSVC and clang warning (that becomes an error)