### PR TITLE
plugins: fix return value for X_get_parameter_string()

### DIFF
--- a/libheif/plugins/encoder_aom.cc
+++ b/libheif/plugins/encoder_aom.cc
@@ -660,6 +660,7 @@ struct heif_error aom_get_parameter_string(void* encoder_raw, const char* name,
         assert(false);
         return heif_error_invalid_parameter_value;
     }
+    return heif_error_ok;
   }
   else if (strcmp(name, kParam_tune) == 0) {
     switch (encoder->tune) {
@@ -673,6 +674,7 @@ struct heif_error aom_get_parameter_string(void* encoder_raw, const char* name,
         assert(false);
         return heif_error_invalid_parameter_value;
     }
+    return heif_error_ok;
   }
 
   return heif_error_unsupported_parameter;

--- a/libheif/plugins/encoder_openjpeg.cc
+++ b/libheif/plugins/encoder_openjpeg.cc
@@ -248,22 +248,25 @@ struct heif_error opj_get_parameter_string(void* encoder_raw, const char* name, 
 {
   struct encoder_struct_opj* encoder = (struct encoder_struct_opj*) encoder_raw;
 
-  switch (encoder->chroma) {
-    case heif_chroma_420:
-      save_strcpy(value, value_size, "420");
-      break;
-    case heif_chroma_422:
-      save_strcpy(value, value_size, "422");
-      break;
-    case heif_chroma_444:
-      save_strcpy(value, value_size, "444");
-      break;
-    case heif_chroma_undefined:
-      save_strcpy(value, value_size, "undefined");
-      break;
-    default:
-      assert(false);
-      return heif_error_invalid_parameter_value;
+  if (strcmp(name, kParam_chroma) == 0) {
+    switch (encoder->chroma) {
+      case heif_chroma_420:
+        save_strcpy(value, value_size, "420");
+        break;
+      case heif_chroma_422:
+        save_strcpy(value, value_size, "422");
+        break;
+      case heif_chroma_444:
+        save_strcpy(value, value_size, "444");
+        break;
+      case heif_chroma_undefined:
+        save_strcpy(value, value_size, "undefined");
+        break;
+      default:
+        assert(false);
+        return heif_error_invalid_parameter_value;
+      }
+      return heif_error_ok;
   }
 
   return heif_error_unsupported_parameter;

--- a/libheif/plugins/encoder_rav1e.cc
+++ b/libheif/plugins/encoder_rav1e.cc
@@ -415,19 +415,22 @@ struct heif_error rav1e_get_parameter_string(void* encoder_raw, const char* name
 {
   struct encoder_struct_rav1e* encoder = (struct encoder_struct_rav1e*) encoder_raw;
 
-  switch (encoder->chroma) {
-    case heif_chroma_420:
-      save_strcpy(value, value_size, "420");
-      break;
-    case heif_chroma_422:
-      save_strcpy(value, value_size, "422");
-      break;
-    case heif_chroma_444:
-      save_strcpy(value, value_size, "444");
-      break;
-    default:
-      assert(false);
-      return heif_error_invalid_parameter_value;
+  if (strcmp(name, kParam_chroma) == 0) {
+    switch (encoder->chroma) {
+      case heif_chroma_420:
+        save_strcpy(value, value_size, "420");
+        break;
+      case heif_chroma_422:
+        save_strcpy(value, value_size, "422");
+        break;
+      case heif_chroma_444:
+        save_strcpy(value, value_size, "444");
+        break;
+      default:
+        assert(false);
+        return heif_error_invalid_parameter_value;
+    }
+    return heif_error_ok;
   }
 
   return heif_error_unsupported_parameter;

--- a/libheif/plugins/encoder_svt.cc
+++ b/libheif/plugins/encoder_svt.cc
@@ -489,6 +489,7 @@ struct heif_error svt_get_parameter_string(void* encoder_raw, const char* name,
         assert(false);
         return heif_error_invalid_parameter_value;
     }
+    return heif_error_ok;
   }
 
   return heif_error_unsupported_parameter;

--- a/libheif/plugins/encoder_x265.cc
+++ b/libheif/plugins/encoder_x265.cc
@@ -571,6 +571,7 @@ static struct heif_error x265_get_parameter_string(void* encoder_raw, const char
         assert(false);
         return heif_error_invalid_parameter_value;
     }
+    return heif_error_ok;
   }
 
   return heif_error_unsupported_parameter;


### PR DESCRIPTION
In the encoder plugins, we have code that looks like:
https://github.com/strukturag/libheif/blob/master/libheif/plugins/encoder_aom.cc#L648-L678

The problem is that if we return `heif_error_unsupported_parameter` even if it is valid.

That doesn't show up in `heif-enc` example, because we ignore the return value. However it doesn't look reasonable.

There is another problem in some of the codecs, where we assume the only string parameter is `chroma`. 

This PR addresses both issues across the codecs that have the problem (pretty much anything that supports a string parameter, given the way the plugins have developed).

Note that there are likely similar problems in other methods, but I wanted to keep this PR simple.
