### PR TITLE
test case for uncompressed decoder advertisement

### DIFF
--- a/libheif/api/libheif/heif.cc
+++ b/libheif/api/libheif/heif.cc
@@ -2832,6 +2832,13 @@ struct heif_error heif_context_get_encoder(struct heif_context* context,
 
 int heif_have_decoder_for_format(enum heif_compression_format format)
 {
+  if (format == heif_compression_uncompressed) {
+#if WITH_UNCOMPRESSED_CODEC
+    return true;
+#else
+    return false;
+#endif
+  }
   auto plugin = get_decoder(format, nullptr);
   return plugin != nullptr;
 }

--- a/tests/uncompressed_decode.cc
+++ b/tests/uncompressed_decode.cc
@@ -165,6 +165,6 @@ TEST_CASE("check image handle no metadata blocks") {
 }
 
 TEST_CASE("check uncompressed is advertised") {
-  REQUIRE(heif_have_decoder_for_format(heif_compression_uncompressed) == true);
+  REQUIRE(heif_have_decoder_for_format(heif_compression_uncompressed) == (int)true);
 }
 

--- a/tests/uncompressed_decode.cc
+++ b/tests/uncompressed_decode.cc
@@ -164,6 +164,7 @@ TEST_CASE("check image handle no metadata blocks") {
   heif_context_free(context);
 }
 
-
-
+TEST_CASE("check uncompressed is advertised") {
+  REQUIRE(heif_have_decoder_for_format(heif_compression_uncompressed) == true);
+}
 


### PR DESCRIPTION
This shows that we are not advertising decoder support for uncompressed.

The base reason is that it checks for the compression type in the list of plugins, and there is no plugin for uncompressed decode. There is one for uncompressed encode.

This doesn't show up in the heif-dec example code, because it has a hard-coded response depending on compile time option for uncompressed.

I can see two ways forward:
 - add a dummy decoder plugin
 - add a special case (depending on compile time option for uncompressed) to `heif_have_decoder_for_format()`.

@farindk your preference?