### PR TITLE
Parse EntityGroup Remaining Data

### DIFF
--- a/libheif/box.h
+++ b/libheif/box.h
@@ -809,6 +809,42 @@ protected:
 };
 
 
+class EntityGroup : public FullBox
+{
+public:
+  EntityGroup(uint32_t fourcc)
+  {
+    set_short_type(fourcc);
+  }
+  std::string dump(Indent&) const override;
+
+protected:
+  Error parse(BitstreamRange& range) override;
+  virtual Error parse_remaining(BitstreamRange& range) { return Error::Ok; }
+  virtual std::string dump_remaining(Indent&) const { return ""; }
+
+public:
+  uint32_t m_group_id;
+  std::vector<heif_item_id> m_entity_ids;
+};
+
+
+class Box_ster : public EntityGroup
+{
+public:
+  Box_ster() : EntityGroup(fourcc("ster"))
+  {
+  }
+
+private:
+  bool m_left_view_flag;
+
+protected:
+  Error parse_remaining(BitstreamRange& range) override;
+  std::string dump_remaining(Indent&) const override;
+};
+
+
 class Box_grpl : public Box
 {
 public:
@@ -816,14 +852,6 @@ public:
 
 protected:
   Error parse(BitstreamRange& range) override;
-
-  struct EntityGroup
-  {
-    FullBox header;
-    uint32_t group_id;
-
-    std::vector<heif_item_id> entity_ids;
-  };
 
   std::vector<EntityGroup> m_entity_groups;
 };


### PR DESCRIPTION
Some EntityToGroupBoxes have additional data at the end of the box (see ISO/IEC 14496-12 section 8.18.3.2). Currently, the libheif Box_grpl class doesn't parse any additional data. This pull request resolves this issue by moving the EntityGroup struct to its own class which allows for other boxes to inherit from it and specify how to parse their own remaining data.

For use cases, see ISO/IEC 23008-12 section 6.8 Entity and Sample Groups which mention the following entity groups:

Equivalent Boxes (eqiz)
Burst Images (brst)
Time-synchronized group (tsyn)
Auto to Image group (iaug)
etc...
Personally, I'm interested in the Image Pyramid Entity Group (pymd) which will be added to HEIF version 3.
Sample Files:
[C007.heic](https://github.com/nokiatech/heif_conformance/blob/master/conformance_files/C007.heic)
Contains a grpl box with an "altr" EntityGroup. The altr box doesn't have additional data at the end of the box, so it can simply reuse the defined EntityGroup class. No Box_altr is required.

[multilayer003.heic](https://github.com/nokiatech/heif_conformance/blob/master/conformance_files/multilayer003.heic)
Contains a grpl box with an "ster" EntityGroup. The ster box has an additional flag so the Box_ster parse_remaining() function accounts for this.