### PR TITLE
libheif: add API to get UUID for user extension boxes

### DIFF
--- a/libheif/api/libheif/heif_properties.cc
+++ b/libheif/api/libheif/heif_properties.cc
@@ -334,16 +334,11 @@ struct heif_error heif_item_add_raw_property(const struct heif_context* context,
   return heif_error_success;
 }
 
-
-struct heif_error heif_item_get_property_raw_size(const struct heif_context* context,
-                                                  heif_item_id itemId,
-                                                  heif_property_id propertyId,
-                                                  size_t* size_out)
+static struct heif_error find_property(const struct heif_context* context,
+                                heif_item_id itemId,
+                                heif_property_id propertyId,
+                                std::shared_ptr<Box_other> *box_other)
 {
-  if (!context || !size_out) {
-    return {heif_error_Usage_error, heif_suberror_Null_pointer_argument, "NULL argument passed in"};
-  }
-
   auto file = context->context->get_heif_file();
 
   std::vector<std::shared_ptr<Box>> properties;
@@ -357,7 +352,24 @@ struct heif_error heif_item_get_property_raw_size(const struct heif_context* con
   }
 
   auto box = properties[propertyId - 1];
-  auto box_other = std::dynamic_pointer_cast<Box_other>(box);
+  *box_other = std::dynamic_pointer_cast<Box_other>(box);
+  return heif_error_success;
+}
+
+
+struct heif_error heif_item_get_property_raw_size(const struct heif_context* context,
+                                                  heif_item_id itemId,
+                                                  heif_property_id propertyId,
+                                                  size_t* size_out)
+{
+  if (!context || !size_out) {
+    return {heif_error_Usage_error, heif_suberror_Null_pointer_argument, "NULL argument passed in"};
+  }
+  std::shared_ptr<Box_other> box_other;
+  struct heif_error err = find_property(context, itemId, propertyId, &box_other);
+  if (err.code) {
+    return err;
+  }
 
   // TODO: every Box (not just Box_other) should have a get_raw_data() method.
   if (box_other == nullptr) {
@@ -381,21 +393,11 @@ struct heif_error heif_item_get_property_raw_data(const struct heif_context* con
     return {heif_error_Usage_error, heif_suberror_Null_pointer_argument, "NULL argument passed in"};
   }
 
-  auto file = context->context->get_heif_file();
-
-  std::vector<std::shared_ptr<Box>> properties;
-  Error err = file->get_properties(itemId, properties);
-  if (err) {
-    return err.error_struct(context->context.get());
+  std::shared_ptr<Box_other> box_other;
+  struct heif_error err = find_property(context, itemId, propertyId, &box_other);
+  if (err.code) {
+    return err;
   }
-
-  if (propertyId - 1 < 0 || propertyId - 1 >= properties.size()) {
-    return {heif_error_Usage_error, heif_suberror_Invalid_property, "property index out of range"};
-  }
-
-
-  auto box = properties[propertyId - 1];
-  auto box_other = std::dynamic_pointer_cast<Box_other>(box);
 
   // TODO: every Box (not just Box_other) should have a get_raw_data() method.
   if (box_other == nullptr) {
@@ -406,6 +408,32 @@ struct heif_error heif_item_get_property_raw_data(const struct heif_context* con
 
 
   std::copy(data.begin(), data.end(), data_out);
+
+  return heif_error_success;
+}
+
+struct heif_error heif_item_get_property_extended_type(const struct heif_context* context,
+                                                       heif_item_id itemId,
+                                                       heif_property_id propertyId,
+                                                       uint8_t* extended_type)
+{
+  if (!context || !extended_type) {
+    return {heif_error_Usage_error, heif_suberror_Null_pointer_argument, "NULL argument passed in"};
+  }
+
+  std::shared_ptr<Box_other> box_other;
+  struct heif_error err = find_property(context, itemId, propertyId, &box_other);
+  if (err.code) {
+    return err;
+  }
+
+  if (box_other == nullptr) {
+    return {heif_error_Usage_error, heif_suberror_Invalid_property, "this property is not read as a raw box"};
+  }
+
+  auto uuid = box_other->get_uuid_type();
+
+  std::copy(uuid.begin(), uuid.end(), extended_type);
 
   return heif_error_success;
 }

--- a/libheif/api/libheif/heif_properties.cc
+++ b/libheif/api/libheif/heif_properties.cc
@@ -412,10 +412,10 @@ struct heif_error heif_item_get_property_raw_data(const struct heif_context* con
   return heif_error_success;
 }
 
-struct heif_error heif_item_get_property_extended_type(const struct heif_context* context,
-                                                       heif_item_id itemId,
-                                                       heif_property_id propertyId,
-                                                       uint8_t* extended_type)
+struct heif_error heif_item_get_property_uuid_type(const struct heif_context* context,
+                                                   heif_item_id itemId,
+                                                   heif_property_id propertyId,
+                                                   uint8_t* extended_type)
 {
   if (!context || !extended_type) {
     return {heif_error_Usage_error, heif_suberror_Null_pointer_argument, "NULL argument passed in"};

--- a/libheif/api/libheif/heif_properties.h
+++ b/libheif/api/libheif/heif_properties.h
@@ -181,10 +181,10 @@ struct heif_error heif_item_get_property_raw_data(const struct heif_context* con
  * @return heif_error_success or an error indicating the failure
  */
 LIBHEIF_API
-struct heif_error heif_item_get_property_extended_type(const struct heif_context* context,
-                                                       heif_item_id itemId,
-                                                       heif_property_id propertyId,
-                                                       uint8_t* extended_type);
+struct heif_error heif_item_get_property_uuid_type(const struct heif_context* context,
+                                                   heif_item_id itemId,
+                                                   heif_property_id propertyId,
+                                                   uint8_t* extended_type);
 #ifdef __cplusplus
 }
 #endif

--- a/libheif/api/libheif/heif_properties.h
+++ b/libheif/api/libheif/heif_properties.h
@@ -167,6 +167,24 @@ struct heif_error heif_item_get_property_raw_data(const struct heif_context* con
                                                   heif_property_id propertyId,
                                                   uint8_t* out_data);
 
+/**
+ * Get the extended type for an extended "uuid" box.
+ *
+ * This provides the UUID for the extended box.
+ *
+ * This method should only be called on properties of type `heif_item_property_type_uuid`.
+ *
+ * @param context the heif_context containing the HEIF file
+ * @param itemId the image item id to which this property belongs.
+ * @param propertyID the property index (1-based) to get the extended type for
+ * @param extended_type output of the call, must be a pointer to at least 16-bytes.
+ * @return heif_error_success or an error indicating the failure
+ */
+LIBHEIF_API
+struct heif_error heif_item_get_property_extended_type(const struct heif_context* context,
+                                                       heif_item_id itemId,
+                                                       heif_property_id propertyId,
+                                                       uint8_t* extended_type);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 # --- tests that only access the public API
 
 add_libheif_test(encode)
+add_libheif_test(extended_type)
 add_libheif_test(region)
 
 if (WITH_OPENJPH_ENCODER)

--- a/tests/extended_type.cc
+++ b/tests/extended_type.cc
@@ -64,7 +64,7 @@ TEST_CASE("make extended type") {
   REQUIRE(err.code == heif_error_Ok);
 
   uint8_t extended_type[16];
-  err = heif_item_get_property_extended_type(ctx, itemId, propertyId, &extended_type[0]);
+  err = heif_item_get_property_uuid_type(ctx, itemId, propertyId, &extended_type[0]);
   REQUIRE(err.code == heif_error_Ok);
   for (int i = 0; i < 16; i++) {
     REQUIRE(extended_type[i] == uuid[i]);

--- a/tests/extended_type.cc
+++ b/tests/extended_type.cc
@@ -1,0 +1,93 @@
+/*
+  libheif integration tests for extended type (uuid) boxes
+
+  MIT License
+
+  Copyright (c) 2024 Brad Hards <bradh@frogmouth.net>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include "catch.hpp"
+#include "libheif/api_structs.h"
+#include "libheif/heif.h"
+#include "test-config.h"
+#include "test_utils.h"
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+
+TEST_CASE("make extended type") {
+  heif_image *input_image = createImage_RGB_planar();
+  heif_init(nullptr);
+  heif_context *ctx = heif_context_alloc();
+  heif_encoder *encoder;
+  struct heif_error err;
+  err = heif_context_get_encoder_for_format(ctx, heif_compression_HEVC, &encoder);
+  REQUIRE(err.code == heif_error_Ok);
+
+  struct heif_encoding_options *options = heif_encoding_options_alloc();
+
+  heif_image_handle *output_image_handle;
+
+  err = heif_context_encode_image(ctx, input_image, encoder, nullptr, &output_image_handle);
+  REQUIRE(err.code == heif_error_Ok);
+
+  heif_item_id itemId;
+  err = heif_context_get_primary_image_ID(ctx, &itemId);
+  REQUIRE(err.code == heif_error_Ok);
+
+  const uint8_t uuid[] = {0x13, 0x7a, 0x17, 0x42, 0x75, 0xac, 0x47, 0x47, 0x82, 0xbc, 0x65, 0x95, 0x76, 0xe8, 0x67, 0x5b};
+  std::vector<uint8_t> body {0x00, 0x00, 0x00, 0x01, 0xfa, 0xde, 0x99, 0x04};
+  heif_property_id propertyId;
+  err = heif_item_add_raw_property(ctx, itemId, heif_item_property_type_uuid, &uuid[0], body.data(), body.size(), 0, &propertyId);
+  REQUIRE(err.code == heif_error_Ok);
+  REQUIRE(propertyId == 4);
+  err = heif_context_write_to_file(ctx, "with_uuid.heif");
+  REQUIRE(err.code == heif_error_Ok);
+
+  uint8_t extended_type[16];
+  err = heif_item_get_property_extended_type(ctx, itemId, propertyId, &extended_type[0]);
+  REQUIRE(err.code == heif_error_Ok);
+  for (int i = 0; i < 16; i++) {
+    REQUIRE(extended_type[i] == uuid[i]);
+  }
+
+  size_t size = 0;
+  err = heif_item_get_property_raw_size(ctx, itemId, propertyId, &size);
+  REQUIRE(err.code == heif_error_Ok);
+  REQUIRE(size == 8);
+
+  uint8_t data[8];
+  err = heif_item_get_property_raw_data(ctx, itemId, propertyId, &data[0]);
+  REQUIRE(err.code == heif_error_Ok);
+  for (int i = 0; i < 8; i++) {
+    REQUIRE(data[i] == body[i]);
+  }
+
+  heif_image_handle_release(output_image_handle);
+  heif_encoding_options_free(options);
+  heif_encoder_release(encoder);
+  heif_image_release(input_image);
+
+  heif_context_free(ctx);
+  heif_deinit();
+}
+


### PR DESCRIPTION
This is an alternative approach to solving #1244, adding a function to get the UUID (`extended_type` field).

Also includes documentation, a unit test, and some refactoring of shared code.