### PR TITLE
examples: initial TIFF encoder support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -129,8 +129,11 @@ endif ()
 
 find_package(TIFF)
 if (TIFF_FOUND)
+    target_link_libraries(heif-dec PRIVATE TIFF::TIFF)
     target_link_libraries(heif-enc PRIVATE TIFF::TIFF)
+    target_sources(heif-dec PRIVATE encoder_tiff.cc encoder_tiff.h)
     target_sources(heif-enc PRIVATE decoder_tiff.cc decoder_tiff.h)
+    target_compile_definitions(heif-dec PUBLIC HAVE_LIBTIFF=1)
     target_compile_definitions(heif-enc PUBLIC HAVE_LIBTIFF=1)
 endif ()
 

--- a/examples/encoder_tiff.cc
+++ b/examples/encoder_tiff.cc
@@ -1,0 +1,77 @@
+/*
+  libheif example application.
+
+  MIT License
+
+  Copyright (c) 2024 Brad Hards <bradh@frogmouth.net>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#include <cerrno>
+#include <tiff.h>
+#include <cstring>
+#include <cstdlib>
+#include <vector>
+
+#include "encoder_tiff.h"
+#include <tiffio.h>
+
+TiffEncoder::TiffEncoder() = default;
+
+bool TiffEncoder::Encode(const struct heif_image_handle *handle,
+                         const struct heif_image *image, const std::string &filename)
+{
+    TIFF *tif = TIFFOpen(filename.c_str(), "w");
+
+    // For now we write interleaved
+    int width = heif_image_get_width(image, heif_channel_interleaved);
+    int height = heif_image_get_height(image, heif_channel_interleaved);
+    bool hasAlpha = ((heif_image_get_chroma_format(image) == heif_chroma_interleaved_RGBA) ||
+                     (heif_image_get_chroma_format(image) == heif_chroma_interleaved_RRGGBBAA_BE));
+    int input_bpp = heif_image_get_bits_per_pixel_range(image, heif_channel_interleaved);
+
+    TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+    TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+    TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, input_bpp);
+    TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, hasAlpha ? 4 : 3);
+    if (hasAlpha)
+    {
+        // TODO: is alpha premultiplied?
+        uint16_t extra_samples[1] = {EXTRASAMPLE_UNASSALPHA};
+        TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, 1, &extra_samples);
+    }
+    TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, 1);
+    TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
+    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
+    TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
+    TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
+
+    int stride_rgb;
+    const uint8_t *row_rgb = heif_image_get_plane_readonly(image,
+                                                           heif_channel_interleaved, &stride_rgb);
+
+    for (int i = 0; i < height; i++)
+    {
+        // memcpy(scan_line, &buffer[i * width], width * sizeof(uint32));
+        TIFFWriteScanline(tif, (void *)(&(row_rgb[i * stride_rgb])), i, 0);
+    }
+    TIFFClose(tif);
+    return true;
+}

--- a/examples/encoder_tiff.h
+++ b/examples/encoder_tiff.h
@@ -1,0 +1,64 @@
+/*
+  libheif example application.
+
+  MIT License
+
+  Copyright (c) 2024 Brad Hards <bradh@frogmouth.net>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef EXAMPLE_ENCODER_TIFF_H
+#define EXAMPLE_ENCODER_TIFF_H
+
+#include <string>
+
+#include "encoder.h"
+
+class TiffEncoder : public Encoder
+{
+public:
+  TiffEncoder();
+
+
+  heif_colorspace colorspace(bool has_alpha) const override
+  {
+    return heif_colorspace_RGB;
+  }
+
+  heif_chroma chroma(bool has_alpha, int bit_depth) const override
+  {
+    if (bit_depth == 8) {
+      if (has_alpha)
+        return heif_chroma_interleaved_RGBA;
+      else
+        return heif_chroma_interleaved_RGB;
+    }
+    else {
+      if (has_alpha)
+        return heif_chroma_interleaved_RRGGBBAA_BE;
+      else
+        return heif_chroma_interleaved_RRGGBB_BE;
+    }
+  }
+
+  bool Encode(const struct heif_image_handle* handle,
+              const struct heif_image* image, const std::string& filename) override;
+};
+
+#endif  // EXAMPLE_ENCODER_TIFF_H

--- a/examples/heif_dec.cc
+++ b/examples/heif_dec.cc
@@ -58,6 +58,10 @@
 
 #endif
 
+#if HAVE_LIBTIFF
+#include "encoder_tiff.h"
+#endif
+
 #include "encoder_y4m.h"
 #include "common.h"
 
@@ -74,7 +78,7 @@ static void show_help(const char* argv0)
                "Usage: " << argv0 << " [options]  <input-image> [output-image]\n"
                "\n"
                "The program determines the output file format from the output filename suffix.\n"
-               "These suffixes are recognized: jpg, jpeg, png, y4m. If no output filename is specified, 'jpg' is used.\n"
+               "These suffixes are recognized: jpg, jpeg, png, tif, tiff, y4m. If no output filename is specified, 'jpg' is used.\n"
                "\n"
                "Options:\n"
                "  -h, --help                     show help\n"
@@ -360,6 +364,15 @@ int main(int argc, char** argv)
       fprintf(stderr, "PNG support has not been compiled in.\n");
       return 1;
 #endif  // HAVE_LIBPNG
+    }
+
+    if (suffix_lowercase == "tif" || suffix_lowercase == "tiff") {
+#if HAVE_LIBTIFF
+      encoder.reset(new TiffEncoder());
+#else
+      fprintf(stderr, "TIFF support has not been compiled in.\n");
+      return 1;
+#endif  // HAVE_LIBTIFF
     }
 
     if (suffix_lowercase == "y4m") {


### PR DESCRIPTION
Inspired by the TIFF decoder (and a cold wet morning), I've implemented a very basic TIFF encoder.

There are a lot more things we can do with TIFF over PNG/JPEG/Y4M. For example, it could do multiple images per file (instead of splitting them), different compression types and levels, different chroma or interleave formats etc. It could also do the various sample types (e.g. signed, float, etc), which is part of the reason for wanting it. None of that is done yet, partly because it will complicate the Encoder API and command line options. 

I wonder if we should have only limited TIFF support for `heif-dec`, or whether to extend the `Encoder` API. Related, we could have HEIF as an output format (e.g. so you can pull in HEIC and output AVIF, or JPEG-2000, or uncompressed, or some other combination). Possibly that should be a different tool.

Thoughts?