### PR TITLE
uncompressed: fix decoding of images with rgba profile

### DIFF
--- a/libheif/codecs/uncompressed_image.cc
+++ b/libheif/codecs/uncompressed_image.cc
@@ -365,6 +365,10 @@ int UncompressedImageCodec::get_chroma_bits_per_pixel_from_configuration_unci(co
   std::shared_ptr<Box_uncC> uncC_box = std::dynamic_pointer_cast<Box_uncC>(box1);
   auto box2 = ipco->get_property_for_item_ID(imageID, ipma, fourcc("cmpd"));
   std::shared_ptr<Box_cmpd> cmpd_box = std::dynamic_pointer_cast<Box_cmpd>(box2);
+  if (uncC_box && uncC_box->get_version() == 1) {
+    // All of the version 1 cases are 8 bit
+    return 8;
+  }
   if (!uncC_box || !cmpd_box) {
     return -1;
   }
@@ -421,16 +425,16 @@ static bool map_uncompressed_component_to_channel(const std::shared_ptr<Box_cmpd
     } else if (uncC->get_profile() == fourcc("rgba")) {
       switch (component_index) {
       case 0:
-        *channel = heif_channel_Alpha;
-        return true;
-      case 1:
         *channel = heif_channel_R;
         return true;
-      case 2:
+      case 1:
         *channel = heif_channel_G;
         return true;
-        case 3:
+      case 2:
         *channel = heif_channel_B;
+        return true;
+      case 3:
+        *channel = heif_channel_Alpha;
         return true;
       }
     } else if (uncC->get_profile() == fourcc("abgr")) {


### PR DESCRIPTION
This is the RGB with alpha part of #1267.

I also noted that the version 1 case wasn't displaying the bit depth correctly, which is resolved by this.

There is still an issue where heif-info shows "alpha channel: no", because its looking for an aux image, not at the actual image channels.

@farindk Can you verify that it works for your test cases?