### PR TITLE
encoder_kvazaar.cc: Fix some memory leaks

### DIFF
--- a/libheif/plugins/encoder_kvazaar.cc
+++ b/libheif/plugins/encoder_kvazaar.cc
@@ -362,6 +362,11 @@ static void copy_plane(kvz_pixel* out_p, uint32_t out_stride, const uint8_t* in_
 }
 
 
+template<typename T, typename D>
+std::unique_ptr<T, D> make_guard(T* ptr, D&& deleter) {
+    return std::unique_ptr<T, D>(ptr, deleter);
+}
+
 static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct heif_image* image,
                                               heif_image_input_class input_class)
 {
@@ -381,7 +386,8 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
     return err;
   }
 
-  kvz_config* config = api->config_alloc();
+  auto uconfig = make_guard(api->config_alloc(), [api](kvz_config* cfg) { api->config_destroy(cfg); });
+  kvz_config* config = uconfig.get();
   api->config_init(config); // param, encoder->preset.c_str(), encoder->tune.c_str());
 
 #if HAVE_KVAZAAR_ENABLE_LOGGING
@@ -556,9 +562,9 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
   }
 */
 
-  kvz_picture* pic = api->picture_alloc_csp(kvzChroma, encoded_width, encoded_height);
+  auto upic = make_guard(api->picture_alloc_csp(kvzChroma, encoded_width, encoded_height), [api](kvz_picture* pic) { api->picture_free(pic); });
+  kvz_picture* pic = upic.get();
   if (!pic) {
-    api->config_destroy(config);
     return heif_error{
         heif_error_Encoder_plugin_error,
         heif_suberror_Encoder_encoding,
@@ -588,11 +594,9 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
                encoded_width >> chroma_stride_shift, encoded_height >> chroma_height_shift);
   }
 
-  kvz_encoder* kvzencoder = api->encoder_open(config);
+  auto uencoder = make_guard(api->encoder_open(config), [api](kvz_encoder* e) { api->encoder_close(e); });
+  kvz_encoder* kvzencoder = uencoder.get();
   if (!kvzencoder) {
-    api->picture_free(pic);
-    api->config_destroy(config);
-
     return heif_error{
         heif_error_Encoder_plugin_error,
         heif_suberror_Encoder_encoding,
@@ -601,14 +605,18 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
   }
 
   kvz_data_chunk* data = nullptr;
+  auto free_data = [api](kvz_data_chunk** data){
+    if(*data) {
+        api->chunk_free(*data);
+        *data = nullptr;
+    }
+  };
+  auto data_deleter = std::unique_ptr<kvz_data_chunk*, decltype(free_data)>(&data, free_data);
+
   uint32_t data_len;
   int success;
   success = api->encoder_headers(kvzencoder, &data, &data_len);
   if (!success) {
-    api->picture_free(pic);
-    api->config_destroy(config);
-    api->encoder_close(kvzencoder);
-
     return heif_error{
         heif_error_Encoder_plugin_error,
         heif_suberror_Encoder_encoding,
@@ -617,17 +625,13 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
   }
 
   append_chunk_data(data, encoder->output_data);
+  free_data(&data);
 
   success = api->encoder_encode(kvzencoder,
                                 pic,
                                 &data, &data_len,
                                 nullptr, nullptr, nullptr);
   if (!success) {
-    api->chunk_free(data);
-    api->picture_free(pic);
-    api->config_destroy(config);
-    api->encoder_close(kvzencoder);
-
     return heif_error{
         heif_error_Encoder_plugin_error,
         heif_suberror_Encoder_encoding,
@@ -636,6 +640,7 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
   }
 
   append_chunk_data(data, encoder->output_data);
+  free_data(&data);
 
   for (;;) {
     success = api->encoder_encode(kvzencoder,
@@ -643,11 +648,6 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
                                   &data, &data_len,
                                   nullptr, nullptr, nullptr);
     if (!success) {
-      api->chunk_free(data);
-      api->picture_free(pic);
-      api->config_destroy(config);
-      api->encoder_close(kvzencoder);
-
       return heif_error{
           heif_error_Encoder_plugin_error,
           heif_suberror_Encoder_encoding,
@@ -660,16 +660,10 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
     }
 
     append_chunk_data(data, encoder->output_data);
+    free_data(&data);
   }
 
   (void) success;
-
-  api->chunk_free(data);
-
-  api->encoder_close(kvzencoder);
-  api->picture_free(pic);
-  api->config_destroy(config);
-
   return heif_error_ok;
 }
 


### PR DESCRIPTION
This fixes the following memory leaks:
- the `data` chunks are not freed in all cases after being appended to the encoder output
- `append_chunk_data` throwing an exception (std::bad_alloc) would not free any of the kvazaar-structures

At least the successful encoding case should be leak-free now: The address sanitizer does not report any leaks.
I did not test the exceptional cases - using unique_ptr this should be no different than the successful case.