### PR TITLE
x265: add x265_cleanup() call to plugin cleanup

### DIFF
--- a/libheif/plugins/encoder_x265.cc
+++ b/libheif/plugins/encoder_x265.cc
@@ -299,6 +299,7 @@ static void x265_init_plugin()
 
 static void x265_cleanup_plugin()
 {
+  x265_cleanup();
 }
 
 


### PR DESCRIPTION
See #960 for the origin, and in particular https://github.com/strukturag/libheif/issues/960#issuecomment-1848861666 for the analysis.

Resolves #960 and #940 (in that this is outside libheif, and we are now calling the only API available).