### PR TITLE
macOS: fix "av_version_info" - Undefined symbol

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -134,7 +134,8 @@ function (_ffmpeg_find component headername)
   endif ()
 endfunction ()
 
-_ffmpeg_find(avutil     avutil.h)
+_ffmpeg_find(avutil     avutil.h
+  avutil)
 _ffmpeg_find(avresample avresample.h
   avutil)
 _ffmpeg_find(swresample swresample.h


### PR DESCRIPTION
Closes: #1095

Maybe this will help, apparently there was just a typo