### PR TITLE
examples: display non-visual colorspace entry in heif-info

### DIFF
--- a/examples/heif_info.cc
+++ b/examples/heif_info.cc
@@ -273,6 +273,9 @@ int main(int argc, char** argv)
       case heif_colorspace_monochrome:
         printf("monochrome");
         break;
+      case heif_colorspace_nonvisual:
+        printf("non-visual");
+        break;
       default:
         printf("unknown");
         break;


### PR DESCRIPTION
Minor item I noted while working on the uncompressed codec support for these data types.