### PR TITLE
Update to SVT-AV1 v2.1.1

### DIFF
--- a/third-party/svt.cmd
+++ b/third-party/svt.cmd
@@ -5,12 +5,12 @@
 : # If you want to enable the SVT-AV1 encoder, please check that the WITH_SvtEnc and WITH_SvtEnc_BUILTIN CMake variables are set correctly.
 : # You will also have to set the PKG_CONFIG_PATH to "third-party/SVT-AV1/Build/linux/Release" so that the local SVT-AV1 library is found.
 
-git clone -b v2.1.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v2.1.1 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 
 cd SVT-AV1
 cd Build/linux
 
-./build.sh release static no-dec no-apps prefix=$(pwd)/install install
+./build.sh release static no-apps prefix=$(pwd)/install install
 cd ../../..
 
 echo ""


### PR DESCRIPTION
Remove the no-dec build option because the decoder portion of SVT-AV1 was removed in v2.1.1.