### PR TITLE
CI: Fail if third-party build fails.

### DIFF
--- a/scripts/install-ci-linux.sh
+++ b/scripts/install-ci-linux.sh
@@ -199,7 +199,7 @@ if [ "$WITH_DAV1D" = "1" ]; then
 
     export PATH="$PATH:$HOME/.local/bin"
     cd third-party
-    sh dav1d.cmd # dav1d does not support this option anymore: -Denable_avx512=false
+    sh -e dav1d.cmd # dav1d does not support this option anymore: -Denable_avx512=false
     cd ..
 fi
 
@@ -208,6 +208,6 @@ if [ "$WITH_RAV1E" = "1" ]; then
 
     export PATH="$PATH:$HOME/.cargo/bin"
     cd third-party
-    sh rav1e.cmd
+    sh -e rav1e.cmd
     cd ..
 fi

--- a/third-party/rav1e.cmd
+++ b/third-party/rav1e.cmd
@@ -13,7 +13,7 @@
 : # Also, the error that "The target windows-msvc is not supported yet" can safely be ignored provided that rav1e/target/release
 : # contains rav1e.h and rav1e.lib.
 
-git clone -b 0.5 --depth 1 https://github.com/xiph/rav1e.git
+git clone -b 0.6 --depth 1 https://github.com/xiph/rav1e.git
 
 cd rav1e
 cargo install cargo-c


### PR DESCRIPTION
rav1 was not built due to compiler error for some time now (see https://github.com/strukturag/libheif/actions/runs/9890048988/job/27319594102#step:3:2004 for an example CI run). As this didn't fail the CI job, the problem went unnoticed and we lost some compile coverage.

This PR changes this, so that if any of the third-party `.cmd` files contains a command that fails, the whole script will fail and with that, the CI job.