### PR TITLE
uncompressed: correctly set chroma and format

### DIFF
--- a/libheif/codecs/uncompressed_image.h
+++ b/libheif/codecs/uncompressed_image.h
@@ -37,6 +37,7 @@ class UncompressedImageCodec
 {
 public:
   static int get_luma_bits_per_pixel_from_configuration_unci(const HeifFile& heif_file, heif_item_id imageID);
+  static int get_chroma_bits_per_pixel_from_configuration_unci(const HeifFile& heif_file, heif_item_id imageID);
 
   static Error decode_uncompressed_image(const HeifContext* context,
                                          heif_item_id ID,
@@ -48,6 +49,12 @@ public:
                                          void* encoder_struct,
                                          const struct heif_encoding_options& options,
                                          std::shared_ptr<HeifContext::Image>& out_image);
+
+  static Error get_heif_chroma_uncompressed(std::shared_ptr<Box_uncC>& uncC,
+                                            std::shared_ptr<Box_cmpd>& cmpd,
+                                            heif_chroma* out_chroma,
+                                            heif_colorspace* out_colourspace);
+
 };
 
 #endif //LIBHEIF_UNCOMPRESSED_IMAGE_H

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -1296,6 +1296,21 @@ Error HeifContext::Image::get_preferred_decoding_colorspace(heif_colorspace* out
     }
     *out_chroma = jpeg2000Header.get_chroma_format();
   }
+  else if (auto uncC = m_heif_context->m_heif_file->get_property<Box_uncC>(id)) {
+    if (uncC->get_version() == 1) {
+      // This is the shortform case, no cmpd box, and always some kind of RGB
+      *out_colorspace = heif_colorspace_RGB;
+      if (uncC->get_profile() == fourcc("rgb3")) {
+        *out_chroma = heif_chroma_interleaved_RGB;
+      } else if ((uncC->get_profile() == fourcc("rgba")) || (uncC->get_profile() == fourcc("abgr"))) {
+        *out_chroma = heif_chroma_interleaved_RGBA;
+      }
+    }
+    if (auto cmpd = m_heif_context->m_heif_file->get_property<Box_cmpd>(id)) {
+      UncompressedImageCodec::get_heif_chroma_uncompressed(uncC, cmpd, out_chroma, out_colorspace);
+    }
+  }
+
 
   return err;
 }

--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -709,6 +709,15 @@ int HeifFile::get_chroma_bits_per_pixel_from_configuration(heif_item_id imageID)
     return header.get_precision(1);
   }
 
+#if WITH_UNCOMPRESSED_CODEC
+  // Uncompressed
+
+  if (image_type == "unci") {
+    int bpp = UncompressedImageCodec::get_chroma_bits_per_pixel_from_configuration_unci(*this, imageID);
+    return bpp;
+  }
+#endif
+
   return -1;
 }
 


### PR DESCRIPTION
This fixes incorrect bit depth and format display for the uncompressed codec with data other than YCbCr.

This also shows up in the API, and hits some no-longer-valid assumptions in GDAL for formats like monochrome.