### PR TITLE
uncompressed: fix encoding of YCbCr with subsampling

### DIFF
--- a/libheif/codecs/uncompressed_image.cc
+++ b/libheif/codecs/uncompressed_image.cc
@@ -1258,10 +1258,10 @@ Error UncompressedImageCodec::encode_uncompressed_image(const std::shared_ptr<He
     {
       int src_stride;
       uint8_t* src_data = src_image->get_plane(channel, &src_stride);
-      uint64_t out_size = src_image->get_height() * src_image->get_width();
+      uint64_t out_size = src_image->get_height(channel) * src_image->get_width(channel);
       data.resize(data.size() + out_size);
-      for (int y = 0; y < src_image->get_height(); y++) {
-        memcpy(data.data() + offset + y * src_image->get_width(), src_data + src_stride * y, src_image->get_width());
+      for (int y = 0; y < src_image->get_height(channel); y++) {
+        memcpy(data.data() + offset + y * src_image->get_width(channel), src_data + src_stride * y, src_image->get_width(channel));
       }
       offset += out_size;
     }


### PR DESCRIPTION
This is the YCbCr part of #1267.

I'm actually surprised it encoded at all (rather than segfaulting), however now valgrind clean.

@farindk Can you confirm this works for your test cases?
