### PR TITLE
exif: protect against EXIF data overflow

### DIFF
--- a/examples/encoder_jpeg.cc
+++ b/examples/encoder_jpeg.cc
@@ -177,12 +177,11 @@ bool JpegEncoder::Encode(const struct heif_image_handle* handle,
       static const uint8_t kExifMarker = JPEG_APP0 + 1;
 
       uint32_t skip = (exifdata[0]<<24) | (exifdata[1]<<16) | (exifdata[2]<<8) | exifdata[3];
-      skip += 4;
-
-      if (skip > exifsize) {
+      if (skip > (exifsize - 4)) {
         fprintf(stderr, "Invalid EXIF data (offset too large)\n");
         return false;
       }
+      skip += 4;
 
       uint8_t* ptr = exifdata + skip;
       size_t size = exifsize - skip;


### PR DESCRIPTION
Relates #1042.

https://github.com/strukturag/libheif/commit/26ec3953d46bb5756b97955661565bcbc6647abf resolved #1042 with protection against EXIF overflow in the JPEG encoder.

However the report at #1042 was against the PNG encoder.  That is addressed at #1052. The review for that identified that its possible to get an overflow in the `size += 4`, and it looks like that is possible in the JPEG version too.

This PR incorporates the same fix as suggested for #1052.