### PR TITLE
uncompressed: fix up reading of uncompressed images that use the uncC short form

### DIFF
--- a/libheif/codecs/uncompressed_image.cc
+++ b/libheif/codecs/uncompressed_image.cc
@@ -324,8 +324,15 @@ int UncompressedImageCodec::get_luma_bits_per_pixel_from_configuration_unci(cons
   std::shared_ptr<Box_uncC> uncC_box = std::dynamic_pointer_cast<Box_uncC>(box1);
   auto box2 = ipco->get_property_for_item_ID(imageID, ipma, fourcc("cmpd"));
   std::shared_ptr<Box_cmpd> cmpd_box = std::dynamic_pointer_cast<Box_cmpd>(box2);
-  if (!uncC_box || !cmpd_box) {
+  if (!uncC_box) {
     return -1;
+  }
+  if (!cmpd_box) {
+    if (isKnownUncompressedFrameConfigurationBoxProfile(uncC_box)) {
+      return 8;
+    } else {
+      return -1;
+    }
   }
 
   int luma_bits = 0;


### PR DESCRIPTION
I am not sure how I failed to test this during development, but hopefully it can work now...