### PR TITLE
Reuse matching ispe box if one exists.

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -753,6 +753,10 @@ int Box::find_or_append_child_box(const std::shared_ptr<Box>& box)
 
 bool Box::operator==(const Box& other) const
 {
+  if (this->get_short_type() != other.get_short_type()) {
+    return false;
+  }
+
   StreamWriter writer1;
   StreamWriter writer2;
 

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -742,7 +742,7 @@ std::vector<std::shared_ptr<Box>> Box::get_child_boxes(uint32_t short_type) cons
 
 int Box::find_or_append_child_box(const std::shared_ptr<Box>& box)
 {
-  for (size_t i = 0; i < m_children.size(); i++) {
+  for (int i = 0; i < (int) m_children.size(); i++) {
     if (Box::equal(m_children[i], box)) {
       return i;
     }

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -740,6 +740,38 @@ std::vector<std::shared_ptr<Box>> Box::get_child_boxes(uint32_t short_type) cons
 }
 
 
+int Box::find_or_append_child_box(const std::shared_ptr<Box>& box)
+{
+  for (size_t i = 0; i < m_children.size(); i++) {
+    if (Box::equal(m_children[i], box)) {
+      return i;
+    }
+  }
+  return append_child_box(box);
+}
+
+
+bool Box::operator==(const Box& other) const
+{
+  StreamWriter writer1;
+  StreamWriter writer2;
+
+  this->write(writer1);
+  other.write(writer2);
+
+  return writer1.get_data() == writer2.get_data();
+}
+
+
+bool Box::equal(const std::shared_ptr<Box>& box1, const std::shared_ptr<Box>& box2)
+{
+    if (!box1 || !box2) {
+        return false;
+    }
+    return *box1 == *box2;
+}
+
+
 Error Box::read_children(BitstreamRange& range, int max_number)
 {
   int count = 0;

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -194,6 +194,13 @@ public:
     return (int) m_children.size() - 1;
   }
 
+  int find_or_append_child_box(const std::shared_ptr<Box>& box);
+
+  bool operator==(const Box& other) const;
+
+  static bool equal(const std::shared_ptr<Box>& box1, const std::shared_ptr<Box>& box2);
+
+
 protected:
   virtual Error parse(BitstreamRange& range);
 

--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -966,6 +966,19 @@ std::shared_ptr<Box_infe> HeifFile::add_new_infe_box(const char* item_type)
 
 void HeifFile::add_ispe_property(heif_item_id id, uint32_t width, uint32_t height)
 {
+  // Reuse matching ispe box if one exists.
+  auto properties = get_ipco_box()->get_all_child_boxes();
+  for (uint16_t i = 0; i < properties.size(); i++) {
+    auto property = properties[i];
+    if (property->get_short_type() == fourcc("ispe")) {
+      auto ispe = std::dynamic_pointer_cast<Box_ispe>(property);
+      if (ispe->get_width() == width && ispe->get_height() == height) {
+        m_ipma_box->add_property_for_item_ID(id, Box_ipma::PropertyAssociation{false, uint16_t(i + 1)});
+        return;
+      }
+    }
+  }
+
   auto ispe = std::make_shared<Box_ispe>();
   ispe->set_size(width, height);
 

--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -966,23 +966,10 @@ std::shared_ptr<Box_infe> HeifFile::add_new_infe_box(const char* item_type)
 
 void HeifFile::add_ispe_property(heif_item_id id, uint32_t width, uint32_t height)
 {
-  // Reuse matching ispe box if one exists.
-  auto properties = get_ipco_box()->get_all_child_boxes();
-  for (uint16_t i = 0; i < properties.size(); i++) {
-    auto property = properties[i];
-    if (property->get_short_type() == fourcc("ispe")) {
-      auto ispe = std::dynamic_pointer_cast<Box_ispe>(property);
-      if (ispe->get_width() == width && ispe->get_height() == height) {
-        m_ipma_box->add_property_for_item_ID(id, Box_ipma::PropertyAssociation{false, uint16_t(i + 1)});
-        return;
-      }
-    }
-  }
-
   auto ispe = std::make_shared<Box_ispe>();
   ispe->set_size(width, height);
 
-  int index = m_ipco_box->append_child_box(ispe);
+  int index = m_ipco_box->find_or_append_child_box(ispe);
 
   m_ipma_box->add_property_for_item_ID(id, Box_ipma::PropertyAssociation{false, uint16_t(index + 1)});
 }
@@ -1080,7 +1067,7 @@ void HeifFile::add_pixi_property(heif_item_id id, uint8_t c1, uint8_t c2, uint8_
     pixi->add_channel_bits(c3);
   }
 
-  int index = m_ipco_box->append_child_box(pixi);
+  int index = m_ipco_box->find_or_append_child_box(pixi);
 
   m_ipma_box->add_property_for_item_ID(id, Box_ipma::PropertyAssociation{false, uint16_t(index + 1)});
 }


### PR DESCRIPTION
Reusing identical properties will help clean up the ipco box. It becomes cumbersome when there are many images like this:
<img width="83" alt="image" src="https://github.com/strukturag/libheif/assets/26695634/9364c515-4684-4130-8025-0bb0adeaff34">
