### PR TITLE
Use ImageItem_Error for items with parse errors

### DIFF
--- a/libheif/api/libheif/heif.cc
+++ b/libheif/api/libheif/heif.cc
@@ -593,6 +593,11 @@ heif_error heif_context_get_primary_image_handle(heif_context* ctx, heif_image_h
     return err.error_struct(ctx->context.get());
   }
 
+  if (auto errImage = std::dynamic_pointer_cast<ImageItem_Error>(primary_image)) {
+    Error error = errImage->get_item_error();
+    return error.error_struct(ctx->context.get());
+  }
+
   *img = new heif_image_handle();
   (*img)->image = std::move(primary_image);
   (*img)->context = ctx->context;

--- a/libheif/api/libheif/heif.cc
+++ b/libheif/api/libheif/heif.cc
@@ -583,7 +583,7 @@ heif_error heif_context_get_primary_image_handle(heif_context* ctx, heif_image_h
     return err.error_struct(ctx->context.get());
   }
 
-  std::shared_ptr<ImageItem> primary_image = ctx->context->get_primary_image();
+  std::shared_ptr<ImageItem> primary_image = ctx->context->get_primary_image(true);
 
   // It is a requirement of an HEIF file there is always a primary image.
   // If there is none, an error is generated when loading the file.
@@ -613,7 +613,7 @@ struct heif_error heif_context_get_primary_image_ID(struct heif_context* ctx, he
                  heif_suberror_Null_pointer_argument).error_struct(ctx->context.get());
   }
 
-  std::shared_ptr<ImageItem> primary = ctx->context->get_primary_image();
+  std::shared_ptr<ImageItem> primary = ctx->context->get_primary_image(true);
   if (!primary) {
     return Error(heif_error_Invalid_input,
                  heif_suberror_No_or_invalid_primary_item).error_struct(ctx->context.get());
@@ -627,7 +627,7 @@ struct heif_error heif_context_get_primary_image_ID(struct heif_context* ctx, he
 
 int heif_context_is_top_level_image_ID(struct heif_context* ctx, heif_item_id id)
 {
-  const std::vector<std::shared_ptr<ImageItem>> images = ctx->context->get_top_level_images();
+  const std::vector<std::shared_ptr<ImageItem>> images = ctx->context->get_top_level_images(true);
 
   for (const auto& img : images) {
     if (img->get_id() == id) {
@@ -641,7 +641,7 @@ int heif_context_is_top_level_image_ID(struct heif_context* ctx, heif_item_id id
 
 int heif_context_get_number_of_top_level_images(heif_context* ctx)
 {
-  return (int) ctx->context->get_top_level_images().size();
+  return (int) ctx->context->get_top_level_images(true).size();
 }
 
 
@@ -656,7 +656,7 @@ int heif_context_get_list_of_top_level_image_IDs(struct heif_context* ctx,
 
   // fill in ID values into output array
 
-  const std::vector<std::shared_ptr<ImageItem>> imgs = ctx->context->get_top_level_images();
+  const std::vector<std::shared_ptr<ImageItem>> imgs = ctx->context->get_top_level_images(true);
   int n = (int) std::min(count, (int) imgs.size());
   for (int i = 0; i < n; i++) {
     ID_array[i] = imgs[i]->get_id();
@@ -674,7 +674,7 @@ struct heif_error heif_context_get_image_handle(struct heif_context* ctx,
     return {heif_error_Usage_error, heif_suberror_Null_pointer_argument, ""};
   }
 
-  auto image = ctx->context->get_image(id);
+  auto image = ctx->context->get_image(id, true);
 
   if (auto errImage = std::dynamic_pointer_cast<ImageItem_Error>(image)) {
     Error error = errImage->get_item_error();

--- a/libheif/api/libheif/heif.cc
+++ b/libheif/api/libheif/heif.cc
@@ -671,6 +671,11 @@ struct heif_error heif_context_get_image_handle(struct heif_context* ctx,
 
   auto image = ctx->context->get_image(id);
 
+  if (auto errImage = std::dynamic_pointer_cast<ImageItem_Error>(image)) {
+    Error error = errImage->get_item_error();
+    return error.error_struct(ctx->context.get());
+  }
+
   if (!image) {
     *imgHdl = nullptr;
 

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -913,7 +913,11 @@ Error HeifContext::interpret_heif_file()
                              "Region mask referenced item is not an image");
               }
 
-              auto mask_image = m_all_images.find(mask_image_id)->second;
+              auto mask_image = get_image(mask_image_id, true);
+              if (auto error = mask_image->get_item_error()) {
+                return error;
+              }
+
               mask_geometry->referenced_item = mask_image_id;
               if (mask_geometry->width == 0) {
                 mask_geometry->width = mask_image->get_ispe_width();

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -315,31 +315,22 @@ Error HeifContext::interpret_heif_file()
     }
 
     auto image = ImageItem::alloc_for_infe_box(this, infe_box);
-    if (image) {
-      m_all_images.insert(std::make_pair(id, image));
+    assert(image);
 
-      if (!infe_box->is_hidden_item()) {
-        if (id == m_heif_file->get_primary_image_ID()) {
-          image->set_primary(true);
-          m_primary_image = image;
-        }
+    m_all_images.insert(std::make_pair(id, image));
 
-        m_top_level_images.push_back(image);
+    if (!infe_box->is_hidden_item()) {
+      if (id == m_heif_file->get_primary_image_ID()) {
+        image->set_primary(true);
+        m_primary_image = image;
       }
 
-      Error err = image->on_load_file();
-      if (err) {
-        return err;
-      }
+      m_top_level_images.push_back(image);
+    }
 
-#if 0
-      if (infe_box->get_item_type() == "grid") {
-        Error err = image->read_grid_spec();
-        if (err) {
-          return err;
-        }
-      }
-#endif
+    Error err = image->on_load_file();
+    if (err) {
+      return err;
     }
   }
 
@@ -354,6 +345,10 @@ Error HeifContext::interpret_heif_file()
 
   for (auto& pair : m_all_images) {
     auto& image = pair.second;
+
+    if (image->is_error_item()) {
+      continue;
+    }
 
     std::vector<std::shared_ptr<Box>> properties;
 
@@ -662,6 +657,10 @@ Error HeifContext::interpret_heif_file()
   for (auto& pair : m_all_images) {
     auto& image = pair.second;
 
+    if (image->is_error_item()) {
+      continue;
+    }
+
     std::shared_ptr<Box_infe> infe = m_heif_file->get_infe_box(image->get_id());
     if (infe->get_item_type_4cc() == fourcc("hvc1")) {
 
@@ -693,6 +692,10 @@ Error HeifContext::interpret_heif_file()
   for (auto& pair : m_all_images) {
     auto& image = pair.second;
     auto id = pair.first;
+
+    if (image->is_error_item()) {
+      continue;
+    }
 
     auto infe_box = m_heif_file->get_infe_box(id);
     if (!infe_box) {

--- a/libheif/context.h
+++ b/libheif/context.h
@@ -94,29 +94,20 @@ public:
 
   std::shared_ptr<HeifFile> get_heif_file() const { return m_heif_file; }
 
-  std::vector<std::shared_ptr<ImageItem>> get_top_level_images() { return m_top_level_images; }
+  std::vector<std::shared_ptr<ImageItem>> get_top_level_images(bool return_error_images);
 
   void insert_new_image(heif_item_id id, std::shared_ptr<ImageItem> img) {
     m_all_images.insert(std::make_pair(id, img));
   }
 
-  std::shared_ptr<ImageItem> get_image(heif_item_id id)
+  std::shared_ptr<ImageItem> get_image(heif_item_id id, bool return_error_images);
+
+  std::shared_ptr<const ImageItem> get_image(heif_item_id id, bool return_error_images) const
   {
-    auto iter = m_all_images.find(id);
-    if (iter == m_all_images.end()) {
-      return nullptr;
-    }
-    else {
-      return iter->second;
-    }
+    return const_cast<HeifContext*>(this)->get_image(id, return_error_images);
   }
 
-  std::shared_ptr<const ImageItem> get_image(heif_item_id id) const
-  {
-    return const_cast<HeifContext*>(this)->get_image(id);
-  }
-
-  std::shared_ptr<ImageItem> get_primary_image() { return m_primary_image; }
+  std::shared_ptr<ImageItem> get_primary_image(bool return_error_image);
 
   bool is_image(heif_item_id ID) const;
 

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -279,11 +279,14 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
 
       heif_item_id tileID = image_references[reference_idx];
 
-      std::shared_ptr<const ImageItem> tileImg = get_context()->get_image(tileID);
+      std::shared_ptr<const ImageItem> tileImg = get_context()->get_image(tileID, true);
       if (!tileImg) {
         return Error{heif_error_Invalid_input,
                      heif_suberror_Missing_grid_images,
                      "Nonexistent grid image referenced"};
+      }
+      if (auto error = tileImg->get_item_error()) {
+        return error;
       }
 
       uint32_t src_width = tileImg->get_width();
@@ -384,8 +387,11 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
 {
   std::shared_ptr<HeifPixelImage> tile_img;
 
-  auto tileItem = get_context()->get_image(tileID);
+  auto tileItem = get_context()->get_image(tileID, true);
   assert(tileItem);
+  if (auto error = tileItem->get_item_error()) {
+    return error;
+  }
 
   auto decodeResult = tileItem->decode_image(options, false, 0, 0);
   if (decodeResult.error) {
@@ -443,7 +449,10 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_grid_tile(const h
   assert(idx < m_grid_tile_ids.size());
 
   heif_item_id tile_id = m_grid_tile_ids[idx];
-  std::shared_ptr<const ImageItem> tile_item = get_context()->get_image(tile_id);
+  std::shared_ptr<const ImageItem> tile_item = get_context()->get_image(tile_id, true);
+  if (auto error = tile_item->get_item_error()) {
+    return error;
+  }
 
   return tile_item->decode_compressed_image(options, true, tx, ty);
 }
@@ -457,14 +466,18 @@ heif_image_tiling ImageItem_Grid::get_heif_image_tiling() const
   tiling.num_columns = gridspec.get_columns();
   tiling.num_rows = gridspec.get_rows();
 
-  heif_item_id tile0_id = get_grid_tiles()[0];
-  auto tile0 = get_context()->get_image(tile0_id);
-  tiling.tile_width = tile0->get_width();
-  tiling.tile_height = tile0->get_height();
-
   tiling.image_width = gridspec.get_width();
   tiling.image_height = gridspec.get_height();
   tiling.number_of_extra_dimensions = 0;
+
+  heif_item_id tile0_id = get_grid_tiles()[0];
+  auto tile0 = get_context()->get_image(tile0_id, true);
+  if (tile0->get_item_error()) {
+    return tiling;
+  }
+
+  tiling.tile_width = tile0->get_width();
+  tiling.tile_height = tile0->get_height();
 
   return tiling;
 }
@@ -473,7 +486,10 @@ heif_image_tiling ImageItem_Grid::get_heif_image_tiling() const
 void ImageItem_Grid::get_tile_size(uint32_t& w, uint32_t& h) const
 {
   heif_item_id first_tile_id = get_grid_tiles()[0];
-  auto tile = get_context()->get_image(first_tile_id);
+  auto tile = get_context()->get_image(first_tile_id, true);
+  if (tile->get_item_error()) {
+    w = h = 0;
+  }
 
   w = tile->get_width();
   h = tile->get_height();
@@ -489,7 +505,7 @@ int ImageItem_Grid::get_luma_bits_per_pixel() const
     return -1;
   }
 
-  auto image = get_context()->get_image(child);
+  auto image = get_context()->get_image(child, true);
   if (!image) {
     return -1;
   }
@@ -506,7 +522,7 @@ int ImageItem_Grid::get_chroma_bits_per_pixel() const
     return -1;
   }
 
-  auto image = get_context()->get_image(child);
+  auto image = get_context()->get_image(child, true);
   return image->get_chroma_bits_per_pixel();
 }
 
@@ -518,6 +534,10 @@ std::shared_ptr<Decoder> ImageItem_Grid::get_decoder() const
     return nullptr;
   }
 
-  auto image = get_context()->get_image(child);
+  auto image = get_context()->get_image(child, true);
+  if (image->get_item_error()) {
+    return nullptr;
+  }
+
   return image->get_decoder();
 }

--- a/libheif/image-items/iden.cc
+++ b/libheif/image-items/iden.cc
@@ -67,11 +67,14 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_iden::decode_compressed_image(
                  "'iden' image referring to itself");
   }
 
-  std::shared_ptr<const ImageItem> imgitem = get_context()->get_image(reference_image_id);
+  std::shared_ptr<const ImageItem> imgitem = get_context()->get_image(reference_image_id, true);
   if (!imgitem) {
     return Error(heif_error_Invalid_input,
                  heif_suberror_Unspecified,
                  "'iden' image references unavailable image");
+  }
+  if (auto error = imgitem->get_item_error()) {
+    return error;
   }
 
   return imgitem->decode_compressed_image(options, decode_tile_only, tile_x0, tile_y0);
@@ -86,7 +89,7 @@ int ImageItem_iden::get_luma_bits_per_pixel() const
     return -1;
   }
 
-  auto image = get_context()->get_image(child);
+  auto image = get_context()->get_image(child, true);
   return image->get_luma_bits_per_pixel();
 }
 
@@ -99,6 +102,6 @@ int ImageItem_iden::get_chroma_bits_per_pixel() const
     return -1;
   }
 
-  auto image = get_context()->get_image(child);
+  auto image = get_context()->get_image(child, true);
   return image->get_chroma_bits_per_pixel();
 }

--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -155,7 +155,7 @@ std::shared_ptr<ImageItem> ImageItem::alloc_for_infe_box(HeifContext* ctx, const
   }
   else {
     std::stringstream sstr;
-    sstr << "Image item of type '" << fourcc_to_string(item_type) << "' are not supported.";
+    sstr << "Image item of type '" << fourcc_to_string(item_type) << "' is not supported.";
     Error err{ heif_error_Unsupported_feature, heif_suberror_Unsupported_image_type, sstr.str() };
     return std::make_shared<ImageItem_Error>(item_type, id, err);
   }

--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -59,12 +59,6 @@ ImageItem::ImageItem(HeifContext* context, heif_item_id id)
 }
 
 
-bool HeifContext::is_image(heif_item_id ID) const
-{
-  return m_all_images.find(ID) != m_all_images.end();
-}
-
-
 std::shared_ptr<HeifFile> ImageItem::get_file() const
 {
   return m_heif_context->get_heif_file();

--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -154,7 +154,10 @@ std::shared_ptr<ImageItem> ImageItem::alloc_for_infe_box(HeifContext* ctx, const
     return std::make_shared<ImageItem_Tiled>(ctx, id);
   }
   else {
-    return nullptr;
+    std::stringstream sstr;
+    sstr << "Image item of type '" << fourcc_to_string(item_type) << "' are not supported.";
+    Error err{ heif_error_Unsupported_feature, heif_suberror_Unsupported_image_type, sstr.str() };
+    return std::make_shared<ImageItem_Error>(item_type, id, err);
   }
 }
 

--- a/libheif/image-items/image_item.h
+++ b/libheif/image-items/image_item.h
@@ -72,7 +72,7 @@ public:
 
   virtual bool is_ispe_essential() const { return false; }
 
-  virtual bool is_error_item() const { return false; }
+  virtual Error get_item_error() const { return Error::Ok; }
 
   // If the output format requires a specific nclx (like JPEG), return this. Otherwise, return NULL.
   virtual const heif_color_profile_nclx* get_forced_output_nclx() const { return nullptr; }
@@ -435,9 +435,11 @@ public:
     return m_item_type;
   }
 
-  bool is_error_item() const override { return true; }
+  Error get_item_error() const override { return m_item_error; }
 
-  Error get_item_error() const { return m_item_error; }
+  [[nodiscard]] int get_luma_bits_per_pixel() const override { return -1; }
+
+  [[nodiscard]] int get_chroma_bits_per_pixel() const override { return -1; }
 
 private:
   uint32_t m_item_type;

--- a/libheif/image-items/image_item.h
+++ b/libheif/image-items/image_item.h
@@ -72,6 +72,8 @@ public:
 
   virtual bool is_ispe_essential() const { return false; }
 
+  virtual bool is_error_item() const { return false; }
+
   // If the output format requires a specific nclx (like JPEG), return this. Otherwise, return NULL.
   virtual const heif_color_profile_nclx* get_forced_output_nclx() const { return nullptr; }
 
@@ -419,5 +421,27 @@ protected:
                                 ImageItem::CodedImageData& inout_codedImage);
 };
 
+
+class ImageItem_Error : public ImageItem
+{
+public:
+  // dummy ImageItem class that is a placeholder for unsupported item types
+
+  ImageItem_Error(uint32_t item_type, heif_item_id id, Error err)
+    : ImageItem(nullptr, id), m_item_type(item_type), m_item_error(err) {}
+
+  uint32_t get_infe_type() const override
+  {
+    return m_item_type;
+  }
+
+  bool is_error_item() const override { return true; }
+
+  Error get_item_error() const { return m_item_error; }
+
+private:
+  uint32_t m_item_type;
+  Error m_item_error;
+};
 
 #endif //LIBHEIF_IMAGEITEM_H

--- a/libheif/image-items/overlay.cc
+++ b/libheif/image-items/overlay.cc
@@ -319,9 +319,12 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Overlay::decode_overlay_image(
                    "Self-reference in 'iovl' image item."};
     }
 
-    auto imgItem = get_context()->get_image(m_overlay_image_ids[i]);
+    auto imgItem = get_context()->get_image(m_overlay_image_ids[i], true);
     if (!imgItem) {
       return Error(heif_error_Invalid_input, heif_suberror_Nonexisting_item_referenced, "'iovl' image references a non-existing item.");
+    }
+    if (auto error = imgItem->get_item_error()) {
+      return error;
     }
 
     auto decodeResult = imgItem->decode_image(options, false, 0,0);
@@ -369,7 +372,7 @@ int ImageItem_Overlay::get_luma_bits_per_pixel() const
     return -1;
   }
 
-  auto image = get_context()->get_image(child);
+  auto image = get_context()->get_image(child, true);
   return image->get_luma_bits_per_pixel();
 }
 
@@ -382,6 +385,6 @@ int ImageItem_Overlay::get_chroma_bits_per_pixel() const
     return -1;
   }
 
-  auto image = get_context()->get_image(child);
+  auto image = get_context()->get_image(child, true);
   return image->get_chroma_bits_per_pixel();
 }


### PR DESCRIPTION
Not sure whether this is a good idea...

Similar to `Box_Error`, we could have an `ImageItem_Error`, serving as a placeholder for any image item that had parse errors or that we do not support (#1331). This allows us to have better error messages like this one:
````
$ heif-dec geo.heif out.jpg
Could not read HEIF/AVIF image 0: Unsupported feature: Unsupported image type: Image item of type 'unci' is not supported.
````

However, having non-decodable image items in our image list will probably introduce issues all over the place.
Thus, I am not sure if it is worth it.