### PR TITLE
libheif: check compatible brands in the ftyp box

### DIFF
--- a/examples/heif_convert.cc
+++ b/examples/heif_convert.cc
@@ -380,20 +380,26 @@ int main(int argc, char** argv)
   // TODO: check, whether reading from named pipes works at all.
 
   std::ifstream istr(input_filename.c_str(), std::ios_base::binary);
-  uint8_t length[4];
-  istr.read((char*) length, 4);
+  std::vector<uint8_t> length(4);
+  istr.read((char*) length.data(), length.size());
   uint32_t box_size = (length[0] << 24) + (length[1] << 16) + (length[2] << 8) + (length[3]);
   if ((box_size < 16) || (box_size > 512)) {
-    fprintf(stderr, "Input file does not appear to start with a valid box length\n");
+    fprintf(stderr, "Input file does not appear to start with a valid box length.");
+    if (box_size == 0xFFD8FFE0) {
+      fprintf(stderr, " Possibly could be a JPEG file instead.\n");
+    } else {
+      fprintf(stderr, "\n");
+    }
     return 1;
   }
 
-  std::vector<uint8_t> ftyp_bytes(box_size - 4);
-  istr.read((char*) ftyp_bytes.data(), ftyp_bytes.size());
+  std::vector<uint8_t> ftyp_bytes(box_size);
+  std::copy(length.begin(), length.end(), ftyp_bytes.begin());
+  istr.read((char*) ftyp_bytes.data() + 4, ftyp_bytes.size() - 4);
 
-  enum heif_filetype_result filetype_check = heif_check_filetype_full(ftyp_bytes.data(), (int)ftyp_bytes.size());
-  if (filetype_check != heif_filetype_yes_supported) {
-    fprintf(stderr, "Input file is not a supported format\n");
+  heif_error filetype_check = heif_has_compatible_filetype(ftyp_bytes.data(), (int)ftyp_bytes.size());
+  if (filetype_check.code != heif_error_Ok) {
+    fprintf(stderr, "Input file is not a supported format. %s\n", filetype_check.message);
     return 1;
   }
 

--- a/examples/heif_convert.cc
+++ b/examples/heif_convert.cc
@@ -380,26 +380,22 @@ int main(int argc, char** argv)
   // TODO: check, whether reading from named pipes works at all.
 
   std::ifstream istr(input_filename.c_str(), std::ios_base::binary);
-  uint8_t magic[12];
-  istr.read((char*) magic, 12);
-
-  if (heif_check_jpeg_filetype(magic, 12)) {
-    fprintf(stderr, "Input file '%s' is a JPEG image\n", input_filename.c_str());
+  uint8_t length[4];
+  istr.read((char*) length, 4);
+  uint32_t box_size = (length[0] << 24) + (length[1] << 16) + (length[2] << 8) + (length[3]);
+  if ((box_size < 16) || (box_size > 512)) {
+    fprintf(stderr, "Input file does not appear to start with a valid box length\n");
     return 1;
   }
 
-  enum heif_filetype_result filetype_check = heif_check_filetype(magic, 12);
-  if (filetype_check == heif_filetype_no) {
-    fprintf(stderr, "Input file is not an HEIF/AVIF file\n");
+  std::vector<uint8_t> ftyp_bytes(box_size - 4);
+  istr.read((char*) ftyp_bytes.data(), ftyp_bytes.size());
+
+  enum heif_filetype_result filetype_check = heif_check_filetype_full(ftyp_bytes.data(), (int)ftyp_bytes.size());
+  if (filetype_check != heif_filetype_yes_supported) {
+    fprintf(stderr, "Input file is not a supported format\n");
     return 1;
   }
-
-  if (filetype_check == heif_filetype_yes_unsupported) {
-    fprintf(stderr, "Input file is an unsupported HEIF/AVIF file type\n");
-    return 1;
-  }
-
-
 
   // --- read the HEIF file
 

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -145,20 +145,17 @@ heif_filetype_result heif_check_filetype(const uint8_t* data, int len)
 }
 
 
-heif_filetype_result heif_check_filetype_full(const uint8_t* data, int len)
+heif_error heif_has_compatible_filetype(const uint8_t* data, int len)
 {
-  if (len < 12) {
-    // It can't be a valid ISOBMFF file without the FourCC, major_brand and minor_version
-    return heif_filetype_no;
+  // Get compatible brands first, because that does validity checks
+  heif_brand2* compatible_brands = nullptr;
+  int nBrands = 0;
+  struct heif_error err = heif_list_compatible_brands(data, len, &compatible_brands, &nBrands);
+  if (err.code) {
+    return err;
   }
 
-  if (data[0] != 'f' ||
-      data[1] != 't' ||
-      data[2] != 'y' ||
-      data[3] != 'p') {
-        // It can't be a valid ISOBMFF file without this FourCC.
-    return heif_filetype_no;
-  }
+  heif_brand2 main_brand = heif_read_main_brand(data, len);
 
   std::set<heif_brand2> supported_brands{
       heif_brand2_avif,
@@ -171,21 +168,22 @@ heif_filetype_result heif_check_filetype_full(const uint8_t* data, int len)
       heif_brand2_mif2
   };
 
-  heif_brand2 brand = heif_fourcc_to_brand((char*) (data + 4));
-  auto it = supported_brands.find(brand);
+  auto it = supported_brands.find(main_brand);
   if (it != supported_brands.end()) {
-    return heif_filetype_yes_supported;
+    heif_free_list_of_compatible_brands(compatible_brands);
+    return heif_error_ok;
   }
 
-  for (int offset = 12; offset < len; offset += 4) {
-    heif_brand2 compatible_brand = heif_fourcc_to_brand((char*) (data + offset));
+  for (int i = 0; i < nBrands; i++) {
+    heif_brand2 compatible_brand = compatible_brands[i];
     it = supported_brands.find(compatible_brand);
     if (it != supported_brands.end()) {
-      return heif_filetype_yes_supported;
+      heif_free_list_of_compatible_brands(compatible_brands);
+      return heif_error_ok;
     }
   }
-
-  return heif_filetype_yes_unsupported;
+  heif_free_list_of_compatible_brands(compatible_brands);
+  return {heif_error_Invalid_input, heif_suberror_Unsupported_image_type, "No supported brands found."};;
 }
 
 
@@ -362,7 +360,7 @@ struct heif_error heif_list_compatible_brands(const uint8_t* data, int len, heif
 
   auto ftyp = std::dynamic_pointer_cast<Box_ftyp>(box);
   if (!ftyp) {
-    return {heif_error_Invalid_input, heif_suberror_No_ftyp_box, "input is no ftyp box"};
+    return {heif_error_Invalid_input, heif_suberror_No_ftyp_box, "input is not a ftyp box"};
   }
 
   auto brands = ftyp->list_brands();

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -576,14 +576,16 @@ LIBHEIF_API
 enum heif_filetype_result heif_check_filetype(const uint8_t* data, int len);
 
 /**
- * Check the filetype box content for a support file type.
+ * Check the filetype box content for a supported file type.
  *
- * <p>The data is assumed to start from the FourCC value (i.e. `ftyp`).
+ * <p>The data is assumed to start from the start of the `ftyp` box.
  *
  * <p>This function checks the compatible brands.
+ * 
+ * @returns heif_error_ok if a supported brand is found, or other error if not.
  */
 LIBHEIF_API
-enum heif_filetype_result heif_check_filetype_full(const uint8_t* data, int len);
+struct heif_error heif_has_compatible_filetype(const uint8_t* data, int len);
 
 LIBHEIF_API
 int heif_check_jpeg_filetype(const uint8_t* data, int len);

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -575,6 +575,16 @@ enum heif_filetype_result
 LIBHEIF_API
 enum heif_filetype_result heif_check_filetype(const uint8_t* data, int len);
 
+/**
+ * Check the filetype box content for a support file type.
+ *
+ * <p>The data is assumed to start from the FourCC value (i.e. `ftyp`).
+ *
+ * <p>This function checks the compatible brands.
+ */
+LIBHEIF_API
+enum heif_filetype_result heif_check_filetype_full(const uint8_t* data, int len);
+
 LIBHEIF_API
 int heif_check_jpeg_filetype(const uint8_t* data, int len);
 


### PR DESCRIPTION
Keeps the existing `heif_check_filetype` behaviour since that is public API. Adds a new function to check both the major version and the compatible_brands list. Switches the heif-convert example to use that new function.

I have put an arbitrary 512 byte limit on how long we expect the `ftyp` box could be. That seems reasonable, but could be higher or lower.

The goal of this is to support files that are both video and images (sharing data), where the major_brand is something like `mp41` but `heic` is listed in the `compatible_brands[]`.