### PR TITLE
CI: add macOS arm64 job

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -10,13 +10,14 @@ jobs:
   build:
     strategy:
       matrix:
+        runner: [ macos-12, macos-14 ]
         env:
           - { NAME: "nothing" }
           - { NAME: "cmake", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_AOM: 1, WITH_LIBDE265: 1 }
           - { NAME: "libde265 (1) / x265 / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_LIBDE265: 1 }
           - { NAME: "libde265 (2) / x265 / graphics", WITH_GRAPHICS: 1, WITH_X265: 1, WITH_LIBDE265: 2 }
     env: ${{ matrix.env }}
-    runs-on: macos-12
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source