### PR TITLE
decoder_openjpeg: Add OPJ_CALLCONV to unique_ptr deleter

### DIFF
--- a/libheif/plugins/decoder_openjpeg.cc
+++ b/libheif/plugins/decoder_openjpeg.cc
@@ -256,7 +256,7 @@ struct heif_error openjpeg_decode_image(void* decoder_raw, struct heif_image** o
 
   OPJ_BOOL success;
   opj_dparameters_t decompression_parameters;
-  std::unique_ptr<opj_codec_t, void (*)(opj_codec_t*)> l_codec(opj_create_decompress(OPJ_CODEC_J2K),
+  std::unique_ptr<opj_codec_t, void (OPJ_CALLCONV *)(opj_codec_t*)> l_codec(opj_create_decompress(OPJ_CODEC_J2K),
                                                                opj_destroy_codec);
 
   // Initialize Decoder
@@ -271,7 +271,7 @@ struct heif_error openjpeg_decode_image(void* decoder_raw, struct heif_image** o
   // Create Input Stream
 
   OPJ_BOOL is_read_stream = true;
-  std::unique_ptr<opj_stream_t, void (*)(opj_stream_t*)> stream(opj_stream_create_default_memory_stream(decoder, is_read_stream),
+  std::unique_ptr<opj_stream_t, void (OPJ_CALLCONV *)(opj_stream_t*)> stream(opj_stream_create_default_memory_stream(decoder, is_read_stream),
                                                                 opj_stream_destroy);
 
 
@@ -283,7 +283,7 @@ struct heif_error openjpeg_decode_image(void* decoder_raw, struct heif_image** o
     return err;
   }
 
-  std::unique_ptr<opj_image_t, void (*)(opj_image_t*)> image(image_ptr, opj_image_destroy);
+  std::unique_ptr<opj_image_t, void (OPJ_CALLCONV *)(opj_image_t*)> image(image_ptr, opj_image_destroy);
 
   if (image->numcomps != 3 && image->numcomps != 1) {
     //TODO - Handle other numbers of components


### PR DESCRIPTION
Fixes calling convention mismatch in unique_ptr declaration by adding OPJ_CALLCONV to the deleter function pointer type.

This fixes the build for 32bit Windows, where the default calling convention doesn't match OPJ_CALLCONV, which is used by all three functions.

This issue was introduced in 4851124559d2cbccc50
(and later adjusted in 242331c3e74a5ba7c)

Fixes #1262