### PR TITLE
iloc: fix error message

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -1268,9 +1268,9 @@ Error Box_iloc::read_data(const Item& item,
     }
     else {
       std::stringstream sstr;
-      sstr << "Item construction method " << item.construction_method << " not implemented";
+      sstr << "Item construction method " << (int) item.construction_method << " not implemented";
       return Error(heif_error_Unsupported_feature,
-                   heif_suberror_No_idat_box,
+                   heif_suberror_Unsupported_item_construction_method,
                    sstr.str());
     }
   }


### PR DESCRIPTION
The construction method of 2 is currently being interpreted as a character (not a number), and doesn't appear.

Also the suberror shouldn't indicate a missing `idat`.