### PR TITLE
[ffmpeg plugin] Add more chroma subsampling support

### DIFF
--- a/libheif/plugins/decoder_ffmpeg.cc
+++ b/libheif/plugins/decoder_ffmpeg.cc
@@ -187,6 +187,60 @@ static struct heif_error ffmpeg_v1_push_data(void* decoder_raw, const void* data
   return heif_error_success;
 }
 
+static heif_chroma ffmpeg_get_chroma_format(enum AVPixelFormat pix_fmt) {
+    if (pix_fmt == AV_PIX_FMT_GRAY8)
+    {
+        return heif_chroma_monochrome;
+    }
+    else if ((pix_fmt == AV_PIX_FMT_YUV420P) || (pix_fmt == AV_PIX_FMT_YUVJ420P) ||
+        (pix_fmt == AV_PIX_FMT_YUV420P10LE))
+    {
+        return heif_chroma_420;
+    }
+    else if (pix_fmt == AV_PIX_FMT_YUV422P)
+    {
+        return heif_chroma_422;
+    }
+    else if (pix_fmt == AV_PIX_FMT_YUV444P)
+    {
+        return heif_chroma_444;
+    }
+    // Unsupported pix_fmt
+    return heif_chroma_undefined;
+}
+
+static int ffmpeg_get_chroma_width(const AVFrame* frame, heif_channel channel, heif_chroma chroma)
+{
+    if (channel == heif_channel_Y)
+    {
+        return frame->width;
+    }
+    else if (chroma == heif_chroma_420 || chroma == heif_chroma_422)
+    {
+        return (frame->width) / 2;
+    }
+    else
+    {
+        return frame->width;
+    }
+}
+
+static int ffmpeg_get_chroma_height(const AVFrame* frame, heif_channel channel, heif_chroma chroma)
+{
+    if (channel == heif_channel_Y)
+    {
+        return frame->height;
+    }
+    else if (chroma == heif_chroma_420)
+    {
+        return (frame->height) / 2;
+    }
+    else
+    {
+        return frame->height;
+    }
+}
+
 static struct heif_error hevc_decode(AVCodecContext* hevc_dec_ctx, AVFrame* hevc_frame, AVPacket* hevc_pkt, struct heif_image** image)
 {
     int ret;
@@ -209,14 +263,16 @@ static struct heif_error hevc_decode(AVCodecContext* hevc_dec_ctx, AVFrame* hevc
     }
 
 
-    if ((hevc_dec_ctx->pix_fmt == AV_PIX_FMT_YUV420P) || (hevc_dec_ctx->pix_fmt == AV_PIX_FMT_YUVJ420P) || //planar YUV 4:2:0, 12bpp, (1 Cr & Cb sample per 2x2 Y samples)
-        (hevc_dec_ctx->pix_fmt == AV_PIX_FMT_YUV420P10LE))
+    heif_chroma chroma = ffmpeg_get_chroma_format(hevc_dec_ctx->pix_fmt);
+    if (chroma != heif_chroma_undefined)
     {
+        bool is_mono = (chroma == heif_chroma_monochrome);
+
         heif_error err;
         err = heif_image_create(hevc_frame->width,
             hevc_frame->height,
-            heif_colorspace_YCbCr,
-            heif_chroma_420,
+            is_mono ? heif_colorspace_monochrome : heif_colorspace_YCbCr,
+            chroma,
             image);
         if (err.code) {
             return err;
@@ -228,7 +284,7 @@ static struct heif_error hevc_decode(AVCodecContext* hevc_dec_ctx, AVFrame* hevc
             heif_channel_Cr
         };
 
-        int nPlanes = 3;
+        int nPlanes = is_mono ? 1 : 3;
 
         for (int channel = 0; channel < nPlanes; channel++) {
 
@@ -236,8 +292,8 @@ static struct heif_error hevc_decode(AVCodecContext* hevc_dec_ctx, AVFrame* hevc
             int stride = hevc_frame->linesize[channel];
             const uint8_t* data = hevc_frame->data[channel];
 
-            int w = (channel == 0) ? hevc_frame->width : hevc_frame->width >> 1;
-            int h = (channel == 0) ? hevc_frame->height : hevc_frame->height >> 1;
+            int w = ffmpeg_get_chroma_width(hevc_frame, channel2plane[channel], chroma);
+            int h = ffmpeg_get_chroma_height(hevc_frame, channel2plane[channel], chroma);
             if (w <= 0 || h <= 0) {
                 heif_image_release(*image);
                 err = { heif_error_Decoder_plugin_error,


### PR DESCRIPTION
In this patch, support for mono, 422, 444 are added.

In terms of implementation:
* The check whether a pixel format is supported is moved into ffmpeg_get_chroma_format
* chroma_width and chroma_height needs to be computed separately for 422, 444 as they are different from 420

For testing: I created mono, YUV422, YUV422 samples with heif-enc and ran with ffmpeg plugin with ASAN. I validated that chroma_height and chroma_width are correctly set as they can cause heap-read-out-of-bound if not set correctly.