### PR TITLE
heif-enc with tiles input

### DIFF
--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -818,12 +818,27 @@ heif_image_handle* encode_tiled(heif_context* ctx, heif_encoder* encoder, heif_e
 
     error = heif_context_add_tiled_image(ctx, &tiled_params, options, encoder, &tiled_image);
     if (error.code != 0) {
-      std::cerr << "Could not generate grid image: " << error.message << "\n";
+      std::cerr << "Could not generate tili image: " << error.message << "\n";
       return nullptr;
     }
   }
   else if (tiling_method == "unci") {
-    // TODO
+    heif_unci_image_parameters params{};
+    params.version = 1;
+    params.image_width = tiling.image_width;
+    params.image_height = tiling.image_height;
+    params.tile_width = tiling.tile_width;
+    params.tile_height = tiling.tile_height;
+    params.compression = heif_metadata_compression_brotli;
+
+    std::string input_filename = tile_generator.filename(0,0);
+    InputImage prototype_image = load_image(input_filename, output_bit_depth);
+
+    error = heif_context_add_unci_image(ctx, &params, options, prototype_image.image.get(), &tiled_image);
+    if (error.code != 0) {
+      std::cerr << "Could not generate unci image: " << error.message << "\n";
+      return nullptr;
+    }
   }
   else {
     assert(false);
@@ -1277,6 +1292,11 @@ int main(int argc, char** argv)
         std::cerr << "Could not encode HEIF/AVIF file: " << error.message << "\n";
         return 1;
       }
+    }
+
+    if (handle==nullptr) {
+      std::cerr << "Could not encode image\n";
+      return 1;
     }
 
     if (is_primary_image) {

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -97,6 +97,8 @@ const int OPTION_USE_JPEG2000_COMPRESSION = 1007;
 const int OPTION_VERBOSE = 1008;
 const int OPTION_USE_HTJ2K_COMPRESSION = 1009;
 const int OPTION_USE_VVC_COMPRESSION = 1010;
+const int OPTION_TILED_IMAGE_WIDTH = 1011;
+const int OPTION_TILED_IMAGE_HEIGHT = 1012;
 
 
 static struct option long_options[] = {
@@ -134,8 +136,8 @@ static struct option long_options[] = {
     {(char* const) "pitm-description",            required_argument, 0,                     OPTION_PITM_DESCRIPTION},
     {(char* const) "chroma-downsampling",         required_argument, 0, 'C'},
     {(char* const) "tiled-input",                 no_argument, 0, 'T'},
-    {(char* const) "tiled-image-width",           required_argument, &tiled_image_width, 0},
-    {(char* const) "tiled-image-height",          required_argument, &tiled_image_height, 0},
+    {(char* const) "tiled-image-width",           required_argument, nullptr, OPTION_TILED_IMAGE_WIDTH},
+    {(char* const) "tiled-image-height",          required_argument, nullptr, OPTION_TILED_IMAGE_HEIGHT},
     {0, 0,                                                           0,  0},
 };
 
@@ -735,6 +737,9 @@ heif_image_handle* encode_tiled(heif_context* ctx, heif_encoder* encoder, heif_e
 {
   std::vector<heif_item_id> image_ids;
 
+  std::cout << "encoding tiled image, tile size: " << tiling.tile_width << "x" << tiling.tile_height
+            << " image size: " << tiling.image_width << "x" << tiling.image_height << "\n";
+
   for (uint32_t ty = 0; ty < tile_generator.nRows(); ty++)
     for (uint32_t tx = 0; tx < tile_generator.nColumns(); tx++) {
       std::string input_filename = tile_generator.filename(tx,ty);
@@ -899,6 +904,12 @@ int main(int argc, char** argv)
         }
         break;
       }
+      case OPTION_TILED_IMAGE_WIDTH:
+        tiled_image_width = (int) strtol(optarg, nullptr, 0);
+        break;
+      case OPTION_TILED_IMAGE_HEIGHT:
+        tiled_image_height = (int) strtol(optarg, nullptr, 0);
+        break;
       case 'C':
         chroma_downsampling = optarg;
         if (chroma_downsampling != "nn" &&

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -846,6 +846,7 @@ heif_image_handle* encode_tiled(heif_context* ctx, heif_encoder* encoder, heif_e
   }
   else {
     assert(false);
+    exit(10);
   }
 
   std::cout << "encoding tiled image, tile size: " << tiling.tile_width << "x" << tiling.tile_height

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <sstream>
 
 #include <libheif/heif.h>
 #include <libheif/heif_properties.h>

--- a/heifio/decoder_tiff.cc
+++ b/heifio/decoder_tiff.cc
@@ -393,7 +393,15 @@ heif_error readBandInterleave(TIFF *tif, uint16_t samplesPerPixel, heif_image **
   }
 }
 
+
+static void suppress_warnings(const char* module, const char* fmt, va_list ap) {
+  // Do nothing
+}
+
+
 heif_error loadTIFF(const char* filename, InputImage *input_image) {
+  TIFFSetWarningHandler(suppress_warnings);
+
   std::unique_ptr<TIFF, void(*)(TIFF*)> tifPtr(TIFFOpen(filename, "r"), [](TIFF* tif) { TIFFClose(tif); });
   if (!tifPtr) {
     struct heif_error err = {

--- a/libheif/api/libheif/heif.cc
+++ b/libheif/api/libheif/heif.cc
@@ -3529,10 +3529,11 @@ struct heif_error heif_context_add_overlay_image(struct heif_context* ctx,
 struct heif_error heif_context_add_tiled_image(struct heif_context* ctx,
                                                const struct heif_tiled_image_parameters* parameters,
                                                const struct heif_encoding_options* options, // TODO: do we need this?
+                                               const struct heif_encoder* encoder,
                                                struct heif_image_handle** out_grid_image_handle)
 {
   Result<std::shared_ptr<ImageItem_Tiled>> gridImageResult;
-  gridImageResult = ctx->context->add_tiled_item(parameters);
+  gridImageResult = ctx->context->add_tiled_item(parameters, encoder);
 
   if (gridImageResult.error != Error::Ok) {
     return gridImageResult.error.error_struct(ctx->context.get());

--- a/libheif/api/libheif/heif.h
+++ b/libheif/api/libheif/heif.h
@@ -2369,7 +2369,7 @@ struct heif_error heif_context_add_grid_image(struct heif_context* ctx,
                                               uint32_t image_height,
                                               uint32_t tile_columns,
                                               uint32_t tile_rows,
-                                              const heif_item_id* image_ids,
+                                              const struct heif_encoding_options* encoding_options,
                                               struct heif_image_handle** out_grid_image_handle);
 
 LIBHEIF_API

--- a/libheif/api/libheif/heif_experimental.h
+++ b/libheif/api/libheif/heif_experimental.h
@@ -123,7 +123,7 @@ struct heif_tiled_image_parameters {
   uint32_t tile_width;
   uint32_t tile_height;
 
-  uint32_t compression_type_fourcc;  // TODO: can this be set automatically ?
+  uint32_t compression_format_fourcc;  // will be set automatically when calling heif_context_add_tiled_image()
 
   uint8_t offset_field_length;   // one of: 32, 40, 48, 64
   uint8_t size_field_length;     // one of:  0, 24, 32, 64
@@ -140,6 +140,7 @@ LIBHEIF_API
 struct heif_error heif_context_add_tiled_image(struct heif_context* ctx,
                                                const struct heif_tiled_image_parameters* parameters,
                                                const struct heif_encoding_options* options, // TODO: do we need this?
+                                               const struct heif_encoder* encoder,
                                                struct heif_image_handle** out_tiled_image_handle);
 
 

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -932,12 +932,16 @@ public:
 
   void add_references(heif_item_id from_id, uint32_t type, const std::vector<heif_item_id>& to_ids);
 
+  void overwrite_reference(heif_item_id from_id, uint32_t type, uint32_t reference_idx, heif_item_id to_item);
+
 protected:
   Error parse(BitstreamRange& range, const heif_security_limits*) override;
 
   Error write(StreamWriter& writer) const override;
 
   void derive_box_version() override;
+
+  Error check_for_double_references() const;
 
 private:
   std::vector<Reference> m_references;

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -1342,9 +1342,10 @@ Result<std::shared_ptr<ImageItem_Overlay>> HeifContext::add_iovl_item(const Imag
 }
 
 
-Result<std::shared_ptr<ImageItem_Tiled>> HeifContext::add_tiled_item(const heif_tiled_image_parameters* parameters)
+Result<std::shared_ptr<ImageItem_Tiled>> HeifContext::add_tiled_item(const heif_tiled_image_parameters* parameters,
+                                                                     const struct heif_encoder* encoder)
 {
-  return ImageItem_Tiled::add_new_tiled_item(this, parameters);
+  return ImageItem_Tiled::add_new_tiled_item(this, parameters, encoder);
 }
 
 
@@ -1354,7 +1355,7 @@ Error HeifContext::add_tiled_image_tile(heif_item_id tild_id, uint32_t tile_x, u
 {
   auto item = ImageItem::alloc_for_compression_format(this, encoder->plugin->compression_format);
 
-  heif_encoding_options* options = heif_encoding_options_alloc();
+  heif_encoding_options* options = heif_encoding_options_alloc(); // TODO: should this be taken from heif_context_add_tiled_image() ?
 
   Result<std::shared_ptr<HeifPixelImage>> colorConversionResult = item->convert_colorspace_for_encoding(image, encoder, *options);
   if (colorConversionResult.error) {

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -1243,25 +1243,18 @@ Error HeifContext::encode_grid(const std::vector<std::shared_ptr<HeifPixelImage>
 }
 
 
-Error HeifContext::add_grid_item(const std::vector<heif_item_id>& tile_ids,
-                               uint32_t output_width,
-                               uint32_t output_height,
-                               uint16_t tile_rows,
-                               uint16_t tile_columns,
-                               std::shared_ptr<ImageItem>& out_grid_image)
+Error HeifContext::add_grid_item(uint32_t output_width,
+                                 uint32_t output_height,
+                                 uint16_t tile_rows,
+                                 uint16_t tile_columns,
+                                 const struct heif_encoding_options* encoding_options,
+                                 std::shared_ptr<ImageItem_Grid>& out_grid_image)
 {
-  if (tile_ids.size() > 0xFFFF) {
+  if (tile_rows > 0xFFFF / tile_columns) {
     return {heif_error_Usage_error,
             heif_suberror_Unspecified,
             "Too many tiles (maximum: 65535)"};
   }
-
-#if 1
-  for (heif_item_id tile_id : tile_ids) {
-    m_heif_file->get_infe_box(tile_id)->set_hidden_item(true); // only show the full grid
-  }
-#endif
-
 
   // Create ImageGrid
 
@@ -1273,10 +1266,17 @@ Error HeifContext::add_grid_item(const std::vector<heif_item_id>& tile_ids,
   // Create Grid Item
 
   heif_item_id grid_id = m_heif_file->add_new_image(fourcc("grid"));
-  out_grid_image = std::make_shared<ImageItem>(this, grid_id);
+  out_grid_image = std::make_shared<ImageItem_Grid>(this, grid_id);
+  out_grid_image->set_encoding_options(encoding_options);
+  out_grid_image->set_grid_spec(grid);
+
   m_all_images.insert(std::make_pair(grid_id, out_grid_image));
   const int construction_method = 1; // 0=mdat 1=idat
   m_heif_file->append_iloc_data(grid_id, grid_data, construction_method);
+
+  // generate dummy grid item IDs (0)
+  std::vector<heif_item_id> tile_ids;
+  tile_ids.resize(tile_rows * tile_columns);
 
   // Connect tiles to grid
   m_heif_file->add_iref_reference(grid_id, fourcc("dimg"), tile_ids);
@@ -1284,9 +1284,7 @@ Error HeifContext::add_grid_item(const std::vector<heif_item_id>& tile_ids,
   // Add ISPE property
   m_heif_file->add_ispe_property(grid_id, output_width, output_height, false);
 
-  // Add PIXI property (copy from first tile)
-  auto pixi = m_heif_file->get_property<Box_pixi>(tile_ids[0]);
-  m_heif_file->add_property(grid_id, pixi, true);
+  // PIXI property will be added when the first tile is set
 
   // Set Brands
   //m_heif_file->set_brand(encoder->plugin->compression_format,
@@ -1422,6 +1420,37 @@ Error HeifContext::add_tiled_image_tile(heif_item_id tild_id, uint32_t tile_x, u
 
   m_heif_file->set_brand(encoder->plugin->compression_format,
                          true); // TODO: out_grid_image->is_miaf_compatible());
+
+  return Error::Ok;
+}
+
+
+Error HeifContext::add_grid_image_tile(heif_item_id grid_id, uint32_t tile_x, uint32_t tile_y,
+                                       const std::shared_ptr<HeifPixelImage>& image,
+                                       struct heif_encoder* encoder)
+{
+  auto grid_item = std::dynamic_pointer_cast<ImageItem_Grid>(get_image(grid_id));
+  auto encoding_options = grid_item->get_encoding_options();
+
+  std::shared_ptr<ImageItem> encoded_image;
+  Error error = encode_image(image,
+                             encoder,
+                             *encoding_options,
+                             heif_image_input_class_normal,
+                             encoded_image);
+  if (error != Error::Ok) {
+    return error;
+  }
+
+  m_heif_file->get_infe_box(encoded_image->get_id())->set_hidden_item(true); // grid tiles are hidden items
+
+  // Assign tile to grid
+  heif_image_tiling tiling = grid_item->get_heif_image_tiling();
+  m_heif_file->set_iref_reference(grid_id, fourcc("dimg"), tile_y * tiling.num_columns + tile_x, encoded_image->get_id());
+
+  // Add PIXI property (copy from first tile)
+  auto pixi = m_heif_file->get_property<Box_pixi>(encoded_image->get_id());
+  m_heif_file->add_property(grid_id, pixi, true);
 
   return Error::Ok;
 }

--- a/libheif/context.h
+++ b/libheif/context.h
@@ -160,7 +160,8 @@ public:
 
   Result<std::shared_ptr<ImageItem_Overlay>> add_iovl_item(const ImageOverlay& overlayspec);
 
-  Result<std::shared_ptr<ImageItem_Tiled>> add_tiled_item(const heif_tiled_image_parameters* parameters);
+  Result<std::shared_ptr<ImageItem_Tiled>> add_tiled_item(const heif_tiled_image_parameters* parameters,
+                                                          const struct heif_encoder* encoder);
 
   Error add_tiled_image_tile(heif_item_id tili_id, uint32_t tile_x, uint32_t tile_y,
                              const std::shared_ptr<HeifPixelImage>& image,

--- a/libheif/context.h
+++ b/libheif/context.h
@@ -151,12 +151,12 @@ public:
                     const struct heif_encoding_options& options,
                     std::shared_ptr<ImageItem>& out_image);
 
-  Error add_grid_item(const std::vector<heif_item_id>& tile_ids,
-                      uint32_t output_width,
+  Error add_grid_item(uint32_t output_width,
                       uint32_t output_height,
                       uint16_t tile_rows,
                       uint16_t tile_columns,
-                      std::shared_ptr<ImageItem>& out_grid_image);
+                      const struct heif_encoding_options* encoding_options,
+                      std::shared_ptr<class ImageItem_Grid>& out_grid_image);
 
   Result<std::shared_ptr<ImageItem_Overlay>> add_iovl_item(const ImageOverlay& overlayspec);
 
@@ -166,6 +166,10 @@ public:
   Error add_tiled_image_tile(heif_item_id tili_id, uint32_t tile_x, uint32_t tile_y,
                              const std::shared_ptr<HeifPixelImage>& image,
                              struct heif_encoder* encoder);
+
+  Error add_grid_image_tile(heif_item_id grid_id, uint32_t tile_x, uint32_t tile_y,
+                            const std::shared_ptr<HeifPixelImage>& image,
+                            struct heif_encoder* encoder);
 
   Result<std::shared_ptr<ImageItem_uncompressed>> add_unci_item(const heif_unci_image_parameters* parameters,
                                                                 const struct heif_encoding_options* encoding_options,

--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -1045,6 +1045,13 @@ void HeifFile::add_iref_reference(heif_item_id from, uint32_t type,
 }
 
 
+void HeifFile::set_iref_reference(heif_item_id from, uint32_t type, int reference_idx, heif_item_id to_item)
+{
+  assert(m_iref_box);
+  m_iref_box->overwrite_reference(from, type, reference_idx, to_item);
+}
+
+
 void HeifFile::add_entity_group_box(const std::shared_ptr<Box>& entity_group_box)
 {
   if (!m_grpl_box) {

--- a/libheif/file.h
+++ b/libheif/file.h
@@ -187,6 +187,8 @@ public:
   void add_iref_reference(heif_item_id from, uint32_t type,
                           const std::vector<heif_item_id>& to);
 
+  void set_iref_reference(heif_item_id from, uint32_t type, int reference_idx, heif_item_id to_item);
+
   void add_entity_group_box(const std::shared_ptr<Box>& entity_group_box);
 
   void set_auxC_property(heif_item_id id, const std::string& type);

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -457,10 +457,17 @@ heif_image_tiling ImageItem_Grid::get_heif_image_tiling() const
   tiling.num_columns = gridspec.get_columns();
   tiling.num_rows = gridspec.get_rows();
 
-  heif_item_id tile0_id = get_grid_tiles()[0];
-  auto tile0 = get_context()->get_image(tile0_id);
-  tiling.tile_width = tile0->get_width();
-  tiling.tile_height = tile0->get_height();
+  auto tile_ids = get_grid_tiles();
+  if (!tile_ids.empty() && tile_ids[0] != 0) {
+    heif_item_id tile0_id = tile_ids[0];
+    auto tile0 = get_context()->get_image(tile0_id);
+    tiling.tile_width = tile0->get_width();
+    tiling.tile_height = tile0->get_height();
+  }
+  else {
+    tiling.tile_width = 0;
+    tiling.tile_height = 0;
+  }
 
   tiling.image_width = gridspec.get_width();
   tiling.image_height = gridspec.get_height();

--- a/libheif/image-items/grid.h
+++ b/libheif/image-items/grid.h
@@ -93,6 +93,12 @@ public:
 
   int get_chroma_bits_per_pixel() const override;
 
+  void set_encoding_options(const heif_encoding_options* options) {
+    m_encoding_options = *options;
+  }
+
+  const heif_encoding_options* get_encoding_options() const { return &m_encoding_options; }
+
   Result<CodedImageData> encode(const std::shared_ptr<HeifPixelImage>& image,
                                 struct heif_encoder* encoder,
                                 const struct heif_encoding_options& options,
@@ -113,6 +119,8 @@ public:
 
   const ImageGrid& get_grid_spec() const { return m_grid_spec; }
 
+  void set_grid_spec(const ImageGrid& grid) { m_grid_spec = grid; }
+
   const std::vector<heif_item_id>& get_grid_tiles() const { return m_grid_tile_ids; }
 
   heif_image_tiling get_heif_image_tiling() const override;
@@ -123,6 +131,7 @@ private:
   ImageGrid m_grid_spec;
   std::vector<heif_item_id> m_grid_tile_ids;
 
+  heif_encoding_options m_encoding_options;
 
   Error read_grid_spec();
 

--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -108,6 +108,28 @@ heif_compression_format ImageItem::compression_format_from_fourcc_infe_type(uint
   }
 }
 
+uint32_t ImageItem::compression_format_to_fourcc_infe_type(heif_compression_format format)
+{
+  switch (format) {
+    case heif_compression_JPEG:
+      return fourcc("jpeg");
+    case heif_compression_HEVC:
+      return fourcc("hvc1");
+    case heif_compression_AV1:
+      return fourcc("av01");
+    case heif_compression_VVC:
+      return fourcc("vvc1");
+    case heif_compression_JPEG2000:
+      return fourcc("j2k1");
+    case heif_compression_uncompressed:
+      return fourcc("unci");
+    case heif_compression_mask:
+      return fourcc("mski");
+    default:
+      return 0;
+  }
+}
+
 
 std::shared_ptr<ImageItem> ImageItem::alloc_for_infe_box(HeifContext* ctx, const std::shared_ptr<Box_infe>& infe)
 {

--- a/libheif/image-items/image_item.h
+++ b/libheif/image-items/image_item.h
@@ -62,6 +62,8 @@ public:
 
   static heif_compression_format compression_format_from_fourcc_infe_type(uint32_t type);
 
+  static uint32_t compression_format_to_fourcc_infe_type(heif_compression_format);
+
   Result<std::shared_ptr<HeifPixelImage>> convert_colorspace_for_encoding(const std::shared_ptr<HeifPixelImage>& image,
                                                                           struct heif_encoder* encoder,
                                                                           const struct heif_encoding_options& options);

--- a/libheif/image-items/tiled.h
+++ b/libheif/image-items/tiled.h
@@ -59,6 +59,8 @@ public:
 
   void set_parameters(const heif_tiled_image_parameters& params) { m_parameters = params; }
 
+  void set_compression_format(heif_compression_format format) { m_parameters.compression_format_fourcc = ImageItem::compression_format_to_fourcc_infe_type(format); }
+
   const heif_tiled_image_parameters& get_parameters() const { return m_parameters; }
 
   Error write(StreamWriter& writer) const override;
@@ -83,6 +85,8 @@ public:
   Error set_parameters(const heif_tiled_image_parameters& params);
 
   const heif_tiled_image_parameters& get_parameters() const { return m_parameters; }
+
+  void set_compression_format(heif_compression_format format) { m_parameters.compression_format_fourcc = ImageItem::compression_format_to_fourcc_infe_type(format); }
 
   Error read_full_offset_table(const std::shared_ptr<HeifFile>& file, heif_item_id tild_id, const heif_security_limits* limits);
 
@@ -140,7 +144,8 @@ public:
 
   heif_compression_format get_compression_format() const override;
 
-  static Result<std::shared_ptr<ImageItem_Tiled>> add_new_tiled_item(HeifContext* ctx, const heif_tiled_image_parameters* parameters);
+  static Result<std::shared_ptr<ImageItem_Tiled>> add_new_tiled_item(HeifContext* ctx, const heif_tiled_image_parameters* parameters,
+                                                                     const heif_encoder* encoder);
 
   Error on_load_file() override;
 

--- a/libheif/image-items/unc_image.cc
+++ b/libheif/image-items/unc_image.cc
@@ -377,7 +377,9 @@ Result<std::shared_ptr<ImageItem_uncompressed>> ImageItem_uncompressed::add_unci
     std::vector<uint8_t> dummydata;
     dummydata.resize(tile_size);
 
-    for (uint64_t i = 0; i < tile_size; i++) {
+    uint32_t nTiles = (parameters->image_width / parameters->tile_width) * (parameters->image_height / parameters->tile_height);
+
+    for (uint64_t i = 0; i < nTiles; i++) {
       const int construction_method = 0; // 0=mdat 1=idat
       file->append_iloc_data(unci_id, dummydata, construction_method);
     }


### PR DESCRIPTION
This adds the capability to encode a tiled image with heif-enc.
It uses a set of numbered input files and encodes it as a large tiled image.
