### PR TITLE
AppVeyor CI: Update to Visual Studio 2022 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # stats available at
 # https://ci.appveyor.com/project/strukturag/libheif
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 cache: c:\tools\vcpkg\installed\
 


### PR DESCRIPTION
Update the AppVeyor CI configuration to the Visual Studio 2022 image. This [updates](https://www.appveyor.com/docs/windows-images-software/) Visual Studio from 16.11.24 to 17.5.0.

AppVeyor builds can be viewed at: https://ci.appveyor.com/project/strukturag/libheif