### PR TITLE
uncompressed: support version 1 boxes

### DIFF
--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -2748,14 +2748,14 @@ static void set_default_options(heif_encoding_options& options)
   options.color_conversion_options.preferred_chroma_upsampling_algorithm = heif_chroma_upsampling_bilinear;
   options.color_conversion_options.only_use_preferred_chroma_algorithm = false;
 
-  options.prefer_minimised = false;
+  options.prefer_uncC_short_form = true;
 }
 
 static void copy_options(heif_encoding_options& options, const heif_encoding_options& input_options)
 {
   switch (input_options.version) {
     case 7:
-      options.prefer_minimised = input_options.prefer_minimised;
+      options.prefer_uncC_short_form = input_options.prefer_uncC_short_form;
       // fallthrough
     case 6:
       options.color_conversion_options = input_options.color_conversion_options;

--- a/libheif/heif.cc
+++ b/libheif/heif.cc
@@ -2734,7 +2734,7 @@ int heif_encoder_has_default(struct heif_encoder* encoder,
 
 static void set_default_options(heif_encoding_options& options)
 {
-  options.version = 6;
+  options.version = 7;
 
   options.save_alpha_channel = true;
   options.macOS_compatibility_workaround = false;
@@ -2747,11 +2747,16 @@ static void set_default_options(heif_encoding_options& options)
   options.color_conversion_options.preferred_chroma_downsampling_algorithm = heif_chroma_downsampling_average;
   options.color_conversion_options.preferred_chroma_upsampling_algorithm = heif_chroma_upsampling_bilinear;
   options.color_conversion_options.only_use_preferred_chroma_algorithm = false;
+
+  options.prefer_minimised = false;
 }
 
 static void copy_options(heif_encoding_options& options, const heif_encoding_options& input_options)
 {
   switch (input_options.version) {
+    case 7:
+      options.prefer_minimised = input_options.prefer_minimised;
+      // fallthrough
     case 6:
       options.color_conversion_options = input_options.color_conversion_options;
       // fallthrough

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -2090,6 +2090,11 @@ struct heif_encoding_options
   // version 6 options
 
   struct heif_color_conversion_options color_conversion_options;
+
+  // version 7 options
+
+  // Set this to true to used minimised versions of boxes where possible
+  uint8_t prefer_minimised;
 };
 
 LIBHEIF_API

--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -2093,8 +2093,8 @@ struct heif_encoding_options
 
   // version 7 options
 
-  // Set this to true to used minimised versions of boxes where possible
-  uint8_t prefer_minimised;
+  // Set this to true to use compressed form of uncC where possible
+  uint8_t prefer_uncC_short_form;
 };
 
 LIBHEIF_API

--- a/libheif/uncompressed_box.cc
+++ b/libheif/uncompressed_box.cc
@@ -198,56 +198,75 @@ Error Box_uncC::parse(BitstreamRange& range)
 {
   parse_full_box_header(range);
   m_profile = range.read32();
-  if (get_version() != 0) {
-    return Error{heif_error_Invalid_input, heif_suberror_Unsupported_data_version, "Unsupported version (only 0 is currently supported)"};
-  }
-
-  unsigned int component_count = range.read32();
-
-  for (unsigned int i = 0; i < component_count && !range.error() && !range.eof(); i++) {
-    Component component;
-    component.component_index = range.read16();
-    component.component_bit_depth = uint16_t(range.read8() + 1);
-    component.component_format = range.read8();
-    component.component_align_size = range.read8();
-    m_components.push_back(component);
-
-    if (!is_valid_component_format(component.component_format)) {
-      return Error{heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "Invalid component format"};
+  if (get_version() == 1) {
+    if (m_profile == fourcc_to_uint32("rgb3")) {
+      Box_uncC::Component component0 = {0, 8, component_format_unsigned, 0};
+      add_component(component0);
+      Box_uncC::Component component1 = {1, 8, component_format_unsigned, 0};
+      add_component(component1);
+      Box_uncC::Component component2 = {2, 8, component_format_unsigned, 0};
+      add_component(component2);
+    } else if ((m_profile == fourcc_to_uint32("rgba")) || (m_profile == fourcc_to_uint32("abgr"))) {
+      Box_uncC::Component component0 = {0, 8, component_format_unsigned, 0};
+      add_component(component0);
+      Box_uncC::Component component1 = {1, 8, component_format_unsigned, 0};
+      add_component(component1);
+      Box_uncC::Component component2 = {2, 8, component_format_unsigned, 0};
+      add_component(component2);
+      Box_uncC::Component component3 = {3, 8, component_format_unsigned, 0};
+      add_component(component3);
+    } else {
+        return Error{heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "Invalid component format"};
     }
+  } else if (get_version() == 0) {
+
+    unsigned int component_count = range.read32();
+
+    for (unsigned int i = 0; i < component_count && !range.error() && !range.eof(); i++) {
+      Component component;
+      component.component_index = range.read16();
+      component.component_bit_depth = uint16_t(range.read8() + 1);
+      component.component_format = range.read8();
+      component.component_align_size = range.read8();
+      m_components.push_back(component);
+
+      if (!is_valid_component_format(component.component_format)) {
+        return Error{heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "Invalid component format"};
+      }
+    }
+
+    m_sampling_type = range.read8();
+    if (!is_valid_sampling_mode(m_sampling_type)) {
+      return Error{heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "Invalid sampling mode"};
+    }
+
+    m_interleave_type = range.read8();
+    if (!is_valid_interleave_mode(m_interleave_type)) {
+      return Error{heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "Invalid interleave mode"};
+    }
+
+    m_block_size = range.read8();
+
+    uint8_t flags = range.read8();
+    m_components_little_endian = !!(flags & 0x80);
+    m_block_pad_lsb = !!(flags & 0x40);
+    m_block_little_endian = !!(flags & 0x20);
+    m_block_reversed = !!(flags & 0x10);
+    m_pad_unknown = !!(flags & 0x08);
+
+    m_pixel_size = range.read32();
+
+    m_row_align_size = range.read32();
+
+    m_tile_align_size = range.read32();
+
+    m_num_tile_cols = range.read32() + 1;
+
+    m_num_tile_rows = range.read32() + 1;
   }
-
-  m_sampling_type = range.read8();
-  if (!is_valid_sampling_mode(m_sampling_type)) {
-    return Error{heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "Invalid sampling mode"};
-  }
-
-  m_interleave_type = range.read8();
-  if (!is_valid_interleave_mode(m_interleave_type)) {
-    return Error{heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "Invalid interleave mode"};
-  }
-
-  m_block_size = range.read8();
-
-  uint8_t flags = range.read8();
-  m_components_little_endian = !!(flags & 0x80);
-  m_block_pad_lsb = !!(flags & 0x40);
-  m_block_little_endian = !!(flags & 0x20);
-  m_block_reversed = !!(flags & 0x10);
-  m_pad_unknown = !!(flags & 0x08);
-
-  m_pixel_size = range.read32();
-
-  m_row_align_size = range.read32();
-
-  m_tile_align_size = range.read32();
-
-  m_num_tile_cols = range.read32() + 1;
-
-  m_num_tile_rows = range.read32() + 1;
-
   return range.get_error();
 }
+
 
 
 std::string Box_uncC::dump(Indent& indent) const
@@ -258,75 +277,76 @@ std::string Box_uncC::dump(Indent& indent) const
   sstr << indent << "profile: " << m_profile;
   if (m_profile != 0) {
     sstr << " (" << to_fourcc(m_profile) << ")";
+    sstr << "\n";
   }
-  sstr << "\n";
+  if (get_version() == 0) {
+    for (const auto& component : m_components) {
+      sstr << indent << "component_index: " << component.component_index << "\n";
+      sstr << indent << "component_bit_depth: " << (int) component.component_bit_depth << "\n";
+      sstr << indent << "component_format: " << get_name(heif_uncompressed_component_format(component.component_format), sNames_uncompressed_component_format) << "\n";
+      sstr << indent << "component_align_size: " << (int) component.component_align_size << "\n";
+    }
 
-  for (const auto& component : m_components) {
-    sstr << indent << "component_index: " << component.component_index << "\n";
-    sstr << indent << "component_bit_depth: " << (int) component.component_bit_depth << "\n";
-    sstr << indent << "component_format: " << get_name(heif_uncompressed_component_format(component.component_format), sNames_uncompressed_component_format) << "\n";
-    sstr << indent << "component_align_size: " << (int) component.component_align_size << "\n";
+    sstr << indent << "sampling_type: " << get_name(heif_uncompressed_sampling_mode(m_sampling_type), sNames_uncompressed_sampling_mode) << "\n";
+
+    sstr << indent << "interleave_type: " << get_name(heif_uncompressed_interleave_mode(m_interleave_type), sNames_uncompressed_interleave_mode) << "\n";
+
+    sstr << indent << "block_size: " << (int) m_block_size << "\n";
+
+    sstr << indent << "components_little_endian: " << m_components_little_endian << "\n";
+    sstr << indent << "block_pad_lsb: " << m_block_pad_lsb << "\n";
+    sstr << indent << "block_little_endian: " << m_block_little_endian << "\n";
+    sstr << indent << "block_reversed: " << m_block_reversed << "\n";
+    sstr << indent << "pad_unknown: " << m_pad_unknown << "\n";
+
+    sstr << indent << "pixel_size: " << m_pixel_size << "\n";
+
+    sstr << indent << "row_align_size: " << m_row_align_size << "\n";
+
+    sstr << indent << "tile_align_size: " << m_tile_align_size << "\n";
+
+    sstr << indent << "num_tile_cols: " << m_num_tile_cols << "\n";
+
+    sstr << indent << "num_tile_rows: " << m_num_tile_rows << "\n";
   }
-
-  sstr << indent << "sampling_type: " << get_name(heif_uncompressed_sampling_mode(m_sampling_type), sNames_uncompressed_sampling_mode) << "\n";
-
-  sstr << indent << "interleave_type: " << get_name(heif_uncompressed_interleave_mode(m_interleave_type), sNames_uncompressed_interleave_mode) << "\n";
-
-  sstr << indent << "block_size: " << (int) m_block_size << "\n";
-
-  sstr << indent << "components_little_endian: " << m_components_little_endian << "\n";
-  sstr << indent << "block_pad_lsb: " << m_block_pad_lsb << "\n";
-  sstr << indent << "block_little_endian: " << m_block_little_endian << "\n";
-  sstr << indent << "block_reversed: " << m_block_reversed << "\n";
-  sstr << indent << "pad_unknown: " << m_pad_unknown << "\n";
-
-  sstr << indent << "pixel_size: " << m_pixel_size << "\n";
-
-  sstr << indent << "row_align_size: " << m_row_align_size << "\n";
-
-  sstr << indent << "tile_align_size: " << m_tile_align_size << "\n";
-
-  sstr << indent << "num_tile_cols: " << m_num_tile_cols << "\n";
-
-  sstr << indent << "num_tile_rows: " << m_num_tile_rows << "\n";
-
   return sstr.str();
 }
-
 
 Error Box_uncC::write(StreamWriter& writer) const
 {
   size_t box_start = reserve_box_header_space(writer);
-
   writer.write32(m_profile);
-  writer.write32((uint32_t) m_components.size());
-  for (const auto& component : m_components) {
-    if (component.component_bit_depth < 1 || component.component_bit_depth > 256) {
-      return {heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "component bit-depth out of range [1..256]"};
-    }
-
-    writer.write16(component.component_index);
-    writer.write8(uint8_t(component.component_bit_depth - 1));
-    writer.write8(component.component_format);
-    writer.write8(component.component_align_size);
+  if (get_version() == 1) {
   }
-  writer.write8(m_sampling_type);
-  writer.write8(m_interleave_type);
-  writer.write8(m_block_size);
-  uint8_t flags = 0;
-  flags |= (m_components_little_endian ? 0x80 : 0);
-  flags |= (m_block_pad_lsb ? 0x40 : 0);
-  flags |= (m_block_little_endian ? 0x20 : 0);
-  flags |= (m_block_reversed ? 0x10 : 0);
-  flags |= (m_pad_unknown ? 0x08 : 0);
-  writer.write8(flags);
-  writer.write32(m_pixel_size);
-  writer.write32(m_row_align_size);
-  writer.write32(m_tile_align_size);
-  writer.write32(m_num_tile_cols - 1);
-  writer.write32(m_num_tile_rows - 1);
+  else if (get_version() == 0) {
+    writer.write32((uint32_t)m_components.size());
+    for (const auto &component : m_components) {
+      if (component.component_bit_depth < 1 || component.component_bit_depth > 256) {
+        return {heif_error_Invalid_input, heif_suberror_Invalid_parameter_value, "component bit-depth out of range [1..256]"};
+      }
+
+      writer.write16(component.component_index);
+      writer.write8(uint8_t(component.component_bit_depth - 1));
+      writer.write8(component.component_format);
+      writer.write8(component.component_align_size);
+    }
+    writer.write8(m_sampling_type);
+    writer.write8(m_interleave_type);
+    writer.write8(m_block_size);
+    uint8_t flags = 0;
+    flags |= (m_components_little_endian ? 0x80 : 0);
+    flags |= (m_block_pad_lsb ? 0x40 : 0);
+    flags |= (m_block_little_endian ? 0x20 : 0);
+    flags |= (m_block_reversed ? 0x10 : 0);
+    flags |= (m_pad_unknown ? 0x08 : 0);
+    writer.write8(flags);
+    writer.write32(m_pixel_size);
+    writer.write32(m_row_align_size);
+    writer.write32(m_tile_align_size);
+    writer.write32(m_num_tile_cols - 1);
+    writer.write32(m_num_tile_rows - 1);
+  }
   prepend_header(writer, box_start);
 
   return Error::Ok;
 }
-

--- a/libheif/uncompressed_box.h
+++ b/libheif/uncompressed_box.h
@@ -79,7 +79,7 @@ public:
   Box_uncC() :
     m_profile(0),
     m_sampling_type(sampling_mode_no_subsampling),
-    m_interleave_type(interleave_mode_component),
+    m_interleave_type(interleave_mode_pixel),
     m_block_size(0),
     m_components_little_endian(false),
     m_block_pad_lsb(false),
@@ -94,6 +94,8 @@ public:
   {
     set_short_type(fourcc("uncC"));
   }
+
+  void derive_box_version() override {};
 
   std::string dump(Indent&) const override;
 

--- a/libheif/uncompressed_image.cc
+++ b/libheif/uncompressed_image.cc
@@ -34,8 +34,23 @@
 #include "uncompressed_box.h"
 #include "uncompressed_image.h"
 
+static bool isKnownUncompressedFrameConfigurationBoxProfile(const std::shared_ptr<Box_uncC> &uncC)
+{
+  return ((uncC != nullptr) && (uncC->get_version() == 1) && ((uncC->get_profile() == fourcc("rgb3")) || (uncC->get_profile() == fourcc("rgba")) || (uncC->get_profile() == fourcc("abgr"))));
+}
+
 static Error uncompressed_image_type_is_supported(std::shared_ptr<Box_uncC>& uncC, std::shared_ptr<Box_cmpd>& cmpd)
 {
+    if (isKnownUncompressedFrameConfigurationBoxProfile(uncC))
+    {
+      return Error::Ok;
+    }
+    if (!cmpd) {
+      return Error(heif_error_Unsupported_feature,
+                   heif_suberror_Unsupported_data_version,
+                   "Missing required cmpd box (no match in uncC box) for uncompressed codec");
+    }
+
   for (Box_uncC::Component component : uncC->get_components()) {
     uint16_t component_index = component.component_index;
     uint16_t component_type = cmpd->get_components()[component_index].component_type;
@@ -228,6 +243,12 @@ static Error get_heif_chroma_uncompressed(std::shared_ptr<Box_uncC>& uncC, std::
   *out_chroma = heif_chroma_undefined;
   *out_colourspace = heif_colorspace_undefined;
 
+  if (isKnownUncompressedFrameConfigurationBoxProfile(uncC)) {
+    *out_chroma = heif_chroma_444;
+    *out_colourspace = heif_colorspace_RGB;
+    return Error::Ok;
+  }
+
   // each 1-bit represents an existing component in the image
   uint16_t componentSet = 0;
 
@@ -339,9 +360,56 @@ int UncompressedImageCodec::get_luma_bits_per_pixel_from_configuration_unci(cons
   }
 }
 
-static bool map_uncompressed_component_to_channel(const std::shared_ptr<Box_cmpd> &cmpd, const Box_uncC::Component component, heif_channel *channel) {
+static bool map_uncompressed_component_to_channel(const std::shared_ptr<Box_cmpd> &cmpd, const std::shared_ptr<Box_uncC> &uncC, Box_uncC::Component component, heif_channel *channel)
+{
   uint16_t component_index = component.component_index;
+  if (isKnownUncompressedFrameConfigurationBoxProfile(uncC)) {
+    if (uncC->get_profile() == fourcc("rgb3")) {
+      switch (component_index) {
+      case 0:
+        *channel = heif_channel_R;
+        return true;
+      case 1:
+        *channel = heif_channel_G;
+        return true;
+      case 2:
+        *channel = heif_channel_B;
+        return true;
+      }
+    } else if (uncC->get_profile() == fourcc("rgba")) {
+      switch (component_index) {
+      case 0:
+        *channel = heif_channel_Alpha;
+        return true;
+      case 1:
+        *channel = heif_channel_R;
+        return true;
+      case 2:
+        *channel = heif_channel_G;
+        return true;
+        case 3:
+        *channel = heif_channel_B;
+        return true;
+      }
+    } else if (uncC->get_profile() == fourcc("abgr")) {
+      switch (component_index) {
+      case 0:
+        *channel = heif_channel_Alpha;
+        return true;
+      case 1:
+        *channel = heif_channel_B;
+        return true;
+      case 2:
+        *channel = heif_channel_G;
+        return true;
+        case 3:
+        *channel = heif_channel_R;
+        return true;
+      }
+    }
+  }
   uint16_t component_type = cmpd->get_components()[component_index].component_type;
+
   switch (component_type) {
   case component_type_monochrome:
     *channel = heif_channel_Y;
@@ -375,8 +443,8 @@ static bool map_uncompressed_component_to_channel(const std::shared_ptr<Box_cmpd
   }
 }
 
-class UncompressedBitReader : public BitReader
-{
+  class UncompressedBitReader : public BitReader
+  {
   public:
     UncompressedBitReader(const std::vector<uint8_t>& data) : BitReader(data.data(), (int)data.size())
     {}
@@ -519,7 +587,7 @@ protected:
   private:
     ChannelListEntry buildChannelListEntry(Box_uncC::Component component, std::shared_ptr<HeifPixelImage> &img) {
       ChannelListEntry entry;
-      entry.use_channel = map_uncompressed_component_to_channel(m_cmpd, component, &(entry.channel));
+      entry.use_channel = map_uncompressed_component_to_channel(m_cmpd, m_uncC, component, &(entry.channel));
       entry.dst_plane = img->get_plane(entry.channel, &(entry.dst_plane_stride));
       entry.tile_width = m_tile_width;
       entry.tile_height = m_tile_height;
@@ -840,14 +908,21 @@ Error UncompressedImageCodec::decode_uncompressed_image(const std::shared_ptr<co
 
 
   // if we miss a required box, show error
-
-  if (!found_ispe || !cmpd || !uncC) {
-    printf("failed to get required boxes\n");
+  if (!found_ispe) {
     return Error(heif_error_Unsupported_feature,
                  heif_suberror_Unsupported_data_version,
-                 "Missing required box for uncompressed codec");
+                 "Missing required ispe box for uncompressed codec");
   }
-
+  if (!uncC) {
+    return Error(heif_error_Unsupported_feature,
+                 heif_suberror_Unsupported_data_version,
+                 "Missing required uncC box for uncompressed codec");
+  }
+  if (!cmpd && (uncC->get_version() !=1)) {
+    return Error(heif_error_Unsupported_feature,
+                 heif_suberror_Unsupported_data_version,
+                 "Missing required cmpd or uncC version 1 box for uncompressed codec");
+}
 
   // check if we support the type of image
 
@@ -871,7 +946,7 @@ Error UncompressedImageCodec::decode_uncompressed_image(const std::shared_ptr<co
 
   for (Box_uncC::Component component : uncC->get_components()) {
     heif_channel channel;
-    if (map_uncompressed_component_to_channel(cmpd, component, &channel)) {
+    if (map_uncompressed_component_to_channel(cmpd, uncC, component, &channel)) {
       if ((channel == heif_channel_Cb) || (channel == heif_channel_Cr)) {
         img->add_plane(channel, (width / chroma_h_subsampling(chroma)), (height / chroma_v_subsampling(chroma)), component.component_bit_depth);
       } else {
@@ -1089,22 +1164,48 @@ Error fill_cmpd_and_uncC(std::shared_ptr<Box_cmpd>& cmpd, std::shared_ptr<Box_un
 }
 
 
+static void maybe_make_minimised_uncC(std::shared_ptr<Box_uncC>& uncC, const std::shared_ptr<HeifPixelImage>& image)
+{
+  uncC->set_version(0);
+  if (image->get_colorspace() != heif_colorspace_RGB) {
+    return;
+  }
+  if (!((image->get_chroma_format() == heif_chroma_interleaved_RGB) || (image->get_chroma_format() == heif_chroma_interleaved_RGBA))) {
+    return;
+  }
+  if (image->get_bits_per_pixel(heif_channel_interleaved) != 8) {
+    return;
+  }
+  if (image->get_chroma_format() == heif_chroma_interleaved_RGBA) {
+    uncC->set_profile(fourcc_to_uint32("rgba"));
+  } else {
+    uncC->set_profile(fourcc_to_uint32("rgb3"));
+  }
+  uncC->set_version(1);
+}
+
 Error UncompressedImageCodec::encode_uncompressed_image(const std::shared_ptr<HeifFile>& heif_file,
                                                         const std::shared_ptr<HeifPixelImage>& src_image,
                                                         void* encoder_struct,
                                                         const struct heif_encoding_options& options,
                                                         std::shared_ptr<HeifContext::Image>& out_image)
 {
-  std::shared_ptr<Box_cmpd> cmpd = std::make_shared<Box_cmpd>();
   std::shared_ptr<Box_uncC> uncC = std::make_shared<Box_uncC>();
-  Error error = fill_cmpd_and_uncC(cmpd, uncC, src_image);
-  if (error)
-  {
-    return error;
+  if (options.prefer_minimised) {
+    maybe_make_minimised_uncC(uncC, src_image);
   }
-  heif_file->add_property(out_image->get_id(), cmpd, true);
-  heif_file->add_property(out_image->get_id(), uncC, true);
+  if (uncC->get_version() == 1) {
+    heif_file->add_property(out_image->get_id(), uncC, true);
+  } else {
+    std::shared_ptr<Box_cmpd> cmpd = std::make_shared<Box_cmpd>();
 
+    Error error = fill_cmpd_and_uncC(cmpd, uncC, src_image);
+    if (error) {
+      return error;
+    }
+    heif_file->add_property(out_image->get_id(), cmpd, true);
+    heif_file->add_property(out_image->get_id(), uncC, true);
+  }
   std::vector<uint8_t> data;
   if (src_image->get_colorspace() == heif_colorspace_YCbCr)
   {

--- a/libheif/uncompressed_image.cc
+++ b/libheif/uncompressed_image.cc
@@ -1191,7 +1191,7 @@ Error UncompressedImageCodec::encode_uncompressed_image(const std::shared_ptr<He
                                                         std::shared_ptr<HeifContext::Image>& out_image)
 {
   std::shared_ptr<Box_uncC> uncC = std::make_shared<Box_uncC>();
-  if (options.prefer_minimised) {
+  if (options.prefer_uncC_short_form) {
     maybe_make_minimised_uncC(uncC, src_image);
   }
   if (uncC->get_version() == 1) {

--- a/tests/uncompressed_encode.cc
+++ b/tests/uncompressed_encode.cc
@@ -565,7 +565,7 @@ struct heif_image *createImage_RGBA_planar()
   return image;
 }
 
-static void do_encode(heif_image* input_image, const char* filename, bool check_decode, uint8_t preferMinimised = 0)
+static void do_encode(heif_image* input_image, const char* filename, bool check_decode, uint8_t prefer_uncC_short_form = 0)
 {
   REQUIRE(input_image != nullptr);
 
@@ -580,7 +580,7 @@ static void do_encode(heif_image* input_image, const char* filename, bool check_
   options->macOS_compatibility_workaround = false;
   options->macOS_compatibility_workaround_no_nclx_profile = true;
   options->image_orientation = heif_orientation_normal;
-  options->prefer_minimised = preferMinimised;
+  options->prefer_uncC_short_form = prefer_uncC_short_form;
   heif_image_handle *output_image_handle;
 
   err = heif_context_encode_image(ctx, input_image, encoder, options, &output_image_handle);

--- a/tests/uncompressed_encode.cc
+++ b/tests/uncompressed_encode.cc
@@ -565,7 +565,7 @@ struct heif_image *createImage_RGBA_planar()
   return image;
 }
 
-static void do_encode(heif_image* input_image, const char* filename, bool check_decode)
+static void do_encode(heif_image* input_image, const char* filename, bool check_decode, uint8_t preferMinimised = 0)
 {
   REQUIRE(input_image != nullptr);
 
@@ -580,6 +580,7 @@ static void do_encode(heif_image* input_image, const char* filename, bool check_
   options->macOS_compatibility_workaround = false;
   options->macOS_compatibility_workaround_no_nclx_profile = true;
   options->image_orientation = heif_orientation_normal;
+  options->prefer_minimised = preferMinimised;
   heif_image_handle *output_image_handle;
 
   err = heif_context_encode_image(ctx, input_image, encoder, options, &output_image_handle);
@@ -644,6 +645,11 @@ TEST_CASE("Encode Mono")
   do_encode(input_image, "encode_mono.heif", true);
 }
 
+TEST_CASE("Encode RGB Version1")
+{
+  heif_image *input_image = createImage_RGB_interleaved();
+  do_encode(input_image, "encode_rgb_version1.heif", true, true);
+}
 
 TEST_CASE("Encode Mono with alpha")
 {
@@ -706,6 +712,12 @@ TEST_CASE("Encode RGBA")
 {
   heif_image *input_image = createImage_RGBA_interleaved();
   do_encode(input_image, "encode_rgba.heif", true);
+}
+
+TEST_CASE("Encode RGBA Version 1")
+{
+  heif_image *input_image = createImage_RGBA_interleaved();
+  do_encode(input_image, "encode_rgba_version1.heif", true, true);
 }
 
 


### PR DESCRIPTION
This solves the same problem as https://github.com/strukturag/libheif/pull/1132, but aligned to the "the uncompressed codec looks for both variants and then internally generates the implied boxes. They are never visible outside the uncompressed codec."

It doesn't actually generate the boxes, it just works with and without the `cmpd` box.