### PR TITLE
examples: fix leak in PNG decoder

### DIFF
--- a/examples/decoder_png.cc
+++ b/examples/decoder_png.cc
@@ -419,6 +419,7 @@ InputImage loadPNG(const char* filename, int output_bit_depth)
   } // for
 
   delete[] row_pointers;
+  fclose(fh);
 
   input_image.image = std::shared_ptr<heif_image>(image,
                                                   [](heif_image* img) { heif_image_release(img); });


### PR DESCRIPTION
This shows up with heif-enc (e.g. with --avif) under valgrind