### PR TITLE
uncompressed: support version 1 boxes

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -928,9 +928,7 @@ std::string Box_other::dump(Indent& indent) const
 
   sstr << std::hex << std::setfill('0');
 
-  size_t len = get_box_size() - get_header_size();
-
-  for (size_t i = 0; i < len; i++) {
+  for (size_t i = 0; i < m_data.size(); i++) {
     if (i % 16 == 0) {
       // start of line
 
@@ -953,7 +951,7 @@ std::string Box_other::dump(Indent& indent) const
 
     sstr << std::setw(2) << ((int) m_data[i]);
 
-    if (i % 16 == 15 || i == len - 1) {
+    if (i % 16 == 15 || i == m_data.size() - 1) {
       sstr << "\n";
     }
   }

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -204,6 +204,16 @@ public:
 
   static bool equal(const std::shared_ptr<Box>& box1, const std::shared_ptr<Box>& box2);
 
+  /**
+   * Get any implied boxes for this box.
+   *
+   * This is intended to support short-cut or minified boxes returning the "implied" boxes.
+   * Most boxes will not need this.
+   */
+  virtual std::shared_ptr<std::vector<std::shared_ptr<Box>>> get_implied_boxes()
+  {
+    return nullptr;
+  };
 
 protected:
   virtual Error parse(BitstreamRange& range);

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -2642,7 +2642,7 @@ int heif_encoder_has_default(struct heif_encoder* encoder,
 
 static void set_default_options(heif_encoding_options& options)
 {
-  options.version = 6;
+  options.version = 7;
 
   options.save_alpha_channel = true;
   options.macOS_compatibility_workaround = false;
@@ -2655,11 +2655,16 @@ static void set_default_options(heif_encoding_options& options)
   options.color_conversion_options.preferred_chroma_downsampling_algorithm = heif_chroma_downsampling_average;
   options.color_conversion_options.preferred_chroma_upsampling_algorithm = heif_chroma_upsampling_bilinear;
   options.color_conversion_options.only_use_preferred_chroma_algorithm = false;
+
+  options.prefer_minimised = false;
 }
 
 static void copy_options(heif_encoding_options& options, const heif_encoding_options& input_options)
 {
   switch (input_options.version) {
+    case 7:
+      options.prefer_minimised = input_options.prefer_minimised;
+      // fallthrough
     case 6:
       options.color_conversion_options = input_options.color_conversion_options;
       // fallthrough

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -2043,6 +2043,11 @@ struct heif_encoding_options
   // version 6 options
 
   struct heif_color_conversion_options color_conversion_options;
+
+  // version 7 options
+
+  // Set this to true to used minimised versions of boxes where possible
+  uint8_t prefer_minimised;
 };
 
 LIBHEIF_API

--- a/libheif/uncompressed_box.h
+++ b/libheif/uncompressed_box.h
@@ -79,7 +79,7 @@ public:
   Box_uncC() :
     m_profile(0),
     m_sampling_type(sampling_mode_no_subsampling),
-    m_interleave_type(interleave_mode_component),
+    m_interleave_type(interleave_mode_pixel),
     m_block_size(0),
     m_components_little_endian(false),
     m_block_pad_lsb(false),
@@ -94,6 +94,8 @@ public:
   {
     set_short_type(fourcc("uncC"));
   }
+
+  void derive_box_version() override {};
 
   std::string dump(Indent&) const override;
 
@@ -211,6 +213,8 @@ public:
   {
     m_num_tile_rows = num_tile_rows;
   }
+
+  std::shared_ptr<std::vector<std::shared_ptr<Box>>> get_implied_boxes() override;
 
 protected:
   Error parse(BitstreamRange& range) override;

--- a/tests/uncompressed_encode.cc
+++ b/tests/uncompressed_encode.cc
@@ -565,7 +565,7 @@ struct heif_image *createImage_RGBA_planar()
   return image;
 }
 
-static void do_encode(heif_image* input_image, const char* filename, bool check_decode)
+static void do_encode(heif_image* input_image, const char* filename, bool check_decode, uint8_t preferMinimised = 0)
 {
   REQUIRE(input_image != nullptr);
 
@@ -580,6 +580,7 @@ static void do_encode(heif_image* input_image, const char* filename, bool check_
   options->macOS_compatibility_workaround = false;
   options->macOS_compatibility_workaround_no_nclx_profile = true;
   options->image_orientation = heif_orientation_normal;
+  options->prefer_minimised = preferMinimised;
   heif_image_handle *output_image_handle;
 
   err = heif_context_encode_image(ctx, input_image, encoder, options, &output_image_handle);
@@ -644,6 +645,11 @@ TEST_CASE("Encode Mono")
   do_encode(input_image, "encode_mono.heif", true);
 }
 
+TEST_CASE("Encode RGB Version1")
+{
+  heif_image *input_image = createImage_RGB_interleaved();
+  do_encode(input_image, "encode_rgb_version1.heif", true, true);
+}
 
 TEST_CASE("Encode Mono with alpha")
 {
@@ -706,6 +712,12 @@ TEST_CASE("Encode RGBA")
 {
   heif_image *input_image = createImage_RGBA_interleaved();
   do_encode(input_image, "encode_rgba.heif", true);
+}
+
+TEST_CASE("Encode RGBA Version 1")
+{
+  heif_image *input_image = createImage_RGBA_interleaved();
+  do_encode(input_image, "encode_rgba_version1.heif", true, true);
 }
 
 


### PR DESCRIPTION
This adds support for parsing uncompressed heif files using version 1 of the `uncC` box, which is a shortcut for simple RGB, RGBA and ABGR files at 8bpp. 

I looked at trying to synthesize the extra box (`cmpd`) at parse time. That didn't work out, because the item property association then didn't line up. Instead, the extra boxes are produced when the item properties are requested.