### PR TITLE
add support for iden derived images

### DIFF
--- a/go/heif/heif.go
+++ b/go/heif/heif.go
@@ -301,6 +301,8 @@ const (
 
 	SuberrorInvalidRegionData = C.heif_suberror_Invalid_region_data
 
+	SuberrorMissingIrefReference = C.heif_suberror_missing_iref_reference
+
 	SuberrorWrongTileImagePixelDepth = C.heif_suberror_Wrong_tile_image_pixel_depth
 
 	SuberrorUnknownNCLXColorPrimaries = C.heif_suberror_Unknown_NCLX_color_primaries

--- a/libheif/error.cc
+++ b/libheif/error.cc
@@ -158,6 +158,8 @@ const char* Error::get_error_string(heif_suberror_code err)
       return "Unknown NCLX matrix coefficients";
     case heif_suberror_Invalid_region_data:
       return "Invalid region item data";
+    case heif_suberror_missing_iref_reference:
+      return "'iref' box does not include a referenced item";
     case heif_suberror_Invalid_J2K_codestream:
       return "Invalid JPEG 2000 codestream";
 

--- a/libheif/file.h
+++ b/libheif/file.h
@@ -232,15 +232,17 @@ private:
   Error parse_heif_file(BitstreamRange& bitstream);
 
   Error check_for_ref_cycle(heif_item_id ID,
-                            std::shared_ptr<Box_iref>& iref_box) const;
+                            const std::shared_ptr<Box_iref>& iref_box) const;
 
   Error check_for_ref_cycle_recursion(heif_item_id ID,
-                                      std::shared_ptr<Box_iref>& iref_box,
+                                      const std::shared_ptr<Box_iref>& iref_box,
                                       std::unordered_set<heif_item_id>& parent_items) const;
 
   std::shared_ptr<Box_infe> get_infe(heif_item_id ID) const;
 
   int jpeg_get_bits_per_pixel(heif_item_id imageID) const;
+
+  Error get_source_image_id(const heif_item_id to_ID, heif_item_id *from_ID) const;
 };
 
 #endif

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -229,6 +229,9 @@ enum heif_suberror_code
   // Invalid specification of region item
   heif_suberror_Invalid_region_data = 136,
 
+  // An item was referenced, but the iref entry didn't include it
+  heif_suberror_missing_iref_reference = 137,
+
   // Invalid JPEG 2000 codestream - usually a missing marker
   heif_suberror_Invalid_J2K_codestream = 140,
 

--- a/libheif/heif_emscripten.h
+++ b/libheif/heif_emscripten.h
@@ -353,6 +353,7 @@ EMSCRIPTEN_BINDINGS(libheif) {
     .value("heif_suberror_Item_reference_cycle", heif_suberror_Item_reference_cycle)
     .value("heif_suberror_Invalid_pixi_box", heif_suberror_Invalid_pixi_box)
     .value("heif_suberror_Invalid_region_data", heif_suberror_Invalid_region_data)
+    .value("heif_suberror_missing_iref_reference", heif_suberror_missing_iref_reference)
     .value("heif_suberror_Invalid_J2K_codestream", heif_suberror_Invalid_J2K_codestream)
     .value("heif_suberror_Unsupported_codec", heif_suberror_Unsupported_codec)
     .value("heif_suberror_Unsupported_image_type", heif_suberror_Unsupported_image_type)


### PR DESCRIPTION
This adds support for `iden` derived images.

For simple cases, see https://github.com/nokiatech/heif_conformance/blob/master/conformance_files/C008.heic and https://github.com/nokiatech/heif_conformance/blob/master/conformance_files/C014.heic

I could see that as a pretty simple edit - where you don't want to redo the encoding, just to rotate / crop.

A more interesting case is https://github.com/nokiatech/heif_conformance/blob/master/conformance_files/C023.heic where four source images are cropped (`clap`) and then incorporated into a grid.

https://github.com/nokiatech/heif_conformance/blob/master/conformance_files/C039.heic is a bit trickier - it does two-stage `iden`. I could maybe see that as a progressive edit.

This PR supports all of those cases.

There is a potential issue around colour handling and alpha. We have code like https://github.com/strukturag/libheif/blob/master/libheif/context.cc#L836-L874 and https://github.com/strukturag/libheif/blob/master/libheif/context.cc#L1058-L1113 that does special handling for the `grid` case. Possibly `iden` needs to be added to that. I don't have any examples though, and am not confident about the changes.

