### PR TITLE
libheif: add <array> includes

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -37,6 +37,7 @@
 #include <cstring>
 #include <set>
 #include <cassert>
+#include <array>
 
 #if WITH_UNCOMPRESSED_CODEC
 #include "uncompressed_box.h"

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -46,6 +46,7 @@
 #include <utility>
 #include <vector>
 #include <cstring>
+#include <array>
 
 #ifdef _WIN32
 // for _write

--- a/libheif/heif_properties.cc
+++ b/libheif/heif_properties.cc
@@ -23,6 +23,7 @@
 #include "api_structs.h"
 #include "file.h"
 
+#include <array>
 #include <cstring>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
When building develop-v1.18.0 branch on Ubuntu 24.04 (gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0), I hit this:

```
[  2%] Building CXX object libheif/CMakeFiles/heif.dir/box.cc.o
/home/bradh/coding/libheif/libheif/box.cc:3451:86: error: return type ‘struct std::array<double, 9>’ is incomplete
 3451 | std::array<double,9> mul(const std::array<double,9>& a, const std::array<double,9>& b)
      |                                                                                      ^
/home/bradh/coding/libheif/libheif/box.cc: In function ‘void mul(const std::array<double, 9>&, const std::array<double, 9>&)’:
/home/bradh/coding/libheif/libheif/box.cc:3453:24: error: aggregate ‘std::array<double, 9> m’ has incomplete type and cannot be defined
 3453 |   std::array<double,9> m;
      |                        ^
/home/bradh/coding/libheif/libheif/box.cc:3455:11: error: no match for ‘operator[]’ (operand types are ‘const std::array<double, 9>’ and ‘int’)
 3455 |   m[0] = a[0]*b[0] + a[1]*b[3] + a[2]*b[6];
      |           ^
```

(and a few other places after that).

Looks like we need an explicit include.