### PR TITLE
Add convenience bindings for javascript to check filetype and to get primary image handle 

### DIFF
--- a/libheif/api/libheif/heif_emscripten.h
+++ b/libheif/api/libheif/heif_emscripten.h
@@ -24,6 +24,11 @@ static struct heif_error _heif_context_read_from_memory(
   return heif_context_read_from_memory(context, data.data(), data.size(), nullptr);
 }
 
+static heif_filetype_result heif_js_check_filetype(const std::string& data) 
+{
+  return heif_check_filetype((const uint8_t*) data.data(), data.size());
+}
+
 static emscripten::val heif_js_context_get_image_handle(
     struct heif_context* context, heif_item_id id)
 {
@@ -272,6 +277,8 @@ EMSCRIPTEN_BINDINGS(libheif) {
     EXPORT_HEIF_FUNCTION(heif_context_free);
     emscripten::function("heif_context_read_from_memory",
     &_heif_context_read_from_memory, emscripten::allow_raw_pointers());
+    emscripten::function("heif_js_check_filetype",
+    &heif_js_check_filetype, emscripten::allow_raw_pointers());
     EXPORT_HEIF_FUNCTION(heif_context_get_number_of_top_level_images);
     emscripten::function("heif_js_context_get_list_of_top_level_image_IDs",
     &heif_js_context_get_list_of_top_level_image_IDs, emscripten::allow_raw_pointers());
@@ -419,6 +426,11 @@ EMSCRIPTEN_BINDINGS(libheif) {
     .value("heif_channel_B", heif_channel_B)
     .value("heif_channel_Alpha", heif_channel_Alpha)
     .value("heif_channel_interleaved", heif_channel_interleaved);
+    emscripten::enum_<heif_filetype_result>("heif_filetype_result")
+    .value("heif_filetype_no", heif_filetype_no)
+    .value("heif_filetype_yes_supported", heif_filetype_yes_supported)
+    .value("heif_filetype_yes_unsupported", heif_filetype_yes_unsupported)
+    .value("heif_filetype_maybe", heif_filetype_maybe);
 
     emscripten::class_<heif_context>("heif_context");
     emscripten::class_<heif_image_handle>("heif_image_handle");

--- a/libheif/api/libheif/heif_emscripten.h
+++ b/libheif/api/libheif/heif_emscripten.h
@@ -46,6 +46,25 @@ static emscripten::val heif_js_context_get_image_handle(
   return emscripten::val(handle);
 }
 
+static emscripten::val heif_js_context_get_primary_image_handle(
+    struct heif_context* context)
+{
+  emscripten::val result = emscripten::val::object();
+  if (!context) {
+    return result;
+  }
+  
+  heif_image_handle* handle;
+  struct heif_error err = heif_context_get_primary_image_handle(context, &handle);
+
+  if (err.code != heif_error_Ok) {
+    return emscripten::val(err);
+  }
+
+  return emscripten::val(handle);
+}
+
+
 static emscripten::val heif_js_context_get_list_of_top_level_image_IDs(
     struct heif_context* context)
 {
@@ -284,6 +303,8 @@ EMSCRIPTEN_BINDINGS(libheif) {
     &heif_js_context_get_list_of_top_level_image_IDs, emscripten::allow_raw_pointers());
     emscripten::function("heif_js_context_get_image_handle",
     &heif_js_context_get_image_handle, emscripten::allow_raw_pointers());
+    emscripten::function("heif_js_context_get_primary_image_handle",
+    &heif_js_context_get_primary_image_handle, emscripten::allow_raw_pointers());
     //emscripten::function("heif_js_decode_image",
     //&heif_js_decode_image, emscripten::allow_raw_pointers());
     emscripten::function("heif_js_decode_image2",


### PR DESCRIPTION
Currently if you want to check the filetype of some buffer in javascript you need to do something like:

```js
const dummy_buffer = new Uint8Array([]) // pretend this has the image data

const ptr = Module._malloc(12);
if (!ptr) {
  //...
}
Module.HEAPU8.set(dummy_buffer.subarray(0, 12), ptr);
const res = Module._heif_check_filetype(ptr, 12);
Module._free(ptr);
if (res === 1) {
 // valid
}
// handle other cases
```
This is not only alot of manual memory management on the javascript side but also requires defining a copy of the  `heif_filetype_result` enum on the javascript side to avoid using hardcoded numbers since the enum is not exported by the emscripten bindings.

With new bindings it would be simplified to:
```js
const res = Module.heif_js_check_filetype(dummy_buffer)
if (res.value === Module.heif_filetype_result.heif_filetype_yes_supported.value) {
 // valid
}
// handle other cases
```

Additionally, (as far I know) the only way to get a proper javascript handle to the primary image is to first use `heif_js_context_get_list_of_top_level_image_IDs` to get all the image ids, then use `heif_context_get_image_handle` on each id, then finally use `heif_image_handle_is_primary_image` on each handle until the primary image handle is found. A special js binding like `heif_js_context_get_primary_image_handle` would be very convenient to avoid having to do this, especially since the function `heif_context_get_primary_image_handle` already exists.