### PR TITLE
uncompressed: fix box dump when profile is 0

### DIFF
--- a/libheif/codecs/uncompressed_box.cc
+++ b/libheif/codecs/uncompressed_box.cc
@@ -288,8 +288,8 @@ std::string Box_uncC::dump(Indent& indent) const
   sstr << indent << "profile: " << m_profile;
   if (m_profile != 0) {
     sstr << " (" << to_fourcc(m_profile) << ")";
-    sstr << "\n";
   }
+  sstr << "\n";
   if (get_version() == 0) {
     for (const auto& component : m_components) {
       sstr << indent << "component_index: " << component.component_index << "\n";


### PR DESCRIPTION
This ensures the newline appears. Otherwise the first component gets pasted on the end of the line.