### PR TITLE
[ffmpeg plugin] Fix leak during failure

### DIFF
--- a/libheif/plugins/decoder_ffmpeg.cc
+++ b/libheif/plugins/decoder_ffmpeg.cc
@@ -115,6 +115,12 @@ static void ffmpeg_free_decoder(void* decoder_raw)
 {
   struct ffmpeg_decoder* decoder = (struct ffmpeg_decoder*) decoder_raw;
 
+  //decoder->NalMap not needed anymore
+  for (auto current = decoder->NalMap.begin(); current != decoder->NalMap.end(); ++current) {
+      delete current->second;
+  }
+  decoder->NalMap.clear();
+
   delete decoder;
 }
 


### PR DESCRIPTION
When decoding "fails" in ffmpeg decoder, it is possible that NalMap is not cleaned up properly causing a leak.