### PR TITLE
encoder_aom.cc: fix memory leaks

### DIFF
--- a/libheif/plugins/encoder_aom.cc
+++ b/libheif/plugins/encoder_aom.cc
@@ -870,6 +870,7 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
     err = {heif_error_Unsupported_feature,
            heif_suberror_Unsupported_codec,
            "Unsupported codec: AOMedia Project AV1 Encoder"};
+    aom_img_free(&input_image);
     return err;
   }
 
@@ -891,6 +892,7 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
     err = {heif_error_Encoder_plugin_error,
            heif_suberror_Encoder_initialization,
            kError_codec_enc_config_default};
+    aom_img_free(&input_image);
     return err;
   }
 
@@ -966,6 +968,7 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
     err = {heif_error_Encoder_plugin_error,
            heif_suberror_Encoder_initialization,
            encoder->set_aom_error(aom_codec_error_detail(&codec))};
+    aom_img_free(&input_image);
     return err;
   }
 


### PR DESCRIPTION
Discovered via fuzz testing.

Resolves: https://github.com/libvips/libvips/issues/4109.