### PR TITLE
heif-enc: exit with invalid x265 internal parameters

### DIFF
--- a/libheif/plugins/encoder_x265.cc
+++ b/libheif/plugins/encoder_x265.cc
@@ -859,7 +859,17 @@ static struct heif_error x265_encode_image(void* encoder_raw, const struct heif_
     }
     else if (strncmp(p.name.c_str(), "x265:", 5) == 0) {
       std::string x265p = p.name.substr(5);
-      api->param_parse(param, x265p.c_str(), p.value_string.c_str());
+      if (api->param_parse(param, x265p.c_str(), p.value_string.c_str()) < 0) {
+        char error_message[1024];
+        strcpy(error_message, "Unsupported internal encoder parameter: ");
+        strcat(error_message, p.name.c_str());
+        struct heif_error err = {
+          .code = heif_error_Usage_error,
+          .subcode = heif_suberror_Unsupported_parameter,
+          .message = error_message
+        };
+        return err;
+      }
     }
   }
 


### PR DESCRIPTION
Tested:
```
$ build/examples/heif-enc lena.490x490.png -p x265:colorprim=12 -p x265:foo=bar -o /tmp/foo.heic
Could not encode HEIF/AVIF file: Usage error: Unsupported parameter: Unsupported internal encoder parameter: x265:foo
```