### PR TITLE
initial version of regression test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 # see here: https://stackoverflow.com/questions/7335420/global-git-ignore
 
 build
+regression/*/__pycache__/
 third-party/SVT-AV1/
 third-party/dav1d/
 third-party/libwebp/
 third-party/rav1e/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,10 @@ endif()
 
 add_subdirectory (gnome)
 
+option(ENABLE_REGRESSION "Enable regression test framework (requires downloads)" OFF)
+if (ENABLE_REGRESSION)
+  add_subdirectory(regression)
+endif()
 
 # --- packaging (source code)
 

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(pytest_url https://github.com/buddly27/pytest-cmake/archive/main.zip)
+
+# Fetch CMake files from the main branch of the Github repository
+file(DOWNLOAD ${pytest_url} ${CMAKE_BINARY_DIR}/regression/pytest.zip)
+file(
+    ARCHIVE_EXTRACT INPUT ${CMAKE_BINARY_DIR}/regression/pytest.zip
+    DESTINATION ${CMAKE_BINARY_DIR}/regression
+    PATTERNS "*.cmake"
+)
+
+# Expand the module path variable to discover the `FindPytest.cmake` module.
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_BINARY_DIR}/regression/pytest-cmake-main/cmake)
+
+find_package(Pytest REQUIRED)
+
+set(TESTING_DATA_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data")
+configure_file(test_data.json.in ${CMAKE_BINARY_DIR}/regression/test_data.json)
+configure_file(version.json.in ${CMAKE_BINARY_DIR}/regression/version.json)
+
+add_test(
+    NAME Regression
+    COMMAND Pytest::Pytest ${CMAKE_CURRENT_SOURCE_DIR}
+)
+

--- a/regression/data/conformance_files_expected_dump/C001.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C001.heic.dump
@@ -1,0 +1,94 @@
+Box: ftyp -----
+size: 36   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,heic,mif1,iso8
+
+Box: meta -----
+size: 303   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1018
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1018
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1083
+|   extents: 16,111554 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1018
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 165   (header size: 8)
+| | Box: ipco -----
+| | size: 136   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | 
+| | Box: ipma -----
+| | size: 21   (header size: 12)
+| | associations for item ID: 1018
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+
+Box: moov -----
+size: 744   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, heic, mif1, iso8

--- a/regression/data/conformance_files_expected_dump/C002.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C002.heic.dump
@@ -1,0 +1,91 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 303   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 327
+|   extents: 16,111554 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 165   (header size: 8)
+| | Box: ipco -----
+| | size: 136   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | 
+| | Box: ipma -----
+| | size: 21   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 111570   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C003.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C003.heic.dump
@@ -1,0 +1,142 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 465   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 489
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 489
+|   extents: 111570,112393 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 278   (header size: 8)
+| | Box: ipco -----
+| | size: 244   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | 
+| | Box: ipma -----
+| | size: 26   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 223963   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C004.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C004.heic.dump
@@ -1,0 +1,265 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 813   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 196   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 16,124054 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 124070,136091 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 260161,137190 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 397351,137792 
+| item ID: 1010
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 535143,137626 
+| item ID: 1012
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 672769,138038 
+| item ID: 1014
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 810807,138611 
+| item ID: 1016
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 949418,138582 
+| item ID: 1018
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 1088000,138698 
+| item ID: 1020
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 837
+|   extents: 1226698,138887 
+| 
+| Box: iinf -----
+| size: 324   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1010
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1012
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1014
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1016
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1018
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1020
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 222   (header size: 8)
+| | Box: ipco -----
+| | size: 148   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d a0 02 80 80 2d 16 59 98 a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | 
+| | Box: ipma -----
+| | size: 66   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1010
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1012
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1014
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1016
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1018
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1020
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 1365585   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C005.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C005.heic.dump
@@ -1,0 +1,151 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 510   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1005
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 534
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 534
+|   extents: 111570,1667 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'thmb' from ID: 1005 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 297   (header size: 8)
+| | Box: ipco -----
+| | size: 263   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 107   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 10 20 49 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 128
+| | | image height: 72
+| | 
+| | Box: ipma -----
+| | size: 26   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 113237   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C006.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C006.heic.dump
@@ -1,0 +1,152 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 543   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 567
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 567
+|   extents: 111570,308 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: true
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'auxl' from ID: 1005 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 330   (header size: 8)
+| | Box: ipco -----
+| | size: 295   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 78 9d 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 78 a0 02 80 80 2d 16 59 d8 a9 24 21 1a e0 10 00 00 03 00 10 00 00 03 01 90 80 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 77 d9 89 
+| | | 
+| | | Box: auxC -----
+| | | size: 39   (header size: 12)
+| | | aux type: urn:mpeg:hevc:2015:auxid:1
+| | | aux subtypes: 
+| | 
+| | Box: ipma -----
+| | size: 27   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 111878   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C007.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C007.heic.dump
@@ -1,0 +1,185 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 647   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1009
+| 
+| Box: iloc -----
+| size: 116   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 16,124054 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 124070,136091 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 260161,137190 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 397351,137792 
+| item ID: 1009
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,8 
+| 
+| Box: iinf -----
+| size: 172   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1009
+| | item_protection_index: 0
+| | item_type: grid
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 32   (header size: 12)
+| reference with type 'dimg' from ID: 1009 to IDs: 1002 1004 1006 1008 
+| 
+| Box: idat -----
+| size: 16   (header size: 8)
+| number of data bytes: 8
+| 
+| Box: iprp -----
+| size: 216   (header size: 8)
+| | Box: ipco -----
+| | size: 168   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d a0 02 80 80 2d 16 59 98 a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 2560
+| | | image height: 1440
+| | 
+| | Box: ipma -----
+| | size: 40   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1009
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 1010
+| | entity IDs: 1009 1002 
+
+Box: mdat -----
+size: 535143   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C008.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C008.heic.dump
@@ -1,0 +1,164 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 539   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1006
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 563
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 563
+|   extents: 111570,112393 
+| 
+| Box: iinf -----
+| size: 110   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'dimg' from ID: 1006 to IDs: 1005 
+| 
+| Box: iprp -----
+| size: 292   (header size: 8)
+| | Box: ipco -----
+| | size: 253   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: irot -----
+| | | size: 9   (header size: 8)
+| | | rotation: 90 degrees (CCW)
+| | 
+| | Box: ipma -----
+| | size: 31   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: true)
+
+Box: mdat -----
+size: 223963   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C009.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C009.heic.dump
@@ -1,0 +1,142 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 465   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 489
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 489
+|   extents: 111570,112393 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: true
+| 
+| Box: iprp -----
+| size: 278   (header size: 8)
+| | Box: ipco -----
+| | size: 244   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | 
+| | Box: ipma -----
+| | size: 26   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 223963   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C010.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C010.heic.dump
@@ -1,0 +1,148 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 501   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 525
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 525
+|   extents: 111570,112393 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 278   (header size: 8)
+| | Box: ipco -----
+| | size: 244   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | 
+| | Box: ipma -----
+| | size: 26   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 1006
+| | entity IDs: 1002 1005 
+
+Box: mdat -----
+size: 223963   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C011.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C011.heic.dump
@@ -1,0 +1,204 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 683   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 70   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 707
+|   extents: 16,112393 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 707
+|   extents: 112409,111554 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 707
+|   extents: 223963,29653 
+| 
+| Box: iinf -----
+| size: 107   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: true
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: true
+| 
+| Box: iprp -----
+| size: 411   (header size: 8)
+| | Box: ipco -----
+| | size: 372   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 640
+| | | image height: 360
+| | 
+| | Box: ipma -----
+| | size: 31   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 1009
+| | entity IDs: 1005 1008 
+
+Box: mdat -----
+size: 253616   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C012.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C012.heic.dump
@@ -1,0 +1,554 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 1811   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 394   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 16,124054 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 124070,136091 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 260161,137190 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 397351,137792 
+| item ID: 1010
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 535143,137626 
+| item ID: 1012
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 672769,138038 
+| item ID: 1014
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 810807,138611 
+| item ID: 1016
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 949418,138582 
+| item ID: 1018
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1088000,138698 
+| item ID: 1020
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1226698,138887 
+| item ID: 1023
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1365585,1632 
+| item ID: 1025
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1367217,1787 
+| item ID: 1027
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1369004,1863 
+| item ID: 1029
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1370867,1904 
+| item ID: 1031
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1372771,1950 
+| item ID: 1033
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1374721,1949 
+| item ID: 1035
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1376670,1923 
+| item ID: 1037
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1378593,1930 
+| item ID: 1039
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1380523,1934 
+| item ID: 1041
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1382457,1961 
+| item ID: 1044
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1835
+|   extents: 1384418,111554 
+| 
+| Box: iinf -----
+| size: 665   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1010
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1012
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1014
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1016
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1018
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1020
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1023
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1025
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1027
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1029
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1031
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1033
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1035
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1037
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1039
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1041
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1044
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 168   (header size: 12)
+| reference with type 'thmb' from ID: 1023 to IDs: 1002 
+| reference with type 'thmb' from ID: 1025 to IDs: 1004 
+| reference with type 'thmb' from ID: 1027 to IDs: 1006 
+| reference with type 'thmb' from ID: 1029 to IDs: 1008 
+| reference with type 'thmb' from ID: 1031 to IDs: 1010 
+| reference with type 'thmb' from ID: 1033 to IDs: 1012 
+| reference with type 'thmb' from ID: 1035 to IDs: 1014 
+| reference with type 'thmb' from ID: 1037 to IDs: 1016 
+| reference with type 'thmb' from ID: 1039 to IDs: 1018 
+| reference with type 'thmb' from ID: 1041 to IDs: 1020 
+| reference with type 'base' from ID: 1044 to IDs: 1023 1025 
+| 
+| Box: iprp -----
+| size: 525   (header size: 8)
+| | Box: ipco -----
+| | size: 396   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d a0 02 80 80 2d 16 59 98 a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 30
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 1e 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 1e a0 10 20 49 65 99 8a 92 42 11 ae 68 08 00 00 03 00 08 00 00 03 00 c8 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 22 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 128
+| | | image height: 72
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | 
+| | Box: ipma -----
+| | size: 121   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1010
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1012
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1014
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1016
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1018
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1020
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1023
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1025
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1027
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1029
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1031
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1033
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1035
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1037
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1039
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1041
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1044
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 1495972   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C013.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C013.heic.dump
@@ -1,0 +1,154 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 547   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 571
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 571
+|   extents: 111570,112393 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 360   (header size: 8)
+| | Box: ipco -----
+| | size: 324   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: clap -----
+| | | size: 40   (header size: 8)
+| | | clean_aperture: 300/1 x 300/1
+| | | offset: 0/1 ; 0/1
+| | | 
+| | | Box: clap -----
+| | | size: 40   (header size: 8)
+| | | clean_aperture: 300/1 x 300/1
+| | | offset: 0/1 ; 0/1
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: true)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: true)
+
+Box: mdat -----
+size: 223963   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C014.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C014.heic.dump
@@ -1,0 +1,189 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 642   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1007
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 666
+|   extents: 16,111554 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 666
+|   extents: 111570,112393 
+| 
+| Box: iinf -----
+| size: 144   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1003
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1007
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 40   (header size: 12)
+| reference with type 'dimg' from ID: 1003 to IDs: 1002 
+| reference with type 'dimg' from ID: 1007 to IDs: 1006 
+| 
+| Box: iprp -----
+| size: 347   (header size: 8)
+| | Box: ipco -----
+| | size: 302   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: irot -----
+| | | size: 9   (header size: 8)
+| | | rotation: 180 degrees (CCW)
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: clap -----
+| | | size: 40   (header size: 8)
+| | | clean_aperture: 300/1 x 300/1
+| | | offset: 0/1 ; 0/1
+| | | 
+| | | Box: irot -----
+| | | size: 9   (header size: 8)
+| | | rotation: 90 degrees (CCW)
+| | 
+| | Box: ipma -----
+| | size: 37   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1003
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | associations for item ID: 1006
+| | | property index: 4 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1007
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: true)
+| | | property index: 6 (essential: true)
+
+Box: mdat -----
+size: 223963   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C015.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C015.heic.dump
@@ -1,0 +1,173 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 605   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 76   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 111570,112393 
+| item ID: 1006
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,22 
+| 
+| Box: iinf -----
+| size: 110   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: iovl
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 28   (header size: 12)
+| reference with type 'dimg' from ID: 1006 to IDs: 1002 1005 
+| 
+| Box: idat -----
+| size: 30   (header size: 8)
+| number of data bytes: 22
+| 
+| Box: iprp -----
+| size: 302   (header size: 8)
+| | Box: ipco -----
+| | size: 264   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1440
+| | | image height: 960
+| | 
+| | Box: ipma -----
+| | size: 30   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 223963   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C016.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C016.heic.dump
@@ -1,0 +1,122 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 435   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 56   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 459
+|   extents: 16,111554 
+| item ID: 1003
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,18 
+| 
+| Box: iinf -----
+| size: 79   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1003
+| | item_protection_index: 0
+| | item_type: iovl
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'dimg' from ID: 1003 to IDs: 1002 
+| 
+| Box: idat -----
+| size: 26   (header size: 8)
+| number of data bytes: 18
+| 
+| Box: iprp -----
+| size: 189   (header size: 8)
+| | Box: ipco -----
+| | size: 156   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1440
+| | | image height: 960
+| | 
+| | Box: ipma -----
+| | size: 25   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1003
+| | | property index: 3 (essential: false)
+
+Box: mdat -----
+size: 111570   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C017.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C017.heic.dump
@@ -1,0 +1,173 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 605   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 76   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 16,29653 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 29669,29978 
+| item ID: 1006
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,22 
+| 
+| Box: iinf -----
+| size: 110   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: iovl
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 28   (header size: 12)
+| reference with type 'dimg' from ID: 1006 to IDs: 1005 1002 
+| 
+| Box: idat -----
+| size: 30   (header size: 8)
+| number of data bytes: 22
+| 
+| Box: iprp -----
+| size: 302   (header size: 8)
+| | Box: ipco -----
+| | size: 264   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 640
+| | | image height: 360
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1440
+| | | image height: 960
+| | 
+| | Box: ipma -----
+| | size: 30   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 59647   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C018.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C018.heic.dump
@@ -1,0 +1,173 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 605   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 76   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 16,29653 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 29669,29978 
+| item ID: 1006
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,22 
+| 
+| Box: iinf -----
+| size: 110   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: iovl
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 28   (header size: 12)
+| reference with type 'dimg' from ID: 1006 to IDs: 1005 1002 
+| 
+| Box: idat -----
+| size: 30   (header size: 8)
+| number of data bytes: 22
+| 
+| Box: iprp -----
+| size: 302   (header size: 8)
+| | Box: ipco -----
+| | size: 264   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 640
+| | | image height: 360
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1440
+| | | image height: 960
+| | 
+| | Box: ipma -----
+| | size: 30   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 59647   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C019.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C019.heic.dump
@@ -1,0 +1,173 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 605   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 76   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 16,29653 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 29669,29978 
+| item ID: 1006
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,22 
+| 
+| Box: iinf -----
+| size: 110   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: iovl
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 28   (header size: 12)
+| reference with type 'dimg' from ID: 1006 to IDs: 1005 1002 
+| 
+| Box: idat -----
+| size: 30   (header size: 8)
+| number of data bytes: 22
+| 
+| Box: iprp -----
+| size: 302   (header size: 8)
+| | Box: ipco -----
+| | size: 264   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 640
+| | | image height: 360
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1440
+| | | image height: 960
+| | 
+| | Box: ipma -----
+| | size: 30   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 59647   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C020.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C020.heic.dump
@@ -1,0 +1,173 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 605   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 76   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 16,29653 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 629
+|   extents: 29669,29978 
+| item ID: 1006
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,22 
+| 
+| Box: iinf -----
+| size: 110   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: iovl
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 28   (header size: 12)
+| reference with type 'dimg' from ID: 1006 to IDs: 1005 1002 
+| 
+| Box: idat -----
+| size: 30   (header size: 8)
+| number of data bytes: 22
+| 
+| Box: iprp -----
+| size: 302   (header size: 8)
+| | Box: ipco -----
+| | size: 264   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 640
+| | | image height: 360
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 05 02 01 69 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1440
+| | | image height: 960
+| | 
+| | Box: ipma -----
+| | size: 30   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 59647   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C021.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C021.heic.dump
@@ -1,0 +1,8 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C022.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C022.heic.dump
@@ -1,0 +1,185 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 647   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1009
+| 
+| Box: iloc -----
+| size: 116   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 16,124054 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 124070,136091 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 260161,137190 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 671
+|   extents: 397351,137792 
+| item ID: 1009
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,8 
+| 
+| Box: iinf -----
+| size: 172   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1009
+| | item_protection_index: 0
+| | item_type: grid
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 32   (header size: 12)
+| reference with type 'dimg' from ID: 1009 to IDs: 1002 1004 1006 1008 
+| 
+| Box: idat -----
+| size: 16   (header size: 8)
+| number of data bytes: 8
+| 
+| Box: iprp -----
+| size: 216   (header size: 8)
+| | Box: ipco -----
+| | size: 168   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d a0 02 80 80 2d 16 59 98 a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1440
+| | | image height: 960
+| | 
+| | Box: ipma -----
+| | size: 40   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1009
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 1010
+| | entity IDs: 1009 1002 
+
+Box: mdat -----
+size: 535143   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C023.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C023.heic.dump
@@ -1,0 +1,239 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 791   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 116   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 815
+|   extents: 16,124054 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 815
+|   extents: 124070,136091 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 815
+|   extents: 260161,137190 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 815
+|   extents: 397351,137792 
+| item ID: 1013
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,8 
+| 
+| Box: iinf -----
+| size: 256   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 21   (header size: 12)
+| | item_ID: 1009
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: 
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 21   (header size: 12)
+| | item_ID: 1010
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: 
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 21   (header size: 12)
+| | item_ID: 1011
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: 
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 21   (header size: 12)
+| | item_ID: 1012
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: 
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1013
+| | item_protection_index: 0
+| | item_type: grid
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 88   (header size: 12)
+| reference with type 'dimg' from ID: 1009 to IDs: 1002 
+| reference with type 'dimg' from ID: 1010 to IDs: 1004 
+| reference with type 'dimg' from ID: 1011 to IDs: 1006 
+| reference with type 'dimg' from ID: 1012 to IDs: 1008 
+| reference with type 'dimg' from ID: 1013 to IDs: 1009 1010 1011 1012 
+| 
+| Box: idat -----
+| size: 16   (header size: 8)
+| number of data bytes: 8
+| 
+| Box: iprp -----
+| size: 256   (header size: 8)
+| | Box: ipco -----
+| | size: 188   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 5d a0 02 80 80 2d 16 59 98 a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: clap -----
+| | | size: 40   (header size: 8)
+| | | clean_aperture: 640/1 x 360/1
+| | | offset: 0/1 ; 0/1
+| | 
+| | Box: ipma -----
+| | size: 60   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1009
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | associations for item ID: 1010
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | associations for item ID: 1011
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | associations for item ID: 1012
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | associations for item ID: 1013
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 535143   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C024.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C024.heic.dump
@@ -1,0 +1,117 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 405   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 56   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 429
+|   extents: 16,111554 
+| item ID: 1003
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,8 
+| 
+| Box: iinf -----
+| size: 79   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1003
+| | item_protection_index: 0
+| | item_type: grid
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'dimg' from ID: 1003 to IDs: 1002 
+| 
+| Box: idat -----
+| size: 16   (header size: 8)
+| number of data bytes: 8
+| 
+| Box: iprp -----
+| size: 169   (header size: 8)
+| | Box: ipco -----
+| | size: 136   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | 
+| | Box: ipma -----
+| | size: 25   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1003
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 111570   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C025.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C025.heic.dump
@@ -1,0 +1,293 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1
+
+Box: meta -----
+size: 951   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 236   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 16,1632 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 1648,1787 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 3435,1863 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 5298,1904 
+| item ID: 1010
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 7202,1950 
+| item ID: 1012
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 9152,1949 
+| item ID: 1014
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 11101,1923 
+| item ID: 1016
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 13024,1930 
+| item ID: 1018
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 14954,1934 
+| item ID: 1020
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 975
+|   extents: 16888,1961 
+| item ID: 1021
+|   construction method: 1
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 0,8 
+| 
+| Box: iinf -----
+| size: 358   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1010
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1012
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1014
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1016
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1018
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1020
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1021
+| | item_protection_index: 0
+| | item_type: grid
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 36   (header size: 12)
+| reference with type 'dimg' from ID: 1021 to IDs: 1002 1004 1006 1008 1010 1012 
+| 
+| Box: idat -----
+| size: 16   (header size: 8)
+| number of data bytes: 8
+| 
+| Box: iprp -----
+| size: 246   (header size: 8)
+| | Box: ipco -----
+| | size: 168   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 30
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 1e 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 1e a0 10 20 49 65 99 8a 92 42 11 ae 68 08 00 00 03 00 08 00 00 03 00 c8 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 22 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 128
+| | | image height: 72
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 384
+| | | image height: 144
+| | 
+| | Box: ipma -----
+| | size: 70   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1010
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1012
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1014
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1016
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1018
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1020
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1021
+| | | property index: 3 (essential: false)
+
+Box: mdat -----
+size: 18849   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_dump/C026.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C026.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 744   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C027.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C027.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 902   (header size: 8)
+
+Box: mdat -----
+size: 464071   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C028.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C028.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 902   (header size: 8)
+
+Box: mdat -----
+size: 449875   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C029.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C029.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 792   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C030.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C030.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 792   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C031.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C031.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8,mp41
+
+Box: moov -----
+size: 1351   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8, mp41

--- a/regression/data/conformance_files_expected_dump/C032.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C032.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 1391   (header size: 8)
+
+Box: mdat -----
+size: 906135   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C034.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C034.heic.dump
@@ -1,0 +1,111 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: mif1,heic
+
+Box: meta -----
+size: 377   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 401
+|   extents: 16,111554 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 401
+|   extents: 111570,176 
+| 
+| Box: iinf -----
+| size: 75   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 30   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: Exif
+| | item_name: Exif data
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'cdsc' from ID: 1004 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 165   (header size: 8)
+| | Box: ipco -----
+| | size: 136   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | 
+| | Box: ipma -----
+| | size: 21   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+
+Box: mdat -----
+size: 111746   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic

--- a/regression/data/conformance_files_expected_dump/C036.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C036.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 780   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C037.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C037.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 780   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C038.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C038.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 780   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C039.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C039.heic.dump
@@ -1,0 +1,140 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: mif1,heic
+
+Box: meta -----
+size: 512   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1004
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 536
+|   extents: 16,111554 
+| 
+| Box: iinf -----
+| size: 113   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1003
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: iden
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 40   (header size: 12)
+| reference with type 'dimg' from ID: 1003 to IDs: 1002 
+| reference with type 'dimg' from ID: 1004 to IDs: 1003 
+| 
+| Box: iprp -----
+| size: 266   (header size: 8)
+| | Box: ipco -----
+| | size: 225   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: clap -----
+| | | size: 40   (header size: 8)
+| | | clean_aperture: 300/1 x 300/1
+| | | offset: 0/1 ; 0/1
+| | | 
+| | | Box: clap -----
+| | | size: 40   (header size: 8)
+| | | clean_aperture: 150/1 x 150/1
+| | | offset: 0/1 ; 0/1
+| | | 
+| | | Box: irot -----
+| | | size: 9   (header size: 8)
+| | | rotation: 90 degrees (CCW)
+| | 
+| | Box: ipma -----
+| | size: 33   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1003
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | | property index: 5 (essential: true)
+| | associations for item ID: 1004
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+
+Box: mdat -----
+size: 111570   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic

--- a/regression/data/conformance_files_expected_dump/C040.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C040.heic.dump
@@ -1,0 +1,304 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: mif1,heic
+
+Box: meta -----
+size: 1003   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1014
+| 
+| Box: iloc -----
+| size: 106   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1027
+|   extents: 16,19260 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1027
+|   extents: 19276,19379 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1027
+|   extents: 38655,19545 
+| item ID: 1011
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1027
+|   extents: 58200,19868 
+| item ID: 1014
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1027
+|   extents: 78068,77741 
+| 
+| Box: iinf -----
+| size: 169   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1011
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1014
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 32   (header size: 12)
+| reference with type 'base' from ID: 1014 to IDs: 1002 1005 1008 1011 
+| 
+| Box: iprp -----
+| size: 637   (header size: 8)
+| | Box: ipco -----
+| | size: 588   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 04 02 01 21 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 512
+| | | image height: 288
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 04 02 01 21 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 04 02 01 21 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 04 02 01 21 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 00 80 24 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1024
+| | | image height: 576
+| | 
+| | Box: ipma -----
+| | size: 41   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 4 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1011
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1014
+| | | property index: 6 (essential: true)
+| | | property index: 7 (essential: false)
+
+Box: mdat -----
+size: 155809   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic

--- a/regression/data/conformance_files_expected_dump/C041.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C041.heic.dump
@@ -1,0 +1,14 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: msf1,hevc,iso8
+
+Box: moov -----
+size: 960   (header size: 8)
+
+Box: mdat -----
+size: 51203   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_dump/C042.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C042.heic.dump
@@ -1,0 +1,96 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: mif1,heic
+
+Box: meta -----
+size: 313   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 337
+|   extents: 16,111554 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 175   (header size: 8)
+| | Box: ipco -----
+| | size: 145   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: imir -----
+| | | size: 9   (header size: 8)
+| | | mirror direction: vertical
+| | 
+| | Box: ipma -----
+| | size: 22   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+
+Box: mdat -----
+size: 111570   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic

--- a/regression/data/conformance_files_expected_dump/C043.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C043.heic.dump
@@ -1,0 +1,149 @@
+Box: ftyp -----
+size: 36   (header size: 8)
+major brand: mif2
+minor version: 0
+compatible brands: mif1,mif2,heic,miaf,MiHB
+
+Box: etyp -----
+size: 24   (header size: 8)
+
+Box: meta -----
+size: 496   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 70   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 556
+|   extents: 16,133270 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 556
+|   extents: 133286,12687 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 556
+|   extents: 145973,17189 
+| 
+| Box: iinf -----
+| size: 87   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 21   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: 
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 21   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: 
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 40   (header size: 12)
+| reference with type 'pred' from ID: 1004 to IDs: 1002 
+| reference with type 'pred' from ID: 1006 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 240   (header size: 8)
+| | Box: ipco -----
+| | size: 196   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 132   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 ac 09 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 ae 49 1b 60 92 e5 52 b9 49 29 65 34 a7 94 44 a2 65 15 28 b9 46 4a 36 51 d2 8f 94 21 6c 80 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 f5 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: rref -----
+| | | size: 20   (header size: 8)
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 36   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 163162   (header size: 16)
+MIME type: unknown
+main brand: mif2
+compatible brands: mif1, mif2, heic, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/C044.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C044.heic.dump
@@ -1,0 +1,127 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif2
+minor version: 0
+compatible brands: mif2,mif1
+
+Box: etyp -----
+size: 24   (header size: 8)
+
+Box: meta -----
+size: 436   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1004
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 484
+|   extents: 16,133270 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 484
+|   extents: 133286,12687 
+| 
+| Box: iinf -----
+| size: 66   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 21   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: 
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'pred' from ID: 1004 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 233   (header size: 8)
+| | Box: ipco -----
+| | size: 196   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 132   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 ac 09 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 ae 49 1b 60 92 e5 52 b9 49 29 65 34 a7 94 44 a2 65 15 28 b9 46 4a 36 51 d2 8f 94 21 6c 80 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 f5 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: rref -----
+| | | size: 20   (header size: 8)
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 29   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+
+Box: mdat -----
+size: 145973   (header size: 16)
+MIME type: unknown
+main brand: mif2
+compatible brands: mif2, mif1

--- a/regression/data/conformance_files_expected_dump/C045.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C045.heic.dump
@@ -1,0 +1,165 @@
+Box: ftyp -----
+size: 36   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: mif1,mif2,heix,miaf,MiHA
+
+Box: meta -----
+size: 549   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 88   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 585
+|   extents: 16,156854 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 585
+|   extents: 156870,49851 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 585
+|   extents: 206721,50606 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 585
+|   extents: 257327,50141 
+| 
+| Box: iinf -----
+| size: 138   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 208   (header size: 8)
+| | Box: ipco -----
+| | size: 160   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 116   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 4
+| | | general_profile_compatibility_flags: 0000.1000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10011111 10101000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d ba 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d a0 02 00 80 30 16 5b a9 24 21 1a f0 16 80 80 00 05 db 80 00 af c8 04 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b0 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1024
+| | | image height: 768
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 40   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 44   (header size: 8)
+| group type: brst
+| | group id: 1009
+| | entity IDs: 1002 1004 1006 1008 
+
+Box: mdat -----
+size: 307468   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, mif2, heix, miaf, MiHA

--- a/regression/data/conformance_files_expected_dump/C046.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C046.heic.dump
@@ -1,0 +1,108 @@
+Box: ftyp -----
+size: 40   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: mif1,msf1,hevc,iso8,miaf,MiHB
+
+Box: meta -----
+size: 388   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1003
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1003
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1282
+|   extents: 16,133270 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1003
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 206   (header size: 8)
+| | Box: ipco -----
+| | size: 176   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 132   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 ac 09 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 ae 49 1b 60 92 e5 52 b9 49 29 65 34 a7 94 44 a2 65 15 28 b9 46 4a 36 51 d2 8f 94 21 6c 80 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 f5 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 22   (header size: 12)
+| | associations for item ID: 1003
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 32   (header size: 8)
+| group type: brst
+| | group id: 1013
+| | entity IDs: 1 
+
+Box: moov -----
+size: 854   (header size: 8)
+
+Box: mdat -----
+size: 218674   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: mif1, msf1, hevc, iso8, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/C047.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C047.heic.dump
@@ -1,0 +1,200 @@
+Box: ftyp -----
+size: 36   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: mif1,mif2,heix,miaf,MiHA
+
+Box: meta -----
+size: 685   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 88   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 721
+|   extents: 16,112523 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 721
+|   extents: 112539,33962 
+| item ID: 1007
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 721
+|   extents: 146501,29802 
+| item ID: 1009
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 721
+|   extents: 176303,14019 
+| 
+| Box: iinf -----
+| size: 138   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1007
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1009
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 324   (header size: 8)
+| | Box: ipco -----
+| | size: 276   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 116   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 4
+| | | general_profile_compatibility_flags: 0000.1000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10011111 10101000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d ba 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d a0 02 80 80 2d 16 5b a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b0 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 116   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 4
+| | | general_profile_compatibility_flags: 0000.1000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10011111 10101000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d ba 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d a0 02 80 80 2d 16 5b a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b0 62 40 
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 40   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1007
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1009
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+| 
+| Box: grpl -----
+| size: 64   (header size: 8)
+| group type: tsyn
+| | group id: 1010
+| | entity IDs: 1002 1007 
+| group type: tsyn
+| | group id: 1011
+| | entity IDs: 1004 1009 
+
+Box: mdat -----
+size: 190322   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, mif2, heix, miaf, MiHA

--- a/regression/data/conformance_files_expected_dump/C048.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C048.heic.dump
@@ -1,0 +1,108 @@
+Box: ftyp -----
+size: 36   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: mif1,msf1,hevx,heix,iso8
+
+Box: meta -----
+size: 376   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1004
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1800
+|   extents: 16,112523 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 190   (header size: 8)
+| | Box: ipco -----
+| | size: 160   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 116   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 4
+| | | general_profile_compatibility_flags: 0000.1000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10011111 10101000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d ba 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 04 08 00 00 03 00 9f a8 00 00 03 00 00 5d a0 02 80 80 2d 16 5b a9 24 21 1a e6 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b0 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 22   (header size: 12)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: tsyn
+| | group id: 1037
+| | entity IDs: 1 2 
+
+Box: moov -----
+size: 1388   (header size: 8)
+
+Box: mdat -----
+size: 481092   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: mif1, msf1, hevx, heix, iso8

--- a/regression/data/conformance_files_expected_dump/C049.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C049.heic.dump
@@ -1,0 +1,108 @@
+Box: ftyp -----
+size: 44   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,mp42,isom,M4A ,miaf,MiHA
+
+Box: meta -----
+size: 377   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1820
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1820
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 2614
+|   extents: 122269,412059 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1820
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 191   (header size: 8)
+| | Box: ipco -----
+| | size: 161   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 117   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 4
+| | | general_profile_compatibility_flags: 0000.1000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10011111 10101000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 04 08 00 00 03 00 9f a8 00 00 03 00 00 78 ba 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 04 08 00 00 03 00 9f a8 00 00 03 00 00 78 a0 03 c0 80 10 e5 96 ea 49 08 46 b9 a0 20 00 00 03 00 20 00 00 03 03 01 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b0 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1920
+| | | image height: 1080
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 22   (header size: 12)
+| | associations for item ID: 1820
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: iaug
+| | group id: 1821
+| | entity IDs: 1 1820 
+
+Box: moov -----
+size: 2193   (header size: 8)
+
+Box: mdat -----
+size: 534328   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, mp42, isom, M4A , miaf, MiHA

--- a/regression/data/conformance_files_expected_dump/C050.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C050.heic.dump
@@ -1,0 +1,226 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHB
+
+Box: meta -----
+size: 841   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 124   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 873
+|   extents: 16,398111 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 873
+|   extents: 398127,88955 
+| item ID: 1006
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 873
+|   extents: 487082,81400 
+| item ID: 1008
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 873
+|   extents: 568482,53464 
+| item ID: 1010
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 873
+|   extents: 621946,101936 
+| item ID: 1012
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 873
+|   extents: 723882,92098 
+| 
+| Box: iinf -----
+| size: 200   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1006
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1008
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1010
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1012
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 366   (header size: 8)
+| | Box: ipco -----
+| | size: 298   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 119   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 3
+| | | general_profile_compatibility_flags: 0111.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 03 70 00 00 03 00 90 00 00 03 00 00 03 00 78 ba 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 03 70 00 00 03 00 90 00 00 03 00 00 03 00 78 a0 02 80 80 3c 16 5b a9 24 21 1a f0 16 80 80 00 00 03 00 80 00 00 0c 84 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b0 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 960
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | | 
+| | | Box: udes -----
+| | | size: 66   (header size: 12)
+| | | lang: en-US
+| | | name: Plants in spring.
+| | | description: 
+| | | tags: en-US
+| | | 
+| | | Box: udes -----
+| | | size: 69   (header size: 12)
+| | | lang: en-US
+| | | name: Favorite views in the garden.
+| | | description: 
+| | | tags: en-US
+| | 
+| | Box: ipma -----
+| | size: 60   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1006
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1008
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1010
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1012
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1013
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1014
+| | | property index: 5 (essential: false)
+| 
+| Box: grpl -----
+| size: 80   (header size: 8)
+| group type: albc
+| | group id: 1013
+| | entity IDs: 1002 1004 1006 1012 
+| group type: albc
+| | group id: 1014
+| | entity IDs: 1008 1010 1012 1002 
+
+Box: mdat -----
+size: 815980   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/C051.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C051.heic.dump
@@ -1,0 +1,128 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHB
+
+Box: meta -----
+size: 430   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 462
+|   extents: 16,111554 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 462
+|   extents: 111570,111481 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 231   (header size: 8)
+| | Box: ipco -----
+| | size: 192   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | | 
+| | | Box: crtt -----
+| | | size: 20   (header size: 8)
+| | | 
+| | | Box: mdft -----
+| | | size: 20   (header size: 8)
+| | 
+| | Box: ipma -----
+| | size: 31   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | | property index: 4 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | | property index: 4 (essential: false)
+| | | property index: 5 (essential: false)
+
+Box: mdat -----
+size: 223051   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/C052.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C052.heic.dump
@@ -1,0 +1,158 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHB
+
+Box: meta -----
+size: 578   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 610
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 610
+|   extents: 111570,308 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: true
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'auxl' from ID: 1005 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 365   (header size: 8)
+| | Box: ipco -----
+| | size: 328   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 90 00 00 03 00 00 03 00 78 9d 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 90 00 00 03 00 00 03 00 78 a0 02 80 80 2d 16 59 d8 a9 24 21 1a e0 10 00 00 03 00 10 00 00 03 01 90 80 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 77 d9 89 
+| | | 
+| | | Box: auxC -----
+| | | size: 56   (header size: 12)
+| | | aux type: urn:mpeg:mpegB:cicp:systems:auxiliary:alpha
+| | | aux subtypes: 
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 29   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 4 (essential: false)
+| | | property index: 5 (essential: false)
+
+Box: mdat -----
+size: 111878   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/C053.heic.dump
+++ b/regression/data/conformance_files_expected_dump/C053.heic.dump
@@ -1,0 +1,125 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHB
+
+Box: meta -----
+size: 423   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 455
+|   extents: 16,7044 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 455
+|   extents: 7060,7035 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 188   (header size: 8)
+| | Box: ipco -----
+| | size: 152   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 5d f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 5d a0 02 00 80 20 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1024
+| | | image height: 512
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: ster
+| | group id: 1005
+| | entity IDs: 1002 1004 
+
+Box: mdat -----
+size: 14095   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/MIAF001.heic.dump
+++ b/regression/data/conformance_files_expected_dump/MIAF001.heic.dump
@@ -1,0 +1,157 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHB
+
+Box: mdat -----
+size: 113237   (header size: 16)
+
+Box: meta -----
+size: 528   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 48,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 0
+|   extents: 111602,1667 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'thmb' from ID: 1005 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 315   (header size: 8)
+| | Box: ipco -----
+| | size: 279   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 107   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 10 20 49 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 128
+| | | image height: 72
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | | property index: 5 (essential: false)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/MIAF002.heic.dump
+++ b/regression/data/conformance_files_expected_dump/MIAF002.heic.dump
@@ -1,0 +1,161 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHA
+
+Box: meta -----
+size: 569   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 601
+|   extents: 16,7993 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 601
+|   extents: 8009,227 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'thmb' from ID: 1005 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 356   (header size: 8)
+| | Box: ipco -----
+| | size: 320   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 4
+| | | general_profile_compatibility_flags: 0000.1000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10011101 10111000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 150
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 10
+| | | bit_depth_chroma: 10
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 04 08 00 00 03 00 9d b8 00 00 03 00 00 96 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 04 08 00 00 03 00 9d b8 00 00 03 00 00 96 a0 01 00 20 02 00 4d 96 66 2a 49 08 46 b9 a0 20 00 00 03 00 20 00 00 03 03 21 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 2048
+| | | image height: 2048
+| | | 
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 3
+| | | general_profile_compatibility_flags: 0111.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 60
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 03 70 00 00 03 00 90 00 00 03 00 00 03 00 3c 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 03 70 00 00 03 00 90 00 00 03 00 00 03 00 3c a0 14 20 28 59 66 62 a4 90 84 6b 9a 02 00 00 03 00 02 00 00 03 00 32 10 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 160
+| | | image height: 160
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 10,10,10
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | | property index: 6 (essential: false)
+
+Box: mdat -----
+size: 8236   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHA

--- a/regression/data/conformance_files_expected_dump/MIAF003.heic.dump
+++ b/regression/data/conformance_files_expected_dump/MIAF003.heic.dump
@@ -1,0 +1,157 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHE
+
+Box: meta -----
+size: 553   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 585
+|   extents: 16,12998 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 585
+|   extents: 13014,227 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'thmb' from ID: 1005 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 340   (header size: 8)
+| | Box: ipco -----
+| | size: 304   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 4
+| | | general_profile_compatibility_flags: 0000.1000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10011110 00111000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 150
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:4:4
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 04 08 00 00 03 00 9e 38 00 00 03 00 00 96 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 04 08 00 00 03 00 9e 38 00 00 03 00 00 96 90 00 20 04 00 40 0b 2c cc 54 92 10 8d 73 40 40 00 00 03 00 40 00 00 06 42 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 86 0c 66 24 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 2048
+| | | image height: 2048
+| | | 
+| | | Box: hvcC -----
+| | | size: 120   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 3
+| | | general_profile_compatibility_flags: 0111.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 10010000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 60
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 03 70 00 00 03 00 90 00 00 03 00 00 03 00 3c 99 8a 02 40 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 03 70 00 00 03 00 90 00 00 03 00 00 03 00 3c a0 14 20 28 59 66 62 a4 90 84 6b 9a 02 00 00 03 00 02 00 00 03 00 32 10 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 76 b6 62 40 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 160
+| | | image height: 160
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | | property index: 5 (essential: false)
+
+Box: mdat -----
+size: 13241   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHE

--- a/regression/data/conformance_files_expected_dump/MIAF004.heic.dump
+++ b/regression/data/conformance_files_expected_dump/MIAF004.heic.dump
@@ -1,0 +1,157 @@
+Box: ftyp -----
+size: 36   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHB,MiPr
+
+Box: meta -----
+size: 528   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1005
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 564
+|   extents: 16,1667 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 564
+|   extents: 1683,111554 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'thmb' from ID: 1002 to IDs: 1005 
+| 
+| Box: iprp -----
+| size: 315   (header size: 8)
+| | Box: ipco -----
+| | size: 279   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 107   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 10 20 49 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 128
+| | | image height: 72
+| | | 
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | | property index: 5 (essential: false)
+
+Box: mdat -----
+size: 113237   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB, MiPr

--- a/regression/data/conformance_files_expected_dump/MIAF005.heic.dump
+++ b/regression/data/conformance_files_expected_dump/MIAF005.heic.dump
@@ -1,0 +1,108 @@
+Box: ftyp -----
+size: 48   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: heic,hevc,mif1,miaf,MiHB,MiAn,msf1,iso8
+
+Box: meta -----
+size: 368   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1004
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1208
+|   extents: 16,111554 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 182   (header size: 8)
+| | Box: ipco -----
+| | size: 152   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 22   (header size: 12)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 1019
+| | entity IDs: 1 1004 
+
+Box: moov -----
+size: 792   (header size: 8)
+
+Box: mdat -----
+size: 892646   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: heic, hevc, mif1, miaf, MiHB, MiAn, msf1, iso8

--- a/regression/data/conformance_files_expected_dump/MIAF006.heic.dump
+++ b/regression/data/conformance_files_expected_dump/MIAF006.heic.dump
@@ -1,0 +1,108 @@
+Box: ftyp -----
+size: 48   (header size: 8)
+major brand: msf1
+minor version: 0
+compatible brands: heic,hevc,mif1,miaf,MiHB,MiBr,msf1,iso8
+
+Box: meta -----
+size: 392   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1004
+| 
+| Box: iloc -----
+| size: 34   (header size: 12)
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1290
+|   extents: 16,190023 
+| 
+| Box: iinf -----
+| size: 45   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 12   (header size: 12)
+| 
+| Box: iprp -----
+| size: 206   (header size: 8)
+| | Box: ipco -----
+| | size: 176   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 132   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 150
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 96 ac 09 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 96 a0 03 c0 80 16 87 f9 6b 92 46 d8 24 b9 54 ae 52 4a 59 4d 29 e5 11 28 99 45 4a 2e 51 92 8d 94 74 a3 e5 08 5b 20 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 f5 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1920
+| | | image height: 1440
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | 
+| | Box: ipma -----
+| | size: 22   (header size: 12)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 3 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 1009
+| | entity IDs: 1 1004 
+
+Box: moov -----
+size: 850   (header size: 8)
+
+Box: mdat -----
+size: 279055   (header size: 16)
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: heic, hevc, mif1, miaf, MiHB, MiBr, msf1, iso8

--- a/regression/data/conformance_files_expected_dump/MIAF007.heic.dump
+++ b/regression/data/conformance_files_expected_dump/MIAF007.heic.dump
@@ -1,0 +1,176 @@
+Box: ftyp -----
+size: 32   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: heic,mif1,miaf,MiHB
+
+Box: meta -----
+size: 592   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 624
+|   extents: 16,111554 
+| item ID: 1005
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 624
+|   extents: 111570,1667 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1005
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'thmb' from ID: 1005 to IDs: 1002 
+| 
+| Box: iprp -----
+| size: 379   (header size: 8)
+| | Box: ipco -----
+| | size: 337   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 02 80 80 2d 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1280
+| | | image height: 720
+| | | 
+| | | Box: hvcC -----
+| | | size: 107   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 120
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 78 a0 10 20 49 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 128
+| | | image height: 72
+| | | 
+| | | Box: pixi -----
+| | | size: 16   (header size: 12)
+| | | bits_per_channel: 8,8,8
+| | | 
+| | | Box: clap -----
+| | | size: 40   (header size: 8)
+| | | clean_aperture: 640/1 x 360/1
+| | | offset: 0/1 ; 0/1
+| | | 
+| | | Box: irot -----
+| | | size: 9   (header size: 8)
+| | | rotation: 90 degrees (CCW)
+| | | 
+| | | Box: imir -----
+| | | size: 9   (header size: 8)
+| | | mirror direction: vertical
+| | 
+| | Box: ipma -----
+| | size: 34   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | | property index: 5 (essential: false)
+| | | property index: 6 (essential: false)
+| | | property index: 7 (essential: false)
+| | | property index: 8 (essential: false)
+| | associations for item ID: 1005
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: false)
+| | | property index: 5 (essential: false)
+| | | property index: 6 (essential: false)
+| | | property index: 7 (essential: false)
+| | | property index: 8 (essential: false)
+
+Box: mdat -----
+size: 113237   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB

--- a/regression/data/conformance_files_expected_dump/multilayer001.heic.dump
+++ b/regression/data/conformance_files_expected_dump/multilayer001.heic.dump
@@ -1,0 +1,130 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: heis
+minor version: 0
+compatible brands: mif1,heic,heis
+
+Box: meta -----
+size: 683   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 20003
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 20003
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 719
+|   extents: 0,17847 
+| item ID: 20004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 719
+|   extents: 0,17847 
+| 
+| Box: iinf -----
+| size: 80   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 20003
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 33   (header size: 12)
+| | item_ID: 20004
+| | item_protection_index: 0
+| | item_type: lhv1
+| | item_name: L-HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 456   (header size: 8)
+| | Box: ipco -----
+| | size: 420   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 147   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 123
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 11 ff ff 01 80 00 00 03 00 00 03 00 00 03 00 00 03 00 7b f0 56 ff 7b 10 00 04 30 3c e0 f0 00 00 03 00 01 f1 00 00 03 00 00 0f 75 90 40 00 20 0a 01 f9 fd ff c8 50 10 10 16 08 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 7b a0 02 00 80 20 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 1d 02 a0 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1024
+| | | image height: 512
+| | | 
+| | | Box: oinf -----
+| | | size: 78   (header size: 8)
+| | | 
+| | | Box: tols -----
+| | | size: 14   (header size: 8)
+| | | 
+| | | Box: lhvC -----
+| | | size: 153   (header size: 8)
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 20003
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20004
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 20005
+| | entity IDs: 20004 20003 
+
+Box: mdat -----
+size: 17855   (header size: 8)
+
+Box: mdat -----
+size: 16   (header size: 8)
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heic, heis

--- a/regression/data/conformance_files_expected_dump/multilayer002.heic.dump
+++ b/regression/data/conformance_files_expected_dump/multilayer002.heic.dump
@@ -1,0 +1,293 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: heis
+minor version: 0
+compatible brands: mif1,heic,heis
+
+Box: meta -----
+size: 1167   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 20010
+| 
+| Box: iloc -----
+| size: 196   (header size: 12)
+| item ID: 20010
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 0,4069 
+| item ID: 20011
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 4069,5244 
+| item ID: 20012
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 9313,4382 
+| item ID: 20013
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 13695,4761 
+| item ID: 20014
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 0,4069 
+| item ID: 20015
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 4069,5244 
+| item ID: 20016
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 9313,4382 
+| item ID: 20017
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 1203
+|   extents: 13695,4761 
+| item ID: 20018
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 19667
+|   extents: 0,8 
+| item ID: 20019
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 19667
+|   extents: 8,8 
+| 
+| Box: iinf -----
+| size: 340   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 20010
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 20011
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 20012
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 20013
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 33   (header size: 12)
+| | item_ID: 20014
+| | item_protection_index: 0
+| | item_type: lhv1
+| | item_name: L-HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 33   (header size: 12)
+| | item_ID: 20015
+| | item_protection_index: 0
+| | item_type: lhv1
+| | item_name: L-HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 33   (header size: 12)
+| | item_ID: 20016
+| | item_protection_index: 0
+| | item_type: lhv1
+| | item_name: L-HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 33   (header size: 12)
+| | item_ID: 20017
+| | item_protection_index: 0
+| | item_type: lhv1
+| | item_name: L-HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 20018
+| | item_protection_index: 0
+| | item_type: grid
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 34   (header size: 12)
+| | item_ID: 20019
+| | item_protection_index: 0
+| | item_type: grid
+| | item_name: Derived image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 52   (header size: 12)
+| reference with type 'dimg' from ID: 20018 to IDs: 20010 20011 20012 20013 
+| reference with type 'dimg' from ID: 20019 to IDs: 20014 20015 20016 20017 
+| 
+| Box: iprp -----
+| size: 520   (header size: 8)
+| | Box: ipco -----
+| | size: 440   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 147   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 123
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 11 ff ff 01 80 00 00 03 00 00 03 00 00 03 00 00 03 00 7b f0 56 ff 7b 10 00 04 30 3c e0 f0 00 00 03 00 01 f1 00 00 03 00 00 0f 75 90 20 00 10 0a 01 f9 fd ff c8 50 10 10 16 08 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 7b a0 04 02 01 01 fe 5f 92 46 d9 ed 90 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 1d 02 a0 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 512
+| | | image height: 256
+| | | 
+| | | Box: oinf -----
+| | | size: 78   (header size: 8)
+| | | 
+| | | Box: tols -----
+| | | size: 14   (header size: 8)
+| | | 
+| | | Box: lhvC -----
+| | | size: 153   (header size: 8)
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1024
+| | | image height: 512
+| | 
+| | Box: ipma -----
+| | size: 72   (header size: 12)
+| | associations for item ID: 20010
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20011
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20012
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20013
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20014
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20015
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20016
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20017
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20018
+| | | property index: 6 (essential: false)
+| | associations for item ID: 20019
+| | | property index: 6 (essential: false)
+
+Box: mdat -----
+size: 18464   (header size: 8)
+
+Box: mdat -----
+size: 24   (header size: 8)
+
+Box: mdat -----
+size: 16   (header size: 8)
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heic, heis

--- a/regression/data/conformance_files_expected_dump/multilayer003.heic.dump
+++ b/regression/data/conformance_files_expected_dump/multilayer003.heic.dump
@@ -1,0 +1,116 @@
+Box: ftyp -----
+size: 24   (header size: 8)
+major brand: mif1
+minor version: 0
+compatible brands: mif1,heic
+
+Box: meta -----
+size: 393   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 1002
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 1002
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 417
+|   extents: 16,7044 
+| item ID: 1004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 417
+|   extents: 7060,7035 
+| 
+| Box: iinf -----
+| size: 76   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1002
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 1004
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 170   (header size: 8)
+| | Box: ipco -----
+| | size: 136   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 108   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 93
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 01 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 5d f0 24 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 5d a0 02 00 80 20 1f e5 f9 24 6d 9e d9 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c1 90 95 81 12 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1024
+| | | image height: 512
+| | 
+| | Box: ipma -----
+| | size: 26   (header size: 12)
+| | associations for item ID: 1002
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 1004
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: ster
+| | group id: 1005
+| | entity IDs: 1002 1004 
+
+Box: mdat -----
+size: 14095   (header size: 16)
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic

--- a/regression/data/conformance_files_expected_dump/multilayer004.heic.dump
+++ b/regression/data/conformance_files_expected_dump/multilayer004.heic.dump
@@ -1,0 +1,108 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: heis
+minor version: 0
+compatible brands: mif1,heis,avci
+
+Box: meta -----
+size: 607   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 20003
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 20003
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 643
+|   extents: 0,6829 
+| item ID: 20004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 7480
+|   extents: 0,6636 
+| 
+| Box: iinf -----
+| size: 79   (header size: 12)
+| | Box: infe -----
+| | size: 30   (header size: 12)
+| | item_ID: 20003
+| | item_protection_index: 0
+| | item_type: avc1
+| | item_name: AVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 33   (header size: 12)
+| | item_ID: 20004
+| | item_protection_index: 0
+| | item_type: lhv1
+| | item_name: L-HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iref -----
+| size: 26   (header size: 12)
+| reference with type 'exbl' from ID: 20004 to IDs: 20003 
+| 
+| Box: iprp -----
+| size: 355   (header size: 8)
+| | Box: ipco -----
+| | size: 319   (header size: 8)
+| | | Box: avcC -----
+| | | size: 52   (header size: 8)
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 1024
+| | | image height: 512
+| | | 
+| | | Box: oinf -----
+| | | size: 78   (header size: 8)
+| | | 
+| | | Box: tols -----
+| | | size: 14   (header size: 8)
+| | | 
+| | | Box: lhvC -----
+| | | size: 147   (header size: 8)
+| | 
+| | Box: ipma -----
+| | size: 28   (header size: 12)
+| | associations for item ID: 20003
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20004
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+| | | property index: 2 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: altr
+| | group id: 20005
+| | entity IDs: 20004 20003 
+
+Box: mdat -----
+size: 6837   (header size: 8)
+
+Box: mdat -----
+size: 6644   (header size: 8)
+
+Box: mdat -----
+size: 16   (header size: 8)
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heis, avci

--- a/regression/data/conformance_files_expected_dump/multilayer005.heic.dump
+++ b/regression/data/conformance_files_expected_dump/multilayer005.heic.dump
@@ -1,0 +1,135 @@
+Box: ftyp -----
+size: 28   (header size: 8)
+major brand: heis
+minor version: 0
+compatible brands: mif1,heic,heis
+
+Box: meta -----
+size: 741   (header size: 12)
+| Box: hdlr -----
+| size: 33   (header size: 12)
+| pre_defined: 0
+| handler_type: pict
+| name: 
+| 
+| Box: pitm -----
+| size: 14   (header size: 12)
+| item_ID: 20003
+| 
+| Box: iloc -----
+| size: 52   (header size: 12)
+| item ID: 20003
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 777
+|   extents: 0,3815 
+| item ID: 20004
+|   construction method: 0
+|   data_reference_index: 0
+|   base_offset: 777
+|   extents: 0,3815 
+| 
+| Box: iinf -----
+| size: 80   (header size: 12)
+| | Box: infe -----
+| | size: 31   (header size: 12)
+| | item_ID: 20003
+| | item_protection_index: 0
+| | item_type: hvc1
+| | item_name: HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| | 
+| | Box: infe -----
+| | size: 33   (header size: 12)
+| | item_ID: 20004
+| | item_protection_index: 0
+| | item_type: lhv1
+| | item_name: L-HEVC Image
+| | content_type: 
+| | content_encoding: 
+| | item uri type: 
+| | hidden item: false
+| 
+| Box: iprp -----
+| size: 514   (header size: 8)
+| | Box: ipco -----
+| | size: 477   (header size: 8)
+| | | Box: hvcC -----
+| | | size: 162   (header size: 8)
+| | | configuration_version: 1
+| | | general_profile_space: 0
+| | | general_tier_flag: 0
+| | | general_profile_idc: 1
+| | | general_profile_compatibility_flags: 0110.0000 0000.0000 0000.0000 0000.0000 
+| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
+| | | general_level_idc: 0
+| | | min_spatial_segmentation_idc: 0
+| | | parallelism_type: 0
+| | | chroma_format: 4:2:0
+| | | bit_depth_luma: 8
+| | | bit_depth_chroma: 8
+| | | avg_frame_rate: 0
+| | | constant_frame_rate: 0
+| | | num_temporal_layers: 1
+| | | temporal_id_nested: 1
+| | | length_size: 4
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 32
+| | | | 40 01 0c 11 ff ff 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 00 94 90 56 ff 00 20 00 21 1a 5c 18 08 00 00 03 00 3e 20 00 00 03 00 00 03 02 34 08 00 04 02 80 7e 14 a4 f4 80 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 33
+| | | | 42 01 01 01 60 00 00 03 00 00 03 00 00 03 00 00 03 00 00 a0 04 02 01 01 fe 59 49 92 46 d8 69 62 2a a4 c4 c3 2f b3 eb cd f9 67 d7 85 11 89 cb b6 a0 20 
+| | | <array>
+| | | | array_completeness: 0
+| | | | NAL_unit_type: 34
+| | | | 44 01 c5 a5 58 11 50 0a 
+| | | 
+| | | Box: ispe -----
+| | | size: 20   (header size: 12)
+| | | image width: 512
+| | | image height: 256
+| | | 
+| | | Box: oinf -----
+| | | size: 78   (header size: 8)
+| | | 
+| | | Box: tols -----
+| | | size: 14   (header size: 8)
+| | | 
+| | | Box: lsel -----
+| | | size: 10   (header size: 8)
+| | | layer_id: 1
+| | | 
+| | | Box: lhvC -----
+| | | size: 185   (header size: 8)
+| | 
+| | Box: ipma -----
+| | size: 29   (header size: 12)
+| | associations for item ID: 20003
+| | | property index: 1 (essential: true)
+| | | property index: 2 (essential: false)
+| | associations for item ID: 20004
+| | | property index: 3 (essential: true)
+| | | property index: 4 (essential: true)
+| | | property index: 5 (essential: true)
+| | | property index: 6 (essential: true)
+| | | property index: 2 (essential: false)
+| 
+| Box: grpl -----
+| size: 36   (header size: 8)
+| group type: ster
+| | group id: 20005
+| | entity IDs: 20003 20004 
+
+Box: mdat -----
+size: 3823   (header size: 8)
+
+Box: mdat -----
+size: 16   (header size: 8)
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heic, heis

--- a/regression/data/conformance_files_expected_info/C001.heic.txt
+++ b/regression/data/conformance_files_expected_info/C001.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, heic, mif1, iso8
+
+image: 1280x720 (id=1018), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C002.heic.txt
+++ b/regression/data/conformance_files_expected_info/C002.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C003.heic.txt
+++ b/regression/data/conformance_files_expected_info/C003.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C004.heic.txt
+++ b/regression/data/conformance_files_expected_info/C004.heic.txt
@@ -1,0 +1,143 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1010)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1012)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1014)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1016)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1018)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1020)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C005.heic.txt
+++ b/regression/data/conformance_files_expected_info/C005.heic.txt
@@ -1,0 +1,18 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C006.heic.txt
+++ b/regression/data/conformance_files_expected_info/C006.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: yes 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C007.heic.txt
+++ b/regression/data/conformance_files_expected_info/C007.heic.txt
@@ -1,0 +1,73 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 2560x1440 (id=1009), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C008.heic.txt
+++ b/regression/data/conformance_files_expected_info/C008.heic.txt
@@ -1,0 +1,45 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 720x1280 (id=1006), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  angle (ccw): 90
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C009.heic.txt
+++ b/regression/data/conformance_files_expected_info/C009.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C010.heic.txt
+++ b/regression/data/conformance_files_expected_info/C010.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C011.heic.txt
+++ b/regression/data/conformance_files_expected_info/C011.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C012.heic.txt
+++ b/regression/data/conformance_files_expected_info/C012.heic.txt
@@ -1,0 +1,167 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1010)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1012)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1014)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1016)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1018)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1020)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1044)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C013.heic.txt
+++ b/regression/data/conformance_files_expected_info/C013.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 300x300 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=490 top=210 right=490 bottom=210
+region annotations:
+  none
+properties:
+
+image: 300x300 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=490 top=210 right=490 bottom=210
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C014.heic.txt
+++ b/regression/data/conformance_files_expected_info/C014.heic.txt
@@ -1,0 +1,60 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1003)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  angle (ccw): 180
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 300x300 (id=1007), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=490 top=210 right=490 bottom=210
+  angle (ccw): 90
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C015.heic.txt
+++ b/regression/data/conformance_files_expected_info/C015.heic.txt
@@ -1,0 +1,45 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1440x960 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C016.heic.txt
+++ b/regression/data/conformance_files_expected_info/C016.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1440x960 (id=1003)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C017.heic.txt
+++ b/regression/data/conformance_files_expected_info/C017.heic.txt
@@ -1,0 +1,45 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 640x360 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1440x960 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C018.heic.txt
+++ b/regression/data/conformance_files_expected_info/C018.heic.txt
@@ -1,0 +1,45 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 640x360 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1440x960 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C019.heic.txt
+++ b/regression/data/conformance_files_expected_info/C019.heic.txt
@@ -1,0 +1,45 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 640x360 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1440x960 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C020.heic.txt
+++ b/regression/data/conformance_files_expected_info/C020.heic.txt
@@ -1,0 +1,45 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 640x360 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1440x960 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C021.heic.txt
+++ b/regression/data/conformance_files_expected_info/C021.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1

--- a/regression/data/conformance_files_expected_info/C022.heic.txt
+++ b/regression/data/conformance_files_expected_info/C022.heic.txt
@@ -1,0 +1,73 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1440x960 (id=1009), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C023.heic.txt
+++ b/regression/data/conformance_files_expected_info/C023.heic.txt
@@ -1,0 +1,129 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1009)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=320 top=180 right=320 bottom=180
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1010)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=320 top=180 right=320 bottom=180
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1011)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=320 top=180 right=320 bottom=180
+region annotations:
+  none
+properties:
+
+image: 640x360 (id=1012)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=320 top=180 right=320 bottom=180
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1013)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C024.heic.txt
+++ b/regression/data/conformance_files_expected_info/C024.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1003)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C025.heic.txt
+++ b/regression/data/conformance_files_expected_info/C025.heic.txt
@@ -1,0 +1,157 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1
+
+image: 128x72 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1010)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1012)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1014)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1016)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1018)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 128x72 (id=1020)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 384x144 (id=1021)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C026.heic.txt
+++ b/regression/data/conformance_files_expected_info/C026.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C027.heic.txt
+++ b/regression/data/conformance_files_expected_info/C027.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C028.heic.txt
+++ b/regression/data/conformance_files_expected_info/C028.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C029.heic.txt
+++ b/regression/data/conformance_files_expected_info/C029.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C030.heic.txt
+++ b/regression/data/conformance_files_expected_info/C030.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C031.heic.txt
+++ b/regression/data/conformance_files_expected_info/C031.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8, mp41

--- a/regression/data/conformance_files_expected_info/C032.heic.txt
+++ b/regression/data/conformance_files_expected_info/C032.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C034.heic.txt
+++ b/regression/data/conformance_files_expected_info/C034.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  Exif: 176 bytes
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C036.heic.txt
+++ b/regression/data/conformance_files_expected_info/C036.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C037.heic.txt
+++ b/regression/data/conformance_files_expected_info/C037.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C038.heic.txt
+++ b/regression/data/conformance_files_expected_info/C038.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C039.heic.txt
+++ b/regression/data/conformance_files_expected_info/C039.heic.txt
@@ -1,0 +1,47 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic
+
+image: 1280x720 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 300x300 (id=1003)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=490 top=210 right=490 bottom=210
+  angle (ccw): 90
+region annotations:
+  none
+properties:
+
+image: 150x150 (id=1004), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=565 top=285 right=565 bottom=285
+  angle (ccw): 90
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C040.heic.txt
+++ b/regression/data/conformance_files_expected_info/C040.heic.txt
@@ -1,0 +1,73 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic
+
+image: 512x288 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 512x288 (id=1005)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 512x288 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 512x288 (id=1011)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x576 (id=1014), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C041.heic.txt
+++ b/regression/data/conformance_files_expected_info/C041.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: msf1, hevc, iso8

--- a/regression/data/conformance_files_expected_info/C042.heic.txt
+++ b/regression/data/conformance_files_expected_info/C042.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  mirror: vertical
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C043.heic.txt
+++ b/regression/data/conformance_files_expected_info/C043.heic.txt
@@ -1,0 +1,45 @@
+MIME type: unknown
+main brand: mif2
+compatible brands: mif1, mif2, heic, miaf, MiHB
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C044.heic.txt
+++ b/regression/data/conformance_files_expected_info/C044.heic.txt
@@ -1,0 +1,31 @@
+MIME type: unknown
+main brand: mif2
+compatible brands: mif2, mif1
+
+image: 1280x720 (id=1002)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C045.heic.txt
+++ b/regression/data/conformance_files_expected_info/C045.heic.txt
@@ -1,0 +1,59 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, mif2, heix, miaf, MiHA
+
+image: 1024x768 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x768 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x768 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x768 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C046.heic.txt
+++ b/regression/data/conformance_files_expected_info/C046.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: mif1, msf1, hevc, iso8, miaf, MiHB
+
+image: 1280x720 (id=1003), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C047.heic.txt
+++ b/regression/data/conformance_files_expected_info/C047.heic.txt
@@ -1,0 +1,59 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, mif2, heix, miaf, MiHA
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1007)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1009)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C048.heic.txt
+++ b/regression/data/conformance_files_expected_info/C048.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: mif1, msf1, hevx, heix, iso8
+
+image: 1280x720 (id=1004), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C049.heic.txt
+++ b/regression/data/conformance_files_expected_info/C049.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, mp42, isom, M4A , miaf, MiHA
+
+image: 1920x1080 (id=1820), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C050.heic.txt
+++ b/regression/data/conformance_files_expected_info/C050.heic.txt
@@ -1,0 +1,87 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB
+
+image: 1280x960 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x960 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x960 (id=1006)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x960 (id=1008)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x960 (id=1010)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x960 (id=1012)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C051.heic.txt
+++ b/regression/data/conformance_files_expected_info/C051.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1280x720 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C052.heic.txt
+++ b/regression/data/conformance_files_expected_info/C052.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: yes 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/C053.heic.txt
+++ b/regression/data/conformance_files_expected_info/C053.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB
+
+image: 1024x512 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x512 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/MIAF001.heic.txt
+++ b/regression/data/conformance_files_expected_info/MIAF001.heic.txt
@@ -1,0 +1,18 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB
+
+image: 1280x720 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/MIAF002.heic.txt
+++ b/regression/data/conformance_files_expected_info/MIAF002.heic.txt
@@ -1,0 +1,18 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHA
+
+image: 2048x2048 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 10
+  thumbnail: 160x160
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/MIAF003.heic.txt
+++ b/regression/data/conformance_files_expected_info/MIAF003.heic.txt
@@ -1,0 +1,18 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHE
+
+image: 2048x2048 (id=1002), primary
+  colorspace: YCbCr, 4:4:4
+  bit depth: 8
+  thumbnail: 160x160
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/MIAF004.heic.txt
+++ b/regression/data/conformance_files_expected_info/MIAF004.heic.txt
@@ -1,0 +1,18 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB, MiPr
+
+image: 1280x720 (id=1005), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 128x72
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/MIAF005.heic.txt
+++ b/regression/data/conformance_files_expected_info/MIAF005.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: heic, hevc, mif1, miaf, MiHB, MiAn, msf1, iso8
+
+image: 1280x720 (id=1004), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/MIAF006.heic.txt
+++ b/regression/data/conformance_files_expected_info/MIAF006.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heif-sequence
+main brand: msf1
+compatible brands: heic, hevc, mif1, miaf, MiHB, MiBr, msf1, iso8
+
+image: 1920x1440 (id=1004), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/MIAF007.heic.txt
+++ b/regression/data/conformance_files_expected_info/MIAF007.heic.txt
@@ -1,0 +1,20 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: heic, mif1, miaf, MiHB
+
+image: 360x640 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  thumbnail: 360x640
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  crop: left=320 top=180 right=320 bottom=180
+  angle (ccw): 90
+  mirror: vertical
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/multilayer001.heic.txt
+++ b/regression/data/conformance_files_expected_info/multilayer001.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heic, heis
+
+image: 1024x512 (id=20003), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/multilayer002.heic.txt
+++ b/regression/data/conformance_files_expected_info/multilayer002.heic.txt
@@ -1,0 +1,87 @@
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heic, heis
+
+image: 512x256 (id=20010), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 512x256 (id=20011)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 512x256 (id=20012)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 512x256 (id=20013)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x512 (id=20018)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x512 (id=20019)
+  colorspace: YCbCr, unknown
+  bit depth: -1
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/multilayer003.heic.txt
+++ b/regression/data/conformance_files_expected_info/multilayer003.heic.txt
@@ -1,0 +1,31 @@
+MIME type: image/heif
+main brand: mif1
+compatible brands: mif1, heic
+
+image: 1024x512 (id=1002), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:
+
+image: 1024x512 (id=1004)
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/data/conformance_files_expected_info/multilayer004.heic.txt
+++ b/regression/data/conformance_files_expected_info/multilayer004.heic.txt
@@ -1,0 +1,3 @@
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heis, avci

--- a/regression/data/conformance_files_expected_info/multilayer005.heic.txt
+++ b/regression/data/conformance_files_expected_info/multilayer005.heic.txt
@@ -1,0 +1,17 @@
+MIME type: image/heic
+main brand: heis
+compatible brands: mif1, heic, heis
+
+image: 512x256 (id=20003), primary
+  colorspace: YCbCr, 4:2:0
+  bit depth: 8
+  color profile: no
+  alpha channel: no 
+  depth channel: no
+metadata:
+  none
+transformations:
+  none
+region annotations:
+  none
+properties:

--- a/regression/examples/config.py
+++ b/regression/examples/config.py
@@ -1,0 +1,28 @@
+import json
+import os
+import subprocess
+
+class Config:
+    def __init__(self):
+        with open("version.json") as version_data:
+            self.version = json.load(version_data)
+        print(self.version)
+
+        with open("test_data.json") as test_data:
+            self.test_config = json.load(test_data)
+        print(self.test_config)
+
+        if not os.path.exists(self.test_config["conformance_test_data"]):
+            subprocess.run(["git", "clone", "https://github.com/nokiatech/heif_conformance", self.test_config["conformance_test_data"]])
+
+    def heif_version(self):
+        return self.version["version_str"]
+    
+    def conformance_file_path(self, filename):
+        return self.test_config["conformance_test_data"] + "/conformance_files/" + filename
+    
+    def getExpectedFileInfo(self, filename):
+        return self.test_config["static_test_data"] + "/conformance_files_expected_info/" + filename + ".txt"
+    
+    def getExpectedFileDump(self, filename):
+        return self.test_config["static_test_data"] + "/conformance_files_expected_dump/" + filename + ".dump"

--- a/regression/examples/test_heif_decode.py
+++ b/regression/examples/test_heif_decode.py
@@ -1,0 +1,39 @@
+import subprocess
+
+from config import Config
+
+APP_NAME = "heif-convert"
+APP_PATH = "../examples/" + APP_NAME
+
+config = Config()
+
+helptext = """\
+ {appname}  libheif version: {version}
+-------------------------------------------
+Usage: {appname} [options]  <input-image> [output-image]
+
+The program determines the output file format from the output filename suffix.
+These suffixes are recognized: jpg, jpeg, png, y4m. If no output filename is specified, 'jpg' is used.
+
+Options:
+  -h, --help                     show help
+  -v, --version                  show version
+  -q, --quality                  quality (for JPEG output)
+  -o, --output FILENAME          write output to FILENAME (optional)
+  -d, --decoder ID               use a specific decoder (see --list-decoders)
+      --with-aux                 also write auxiliary images (e.g. depth images)
+      --with-xmp                 write XMP metadata to file (output filename with .xmp suffix)
+      --with-exif                write EXIF metadata to file (output filename with .exif suffix)
+      --skip-exif-offset         skip EXIF metadata offset bytes
+      --no-colons                replace ':' characters in auxiliary image filenames with '_'
+      --list-decoders            list all available decoders (built-in and plugins)
+      --quiet                    do not output status messages to console
+  -C, --chroma-upsampling ALGO   Force chroma upsampling algorithm (nn = nearest-neighbor / bilinear)
+      --png-compression-level #  Set to integer between 0 (fastest) and 9 (best). Use -1 for default.
+""".format(appname = APP_NAME, version = config.heif_version())
+
+
+def test_help_output():
+
+    ret = subprocess.run([APP_PATH, "--help"], capture_output=True, text=True)
+    assert ret.stderr == helptext

--- a/regression/examples/test_heif_info.py
+++ b/regression/examples/test_heif_info.py
@@ -1,0 +1,105 @@
+import pytest
+import subprocess
+
+from config import Config
+
+config = Config()
+
+CONFORMANCE_FILES = [
+  "C001.heic",
+  "C002.heic",
+  "C003.heic",
+  "C004.heic",
+  "C005.heic",
+  "C006.heic",
+  "C007.heic",
+  "C008.heic",
+  "C009.heic",
+  "C010.heic",
+  "C011.heic",
+  "C012.heic",
+  "C013.heic",
+  "C014.heic",
+  "C015.heic",
+  "C016.heic",
+  "C017.heic",
+  "C018.heic",
+  "C019.heic",
+  "C020.heic",
+  pytest.param("C021.heic", marks=pytest.mark.xfail(reason="No AVC support yet")),
+  "C022.heic",
+  "C023.heic",
+  "C024.heic",
+  "C025.heic",
+  pytest.param("C026.heic", marks=pytest.mark.xfail(reason="No supported brands - image sequence")),
+  pytest.param("C027.heic", marks=pytest.mark.xfail(reason="No supported brands - image sequence")),
+  pytest.param("C028.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  pytest.param("C029.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  pytest.param("C030.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  pytest.param("C031.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  pytest.param("C032.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  "C034.heic",
+  pytest.param("C036.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  pytest.param("C037.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  pytest.param("C038.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  "C039.heic",
+  "C040.heic",
+  pytest.param("C041.heic", marks=pytest.mark.xfail(reason="No supported brands")),
+  "C042.heic",
+  "C043.heic",
+  "C044.heic",
+  "C045.heic",
+  "C046.heic",
+  "C047.heic",
+  "C048.heic",
+  "C049.heic",
+  "C050.heic",
+  "C051.heic",
+  "C052.heic",
+  "C053.heic",
+  "MIAF001.heic",
+  "MIAF002.heic",
+  "MIAF003.heic",
+  "MIAF004.heic",
+  "MIAF005.heic",
+  "MIAF006.heic",
+  "MIAF007.heic",
+  "multilayer001.heic",
+  pytest.param("multilayer002.heic", marks=pytest.mark.xfail(reason="L-HEVC image")),
+  "multilayer003.heic",
+  pytest.param("multilayer004.heic", marks=pytest.mark.xfail(reason="No AVC support yet")),
+  "multilayer005.heic"
+]
+
+helptext = """\
+ heif-info  libheif version: {version}
+------------------------------------
+usage: heif-info [options] image.heic
+
+options:
+  -d, --dump-boxes     show a low-level dump of all MP4 file boxes
+  -h, --help           show help
+  -v, --version        show version
+""".format(version=config.heif_version())
+
+
+def test_help_output():
+    ret = subprocess.run(["../examples/heif-info", "--help"], capture_output=True, text=True)
+    assert ret.stderr == helptext
+
+@pytest.mark.parametrize("filename", CONFORMANCE_FILES)
+def test_info(filename):
+    ret = subprocess.run(["../examples/heif-info", config.conformance_file_path(filename)], capture_output=True, text=True)
+    with open(config.getExpectedFileInfo(filename)) as f:
+      expected = f.read()
+    assert ret.stdout == expected
+    assert ret.stderr == ""
+    
+
+@pytest.mark.parametrize("filename", CONFORMANCE_FILES)
+def test_dump(filename):
+    ret = subprocess.run(["../examples/heif-info", "--dump-boxes", config.conformance_file_path(filename)], capture_output=True, text=True)
+    with open(config.getExpectedFileDump(filename)) as f:
+      expected = f.read()
+    assert ret.stdout == expected
+    assert ret.stderr == ""

--- a/regression/test_data.json.in
+++ b/regression/test_data.json.in
@@ -1,0 +1,4 @@
+{
+    "static_test_data" : "@TESTING_DATA_DIRECTORY@",
+    "conformance_test_data" : "heif_conformance"
+}

--- a/regression/version.json.in
+++ b/regression/version.json.in
@@ -1,0 +1,1 @@
+{"version_str":"@PROJECT_VERSION@"}


### PR DESCRIPTION
This is a concept draft for regression testing. It was inspired by the `iden` regression going unnoticed.

We do have unit testing, but it doesn't really exercise a lot of the functionality. 

So this makes use of pytest (which is assumed installed - its a package on ubuntu) to do black-box testing. The main check at this stage is that heif-info produces the right result. There are a bunch of other things that could be tested.

Key decisions are:

1. Is this worth the effort to maintain?
2. Are the tests reliable? (I'm not sure what I have is reliable).
3. Is there an additional / better source of test data?
4. Do we want to do image comparisons against known-good snapshots (e.g. PNG files)

A couple of other things I noticed:
* The output of `heif-info --dump-boxes`  puts the MIME type, main brand and compatible brand at the start when you are using it interactively, and at the end when redirected to a file (e.g. see the last three lines in any of the .dump files).
* The output of `--help` goes to stderr. That is probably OK for a mis-use, but might not be appropriate when requested, since its not really an error at this point.

Thoughts / opinions welcome.

