### PR TITLE
tile access for uncompressed codec

### DIFF
--- a/libheif/api/libheif/heif.cc
+++ b/libheif/api/libheif/heif.cc
@@ -905,8 +905,6 @@ struct heif_error heif_image_handle_get_tile_size(const struct heif_image_handle
   }
 
 
-  // --- 'grid' image
-
   uint32_t w,h;
 
   handle->image->get_tile_size(w,h);

--- a/libheif/api/libheif/heif.h
+++ b/libheif/api/libheif/heif.h
@@ -1167,15 +1167,15 @@ struct heif_context* heif_image_handle_get_context(const struct heif_image_handl
 
 struct heif_image_tiling
 {
-  uint64_t num_columns;  // TODO: 32bit or 64bit ???
-  uint64_t num_rows;
+  uint32_t num_columns;
+  uint32_t num_rows;
   uint32_t tile_width;
   uint32_t tile_height;
 
-  uint64_t image_width;
-  uint64_t image_height;
+  uint32_t image_width;
+  uint32_t image_height;
   uint8_t number_of_extra_dimensions;  // 0 for normal images, 1 for volumetric (3D), ...
-  uint64_t extra_dimensions[8];        // size of extra dimensions (first 8 dimensions)
+  uint32_t extra_dimensions[8];        // size of extra dimensions (first 8 dimensions)
 };
 
 // If the image is not tiled, all entries of he returned struct will be zero.

--- a/libheif/codecs/tild.cc
+++ b/libheif/codecs/tild.cc
@@ -39,7 +39,7 @@ static uint64_t readvec(const std::vector<uint8_t>& data, size_t& ptr, int len)
 
 uint64_t number_of_tiles(const heif_tild_image_parameters& params)
 {
-  uint64_t nTiles = nTiles_h(params) * nTiles_v(params);
+  uint64_t nTiles = nTiles_h(params) * static_cast<uint64_t>(nTiles_v(params));
 
   for (int i = 0; i < params.number_of_extra_dimensions; i++) {
     // We only support up to 8 extra dimensions
@@ -54,13 +54,13 @@ uint64_t number_of_tiles(const heif_tild_image_parameters& params)
 }
 
 
-uint64_t nTiles_h(const heif_tild_image_parameters& params)
+uint32_t nTiles_h(const heif_tild_image_parameters& params)
 {
   return (params.image_width + params.tile_width - 1) / params.tile_width;
 }
 
 
-uint64_t nTiles_v(const heif_tild_image_parameters& params)
+uint32_t nTiles_v(const heif_tild_image_parameters& params)
 {
   return (params.image_height + params.tile_height - 1) / params.tile_height;
 }

--- a/libheif/codecs/tild.h
+++ b/libheif/codecs/tild.h
@@ -31,9 +31,9 @@
 
 uint64_t number_of_tiles(const heif_tild_image_parameters& params);
 
-uint64_t nTiles_h(const heif_tild_image_parameters& params);
+uint32_t nTiles_h(const heif_tild_image_parameters& params);
 
-uint64_t nTiles_v(const heif_tild_image_parameters& params);
+uint32_t nTiles_v(const heif_tild_image_parameters& params);
 
 
 class Box_tilC : public FullBox

--- a/libheif/codecs/uncompressed_image.cc
+++ b/libheif/codecs/uncompressed_image.cc
@@ -1421,3 +1421,17 @@ int ImageItem_uncompressed::get_chroma_bits_per_pixel() const
   int bpp = UncompressedImageCodec::get_chroma_bits_per_pixel_from_configuration_unci(*get_file(), get_id());
   return bpp;
 }
+
+
+void ImageItem_uncompressed::get_tile_size(uint32_t& w, uint32_t& h) const
+{
+  auto ispe = get_file()->get_property<Box_ispe>(get_id());
+  auto uncC = get_file()->get_property<Box_uncC>(get_id());
+
+  if (!ispe || !uncC) {
+    w=h=0;
+  }
+
+  w = ispe->get_width() / uncC->get_number_of_tile_columns();
+  h = ispe->get_height() / uncC->get_number_of_tile_rows();
+}

--- a/libheif/codecs/uncompressed_image.h
+++ b/libheif/codecs/uncompressed_image.h
@@ -74,6 +74,8 @@ public:
 
   int get_chroma_bits_per_pixel() const override;
 
+  void get_tile_size(uint32_t& w, uint32_t& h) const override;
+
   // Code from encode_uncompressed_image() has been moved to here.
 
   Result<std::shared_ptr<HeifPixelImage>> decode_compressed_image(const struct heif_decoding_options& options,


### PR DESCRIPTION
Single tile decoding for `unci` images.