### PR TITLE
context: add sanity-check to tile dimensions/resolution

### DIFF
--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -1914,6 +1914,10 @@ Error HeifContext::decode_full_grid_image(heif_item_id ID,
       const std::shared_ptr<Image> tileImg = iter->second;
       int src_width = tileImg->get_width();
       int src_height = tileImg->get_height();
+      err = check_resolution(src_width, src_height);
+      if (err) {
+        return err;
+      }
 
 #if ENABLE_PARALLEL_TILE_DECODING
       if (m_max_decoding_threads > 0)


### PR DESCRIPTION
The libvips' fuzz tests found a possible integer overflow here:

https://github.com/strukturag/libheif/blob/7c9729ea8d0f319ab423f8e4e6de121fd78596d0/libheif/context.cc#L1938

```
/src/libheif/libheif/context.cc:1938:8: runtime error: signed integer overflow: 1344282656 + 1344282656 cannot be represented in type 'int'
0 0x5b6b1f26031b in HeifContext::decode_full_grid_image(unsigned int, std::__1::shared_ptr<HeifPixelImage>&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> const&, heif_decoding_options const&) const libheif/libheif/context.cc:1938
1 0x5b6b1f258489 in HeifContext::decode_image_planar(unsigned int, std::__1::shared_ptr<HeifPixelImage>&, heif_colorspace, heif_decoding_options const&, bool) const libheif/libheif/context.cc:1512
2 0x5b6b1f256d36 in HeifContext::decode_image_user(unsigned int, std::__1::shared_ptr<HeifPixelImage>&, heif_colorspace, heif_chroma, heif_decoding_options const&) const libheif/libheif/context.cc:1324
3 0x5b6b1f15d2c2 in heif_decode_image [libheif/libheif/api/libheif/heif.cc:1083]
```

Adding a sanity check on the dimensions of each tile as it is processed seems to do the job of preventing this logic being reached, although there may be additional/alternative solutions too.