### PR TITLE
Set kvazaar config threads to 0 if ENABLE_MULTITHREADING_SUPPORT is false

### DIFF
--- a/libheif/plugins/encoder_kvazaar.cc
+++ b/libheif/plugins/encoder_kvazaar.cc
@@ -382,8 +382,15 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
 
   kvz_config* config = api->config_alloc();
   api->config_init(config); // param, encoder->preset.c_str(), encoder->tune.c_str());
+
 #if HAVE_KVAZAAR_ENABLE_LOGGING
   config->enable_logging_output = 0;
+#endif
+
+#if !ENABLE_MULTITHREADING_SUPPORT
+  // 0: Process everything with main thread
+  // -1 (default): Select automatically.
+  config->threads = 0;
 #endif
 
 #if 1


### PR DESCRIPTION
The background:

I am trying to build libheif to wasm with kvazaar.
The building is successful but it run with error from kvazaar:
```
--threads=auto value set to 4.
pthread_create failed!
Could not initialize threadqueue.
```

It seems that kvazaar doesn't provide a build option for disable threads, the only way is settings `config->threads` to `0` at runtime.