### PR TITLE
Tili with contained properties

### DIFF
--- a/libheif/api/libheif/heif.cc
+++ b/libheif/api/libheif/heif.cc
@@ -1557,7 +1557,7 @@ void heif_image_get_content_light_level(const struct heif_image* image, struct h
 
 int heif_image_handle_get_content_light_level(const struct heif_image_handle* handle, struct heif_content_light_level* out)
 {
-  auto clli = handle->image->get_file()->get_property<Box_clli>(handle->image->get_id());
+  auto clli = handle->image->get_property<Box_clli>();
   if (out && clli) {
     *out = clli->clli;
   }
@@ -1587,7 +1587,7 @@ void heif_image_get_mastering_display_colour_volume(const struct heif_image* ima
 
 int heif_image_handle_get_mastering_display_colour_volume(const struct heif_image_handle* handle, struct heif_mastering_display_colour_volume* out)
 {
-  auto mdcv = handle->image->get_file()->get_property<Box_mdcv>(handle->image->get_id());
+  auto mdcv = handle->image->get_property<Box_mdcv>();
   if (out && mdcv) {
     *out = mdcv->mdcv;
   }
@@ -1664,7 +1664,7 @@ void heif_image_get_pixel_aspect_ratio(const struct heif_image* image, uint32_t*
 
 int heif_image_handle_get_pixel_aspect_ratio(const struct heif_image_handle* handle, uint32_t* aspect_h, uint32_t* aspect_v)
 {
-  auto pasp = handle->image->get_file()->get_property<Box_pasp>(handle->image->get_id());
+  auto pasp = handle->image->get_property<Box_pasp>();
   if (pasp) {
     *aspect_h = pasp->hSpacing;
     *aspect_v = pasp->vSpacing;

--- a/libheif/api/libheif/heif_properties.cc
+++ b/libheif/api/libheif/heif_properties.cc
@@ -389,7 +389,7 @@ struct heif_error heif_property_set_clock_info(struct heif_context* ctx,
   }
 
   // Create new taic if one doesn't exist for the itemId.
-  auto taic = ctx->context->get_heif_file()->get_property<Box_taic>(itemId);
+  auto taic = ctx->context->get_heif_file()->get_property_for_item<Box_taic>(itemId);
   if (!taic) {
     taic = std::make_shared<Box_taic>();
   }
@@ -427,7 +427,7 @@ struct heif_error heif_property_get_clock_info(const struct heif_context* ctx,
   }
 
   // Check if taic exists for itemId
-  auto taic = file->get_property<Box_taic>(itemId);
+  auto taic = file->get_property_for_item<Box_taic>(itemId);
   if (!taic) {
     out_clock = nullptr;
     return {heif_error_Usage_error, heif_suberror_Invalid_property, "TAI Clock property not found for itemId"};
@@ -462,7 +462,7 @@ struct heif_error heif_property_set_tai_timestamp(struct heif_context* ctx,
   }
 
   // Create new itai if one doesn't exist for the itemId.
-  auto itai = file->get_property<Box_itai>(itemId);
+  auto itai = file->get_property_for_item<Box_itai>(itemId);
   if (!itai) {
     itai = std::make_shared<Box_itai>();
   }
@@ -475,7 +475,7 @@ struct heif_error heif_property_set_tai_timestamp(struct heif_context* ctx,
   heif_property_id id = ctx->context->add_property(itemId, itai, false);
   
   // Create new taic if one doesn't exist for the itemId.
-  auto taic = file->get_property<Box_taic>(itemId);
+  auto taic = file->get_property_for_item<Box_taic>(itemId);
   if (!taic) {
     taic = std::make_shared<Box_taic>();
     ctx->context->add_property(itemId, taic, false);
@@ -505,7 +505,7 @@ struct heif_error heif_property_get_tai_timestamp(const struct heif_context* ctx
   }
 
   //Check if itai exists for itemId
-  auto itai = file->get_property<Box_itai>(itemId);
+  auto itai = file->get_property_for_item<Box_itai>(itemId);
   if (!itai) {
     out_timestamp = nullptr;
     return {heif_error_Usage_error, heif_suberror_Invalid_property, "Timestamp property not found for itemId"};

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -899,22 +899,24 @@ Error Box::read_children(BitstreamRange& range, uint32_t max_number, const heif_
       return error;
     }
 
-    uint32_t max_children;
-    if (get_short_type() == fourcc("iinf")) {
-      max_children = limits->max_items;
-    }
-    else {
-      max_children = limits->max_children_per_box;
-    }
+    if (max_number == READ_CHILDREN_ALL) {
+      uint32_t max_children;
+      if (get_short_type() == fourcc("iinf")) {
+        max_children = limits->max_items;
+      }
+      else {
+        max_children = limits->max_children_per_box;
+      }
 
-    if (max_children && m_children.size() > max_children) {
-      std::stringstream sstr;
-      sstr << "Maximum number of child boxes (" << max_children << ") in '" << get_type_string() << "' box exceeded.";
+      if (max_children && m_children.size() > max_children) {
+        std::stringstream sstr;
+        sstr << "Maximum number of child boxes (" << max_children << ") in '" << get_type_string() << "' box exceeded.";
 
-      // Sanity check.
-      return Error(heif_error_Memory_allocation_error,
-                   heif_suberror_Security_limit_exceeded,
-                   sstr.str());
+        // Sanity check.
+        return Error(heif_error_Memory_allocation_error,
+                     heif_suberror_Security_limit_exceeded,
+                     sstr.str());
+      }
     }
 
     m_children.push_back(std::move(box));

--- a/libheif/codecs/decoder.cc
+++ b/libheif/codecs/decoder.cc
@@ -98,37 +98,39 @@ Result<std::vector<uint8_t>> DataExtent::read_data(uint64_t offset, uint64_t siz
 }
 
 
-std::shared_ptr<Decoder> Decoder::alloc_for_infe_type(const HeifContext* ctx, heif_item_id id, uint32_t format_4cc)
+std::shared_ptr<Decoder> Decoder::alloc_for_infe_type(const ImageItem* item)
 {
+  uint32_t format_4cc = item->get_infe_type();
+
   switch (format_4cc) {
     case fourcc("hvc1"): {
-      auto hvcC = ctx->get_heif_file()->get_property<Box_hvcC>(id);
+      auto hvcC = item->get_property<Box_hvcC>();
       return std::make_shared<Decoder_HEVC>(hvcC);
     }
     case fourcc("av01"): {
-      auto av1C = ctx->get_heif_file()->get_property<Box_av1C>(id);
+      auto av1C = item->get_property<Box_av1C>();
       return std::make_shared<Decoder_AVIF>(av1C);
     }
     case fourcc("avc1"): {
-      auto avcC = ctx->get_heif_file()->get_property<Box_avcC>(id);
+      auto avcC = item->get_property<Box_avcC>();
       return std::make_shared<Decoder_AVC>(avcC);
     }
     case fourcc("j2k1"): {
-      auto j2kH = ctx->get_heif_file()->get_property<Box_j2kH>(id);
+      auto j2kH = item->get_property<Box_j2kH>();
       return std::make_shared<Decoder_JPEG2000>(j2kH);
     }
     case fourcc("vvc1"): {
-      auto vvcC = ctx->get_heif_file()->get_property<Box_vvcC>(id);
+      auto vvcC = item->get_property<Box_vvcC>();
       return std::make_shared<Decoder_VVC>(vvcC);
     }
     case fourcc("jpeg"): {
-      auto jpgC = ctx->get_heif_file()->get_property<Box_jpgC>(id);
+      auto jpgC = item->get_property<Box_jpgC>();
       return std::make_shared<Decoder_JPEG>(jpgC);
     }
 #if WITH_UNCOMPRESSED_CODEC
     case fourcc("unci"): {
-      auto uncC = ctx->get_heif_file()->get_property<Box_uncC>(id);
-      auto cmpd = ctx->get_heif_file()->get_property<Box_cmpd>(id);
+      auto uncC = item->get_property<Box_uncC>();
+      auto cmpd = item->get_property<Box_cmpd>();
       return std::make_shared<Decoder_uncompressed>(uncC,cmpd);
     }
 #endif

--- a/libheif/codecs/decoder.h
+++ b/libheif/codecs/decoder.h
@@ -61,7 +61,7 @@ struct DataExtent
 class Decoder
 {
 public:
-  static std::shared_ptr<Decoder> alloc_for_infe_type(const HeifContext* ctx, heif_item_id, uint32_t format_4cc);
+  static std::shared_ptr<Decoder> alloc_for_infe_type(const ImageItem* item);
 
 
   virtual ~Decoder() = default;

--- a/libheif/codecs/uncompressed/decoder_abstract.cc
+++ b/libheif/codecs/uncompressed/decoder_abstract.cc
@@ -166,10 +166,16 @@ const Error AbstractDecoder::get_compressed_image_data_uncompressed(const HeifCo
                                                                     uint32_t tile_idx,
                                                                     const Box_iloc::Item* item) const
 {
+  auto image = context->get_image(ID, false);
+  if (!image) {
+    return {heif_error_Invalid_input,
+            heif_suberror_Nonexisting_item_referenced};
+  }
+
   // --- get codec configuration
 
-  std::shared_ptr<const Box_cmpC> cmpC_box = context->get_heif_file()->get_property<const Box_cmpC>(ID);
-  std::shared_ptr<const Box_icef> icef_box = context->get_heif_file()->get_property<const Box_icef>(ID);
+  std::shared_ptr<const Box_cmpC> cmpC_box = image->get_property<const Box_cmpC>();
+  std::shared_ptr<const Box_icef> icef_box = image->get_property<const Box_icef>();
 
   if (!cmpC_box) {
     // assume no generic compression

--- a/libheif/codecs/uncompressed/unc_codec.cc
+++ b/libheif/codecs/uncompressed/unc_codec.cc
@@ -483,9 +483,15 @@ Error UncompressedImageCodec::decode_uncompressed_image_tile(const HeifContext* 
                                                              uint32_t tile_x0, uint32_t tile_y0)
 {
   auto file = context->get_heif_file();
-  std::shared_ptr<Box_ispe> ispe = file->get_property<Box_ispe>(ID);
-  std::shared_ptr<Box_cmpd> cmpd = file->get_property<Box_cmpd>(ID);
-  std::shared_ptr<Box_uncC> uncC = file->get_property<Box_uncC>(ID);
+  auto image = context->get_image(ID, false);
+  if (!image) {
+    return {heif_error_Invalid_input,
+            heif_suberror_Nonexisting_item_referenced};
+  }
+
+  std::shared_ptr<Box_ispe> ispe = image->get_property<Box_ispe>();
+  std::shared_ptr<Box_cmpd> cmpd = image->get_property<Box_cmpd>();
+  std::shared_ptr<Box_uncC> uncC = image->get_property<Box_uncC>();
 
   Error error = check_header_validity(ispe, cmpd, uncC);
   if (error) {
@@ -589,9 +595,15 @@ Error UncompressedImageCodec::decode_uncompressed_image(const HeifContext* conte
     return error;
   }
 
-  std::shared_ptr<Box_ispe> ispe = context->get_heif_file()->get_property<Box_ispe>(ID);
-  std::shared_ptr<Box_cmpd> cmpd = context->get_heif_file()->get_property<Box_cmpd>(ID);
-  std::shared_ptr<Box_uncC> uncC = context->get_heif_file()->get_property<Box_uncC>(ID);
+  auto image = context->get_image(ID, false);
+  if (!image) {
+    return {heif_error_Invalid_input,
+            heif_suberror_Nonexisting_item_referenced};
+  }
+
+  std::shared_ptr<Box_ispe> ispe = image->get_property<Box_ispe>();
+  std::shared_ptr<Box_cmpd> cmpd = image->get_property<Box_cmpd>();
+  std::shared_ptr<Box_uncC> uncC = image->get_property<Box_uncC>();
 
   error = check_header_validity(ispe, cmpd, uncC);
   if (error) {

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -354,7 +354,15 @@ Error HeifContext::interpret_heif_file()
       m_top_level_images.push_back(image);
     }
 
-    Error err = image->on_load_file();
+    std::vector<std::shared_ptr<Box>> properties;
+    Error err = m_heif_file->get_properties(id, properties);
+    if (err) {
+      return err;
+    }
+
+    image->set_properties(properties);
+
+    err = image->on_load_file();
     if (err) {
       return err;
     }
@@ -555,7 +563,7 @@ Error HeifContext::interpret_heif_file()
           // --- this is an auxiliary image
           //     check whether it is an alpha channel and attach to the main image if yes
 
-          std::shared_ptr<Box_auxC> auxC_property = m_heif_file->get_property<Box_auxC>(image->get_id());
+          std::shared_ptr<Box_auxC> auxC_property = image->get_property<Box_auxC>();
           if (!auxC_property) {
             std::stringstream sstr;
             sstr << "No auxC property for image " << image->get_id();

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -1216,6 +1216,12 @@ Result<std::shared_ptr<ImageItem>> HeifContext::encode_image(const std::shared_p
     }
   }
 
+  std::vector<std::shared_ptr<Box>> properties;
+  err = m_heif_file->get_properties(output_image_item->get_id(), properties);
+  if (err) {
+    return err;
+  }
+  output_image_item->set_properties(properties);
 
   m_heif_file->set_brand(encoder->plugin->compression_format,
                          output_image_item->is_miaf_compatible());

--- a/libheif/file.h
+++ b/libheif/file.h
@@ -139,7 +139,7 @@ public:
                        std::vector<std::shared_ptr<Box>>& properties) const;
 
   template<class BoxType>
-  std::shared_ptr<BoxType> get_property(heif_item_id imageID) const
+  std::shared_ptr<BoxType> get_property_for_item(heif_item_id imageID) const
   {
     std::vector<std::shared_ptr<Box>> properties;
     Error err = get_properties(imageID, properties);

--- a/libheif/image-items/avc.cc
+++ b/libheif/image-items/avc.cc
@@ -128,7 +128,7 @@ std::shared_ptr<Decoder> ImageItem_AVC::get_decoder() const
 
 Error ImageItem_AVC::on_load_file()
 {
-  auto avcC_box = get_file()->get_property<Box_avcC>(get_id());
+  auto avcC_box = get_property<Box_avcC>();
   if (!avcC_box) {
     return Error{heif_error_Invalid_input,
                  heif_suberror_No_av1C_box};

--- a/libheif/image-items/avif.cc
+++ b/libheif/image-items/avif.cc
@@ -38,7 +38,7 @@
 
 Error ImageItem_AVIF::on_load_file()
 {
-  auto av1C_box = get_file()->get_property<Box_av1C>(get_id());
+  auto av1C_box = get_property<Box_av1C>();
   if (!av1C_box) {
     return Error{heif_error_Invalid_input,
                  heif_suberror_No_av1C_box};
@@ -102,7 +102,7 @@ Result<ImageItem::CodedImageData> ImageItem_AVIF::encode(const std::shared_ptr<H
 }
 
 
-Result<std::vector<uint8_t>> ImageItem_AVIF::read_bitstream_configuration_data(heif_item_id itemId) const
+Result<std::vector<uint8_t>> ImageItem_AVIF::read_bitstream_configuration_data() const
 {
   return m_decoder->read_bitstream_configuration_data();
 }

--- a/libheif/image-items/avif.h
+++ b/libheif/image-items/avif.h
@@ -57,7 +57,7 @@ public:
                                 enum heif_image_input_class input_class) override;
 
 protected:
-  Result<std::vector<uint8_t>> read_bitstream_configuration_data(heif_item_id itemId) const override;
+  Result<std::vector<uint8_t>> read_bitstream_configuration_data() const override;
 
   std::shared_ptr<class Decoder> get_decoder() const override;
 

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -684,7 +684,7 @@ Error ImageItem_Grid::add_image_tile(heif_item_id grid_id, uint32_t tile_x, uint
   set_grid_tile_id(tile_x, tile_y, encoded_image->get_id());
 
   // Add PIXI property (copy from first tile)
-  auto pixi = file->get_property<Box_pixi>(encoded_image->get_id());
+  auto pixi = encoded_image->get_property<Box_pixi>();
   file->add_property(grid_id, pixi, true);
 
   return Error::Ok;
@@ -715,6 +715,8 @@ Result<std::shared_ptr<ImageItem_Grid>> ImageItem_Grid::add_and_encode_full_grid
 
   std::vector<heif_item_id> tile_ids;
 
+  std::shared_ptr<Box_pixi> pixi_property;
+
   for (int i=0; i<rows*columns; i++) {
     std::shared_ptr<ImageItem> out_tile;
     auto encodingResult = ctx->encode_image(tiles[i],
@@ -728,6 +730,10 @@ Result<std::shared_ptr<ImageItem_Grid>> ImageItem_Grid::add_and_encode_full_grid
     heif_item_id tile_id = out_tile->get_id();
     file->get_infe_box(tile_id)->set_hidden_item(true); // only show the full grid
     tile_ids.push_back(out_tile->get_id());
+
+    if (!pixi_property) {
+      pixi_property = out_tile->get_property<Box_pixi>();
+    }
   }
 
   // Create Grid Item
@@ -750,8 +756,7 @@ Result<std::shared_ptr<ImageItem_Grid>> ImageItem_Grid::add_and_encode_full_grid
 
   // Add PIXI property (copy from first tile)
 
-  auto pixi = file->get_property<Box_pixi>(tile_ids[0]);
-  file->add_property(grid_id, pixi, true);
+  file->add_property(grid_id, pixi_property, true);
 
   // Set Brands
 

--- a/libheif/image-items/hevc.cc
+++ b/libheif/image-items/hevc.cc
@@ -36,7 +36,7 @@
 
 Error ImageItem_HEVC::on_load_file()
 {
-  auto hvcC_box = get_file()->get_property<Box_hvcC>(get_id());
+  auto hvcC_box = get_property<Box_hvcC>();
   if (!hvcC_box) {
     return Error{heif_error_Invalid_input,
                  heif_suberror_No_hvcC_box};
@@ -139,7 +139,7 @@ Result<ImageItem::CodedImageData> ImageItem_HEVC::encode(const std::shared_ptr<H
 }
 
 
-Result<std::vector<uint8_t>> ImageItem_HEVC::read_bitstream_configuration_data(heif_item_id itemId) const
+Result<std::vector<uint8_t>> ImageItem_HEVC::read_bitstream_configuration_data() const
 {
   return m_decoder->read_bitstream_configuration_data();
 }

--- a/libheif/image-items/hevc.h
+++ b/libheif/image-items/hevc.h
@@ -58,7 +58,7 @@ public:
   void set_preencoded_hevc_image(const std::vector<uint8_t>& data);
 
 protected:
-  Result<std::vector<uint8_t>> read_bitstream_configuration_data(heif_item_id itemId) const override;
+  Result<std::vector<uint8_t>> read_bitstream_configuration_data() const override;
 
   std::shared_ptr<class Decoder> get_decoder() const override;
 

--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -407,12 +407,12 @@ Error ImageItem::encode_to_item(HeifContext* ctx,
 
 bool ImageItem::has_ispe_resolution() const
 {
-  return m_heif_context->get_heif_file()->get_property<Box_ispe>(m_id) != nullptr;
+  return get_property<Box_ispe>() != nullptr;
 }
 
 uint32_t ImageItem::get_ispe_width() const
 {
-  auto ispe = m_heif_context->get_heif_file()->get_property<Box_ispe>(m_id);
+  auto ispe = get_property<Box_ispe>();
   if (!ispe) {
     return 0;
   }
@@ -424,7 +424,7 @@ uint32_t ImageItem::get_ispe_width() const
 
 uint32_t ImageItem::get_ispe_height() const
 {
-  auto ispe = m_heif_context->get_heif_file()->get_property<Box_ispe>(m_id);
+  auto ispe = get_property<Box_ispe>();
   if (!ispe) {
     return 0;
   }
@@ -740,7 +740,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem::decode_image(const struct hei
   // --- check whether image size (according to 'ispe') exceeds maximum
 
   if (!decode_tile_only) {
-    auto ispe = m_heif_context->get_heif_file()->get_property<Box_ispe>(m_id);
+    auto ispe = get_property<Box_ispe>();
     if (ispe) {
       Error err = check_for_valid_image_size(get_context()->get_security_limits(), ispe->get_width(), ispe->get_height());
       if (err) {
@@ -921,21 +921,21 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem::decode_image(const struct hei
 
     // CLLI
 
-    auto clli = get_file()->get_property<Box_clli>(m_id);
+    auto clli = get_property<Box_clli>();
     if (clli) {
       img->set_clli(clli->clli);
     }
 
     // MDCV
 
-    auto mdcv = get_file()->get_property<Box_mdcv>(m_id);
+    auto mdcv = get_property<Box_mdcv>();
     if (mdcv) {
       img->set_mdcv(mdcv->mdcv);
     }
 
     // PASP
 
-    auto pasp = get_file()->get_property<Box_pasp>(m_id);
+    auto pasp = get_property<Box_pasp>();
     if (pasp) {
       img->set_pixel_ratio(pasp->hSpacing, pasp->vSpacing);
     }
@@ -944,7 +944,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem::decode_image(const struct hei
   return img;
 }
 
-
+#if 0
 Result<std::vector<uint8_t>> ImageItem::read_bitstream_configuration_data_override(heif_item_id itemId, heif_compression_format format) const
 {
   auto item_codec = ImageItem::alloc_for_compression_format(const_cast<HeifContext*>(get_context()), format);
@@ -957,7 +957,7 @@ Result<std::vector<uint8_t>> ImageItem::read_bitstream_configuration_data_overri
 
   return item_codec->read_bitstream_configuration_data(itemId);
 }
-
+#endif
 
 Result<std::vector<uint8_t>> ImageItem::get_compressed_image_data() const
 {
@@ -967,7 +967,7 @@ Result<std::vector<uint8_t>> ImageItem::get_compressed_image_data() const
 
   // data from configuration blocks
 
-  Result<std::vector<uint8_t>> confData = read_bitstream_configuration_data(get_id());
+  Result<std::vector<uint8_t>> confData = read_bitstream_configuration_data();
   if (confData.error) {
     return confData.error;
   }

--- a/libheif/image-items/image_item.h
+++ b/libheif/image-items/image_item.h
@@ -80,7 +80,7 @@ public:
 
   virtual heif_compression_format get_compression_format() const { return heif_compression_undefined; }
 
-  virtual Result<std::vector<uint8_t>> read_bitstream_configuration_data(heif_item_id itemId) const { return std::vector<uint8_t>{}; }
+  virtual Result<std::vector<uint8_t>> read_bitstream_configuration_data() const { return std::vector<uint8_t>{}; }
 
   void clear()
   {
@@ -95,6 +95,22 @@ public:
   const HeifContext* get_context() const { return m_heif_context; }
 
   std::shared_ptr<class HeifFile> get_file() const;
+
+  void set_properties(std::vector<std::shared_ptr<Box>> properties) {
+    m_properties = std::move(properties);
+  }
+
+  template<class BoxType>
+  std::shared_ptr<BoxType> get_property() const
+  {
+    for (auto& property : m_properties) {
+      if (auto box = std::dynamic_pointer_cast<BoxType>(property)) {
+        return box;
+      }
+    }
+
+    return nullptr;
+  }
 
   void set_resolution(uint32_t w, uint32_t h)
   {
@@ -363,6 +379,7 @@ public:
 
 private:
   HeifContext* m_heif_context;
+  std::vector<std::shared_ptr<Box>> m_properties;
 
   heif_item_id m_id = 0;
   uint32_t m_width = 0, m_height = 0;  // after all transformations have been applied
@@ -404,7 +421,7 @@ private:
   std::vector<Error> m_decoding_warnings;
 
 protected:
-  Result<std::vector<uint8_t>> read_bitstream_configuration_data_override(heif_item_id itemId, heif_compression_format format) const;
+  // Result<std::vector<uint8_t>> read_bitstream_configuration_data_override(heif_item_id itemId, heif_compression_format format) const;
 
   virtual Result<CodedImageData> encode(const std::shared_ptr<HeifPixelImage>& image,
                                         struct heif_encoder* encoder,

--- a/libheif/image-items/jpeg.cc
+++ b/libheif/image-items/jpeg.cc
@@ -112,7 +112,7 @@ Result<ImageItem::CodedImageData> ImageItem_JPEG::encode(const std::shared_ptr<H
 }
 
 
-Result<std::vector<uint8_t>> ImageItem_JPEG::read_bitstream_configuration_data(heif_item_id itemId) const
+Result<std::vector<uint8_t>> ImageItem_JPEG::read_bitstream_configuration_data() const
 {
   return m_decoder->read_bitstream_configuration_data();
 }
@@ -126,7 +126,7 @@ std::shared_ptr<Decoder> ImageItem_JPEG::get_decoder() const
 Error ImageItem_JPEG::on_load_file()
 {
   // Note: jpgC box is optional. NULL is a valid value.
-  auto jpgC_box = get_file()->get_property<Box_jpgC>(get_id());
+  auto jpgC_box = get_property<Box_jpgC>();
 
   m_decoder = std::make_shared<Decoder_JPEG>(jpgC_box);
 

--- a/libheif/image-items/jpeg.h
+++ b/libheif/image-items/jpeg.h
@@ -54,7 +54,7 @@ public:
 protected:
   std::shared_ptr<Decoder> get_decoder() const override;
 
-  Result<std::vector<uint8_t>> read_bitstream_configuration_data(heif_item_id itemId) const override;
+  Result<std::vector<uint8_t>> read_bitstream_configuration_data() const override;
 
 private:
   std::shared_ptr<class Decoder_JPEG> m_decoder;

--- a/libheif/image-items/jpeg2000.cc
+++ b/libheif/image-items/jpeg2000.cc
@@ -69,11 +69,11 @@ Result<ImageItem::CodedImageData> ImageItem_JPEG2000::encode(const std::shared_p
 }
 
 
-Result<std::vector<uint8_t>> ImageItem_JPEG2000::read_bitstream_configuration_data(heif_item_id itemId) const
+Result<std::vector<uint8_t>> ImageItem_JPEG2000::read_bitstream_configuration_data() const
 {
   // --- get codec configuration
 
-  std::shared_ptr<Box_j2kH> j2kH_box = get_file()->get_property<Box_j2kH>(itemId);
+  std::shared_ptr<Box_j2kH> j2kH_box = get_property<Box_j2kH>();
   if (!j2kH_box)
   {
     // TODO - Correctly Find the j2kH box
@@ -95,7 +95,7 @@ std::shared_ptr<Decoder> ImageItem_JPEG2000::get_decoder() const
 
 Error ImageItem_JPEG2000::on_load_file()
 {
-  auto j2kH = get_file()->get_property<Box_j2kH>(get_id());
+  auto j2kH = get_property<Box_j2kH>();
   if (!j2kH) {
     return Error{heif_error_Invalid_input,
                  heif_suberror_Unspecified,

--- a/libheif/image-items/jpeg2000.h
+++ b/libheif/image-items/jpeg2000.h
@@ -47,7 +47,7 @@ public:
                                 enum heif_image_input_class input_class) override;
 
 protected:
-  Result<std::vector<uint8_t>> read_bitstream_configuration_data(heif_item_id itemId) const override;
+  Result<std::vector<uint8_t>> read_bitstream_configuration_data() const override;
 
   std::shared_ptr<Decoder> get_decoder() const override;
 

--- a/libheif/image-items/mask_image.cc
+++ b/libheif/image-items/mask_image.cc
@@ -62,8 +62,14 @@ Error MaskImageCodec::decode_mask_image(const HeifContext* context,
                                         std::shared_ptr<HeifPixelImage>& img,
                                         const std::vector<uint8_t>& data)
 {
-  std::shared_ptr<Box_ispe> ispe = context->get_heif_file()->get_property<Box_ispe>(ID);
-  std::shared_ptr<Box_mskC> mskC = context->get_heif_file()->get_property<Box_mskC>(ID);
+  auto image = context->get_image(ID, false);
+  if (!image) {
+    return {heif_error_Invalid_input,
+            heif_suberror_Nonexisting_item_referenced};
+  }
+
+  std::shared_ptr<Box_ispe> ispe = image->get_property<Box_ispe>();
+  std::shared_ptr<Box_mskC> mskC = image->get_property<Box_mskC>();
 
   uint32_t width = 0;
   uint32_t height = 0;
@@ -193,7 +199,7 @@ Result<ImageItem::CodedImageData> ImageItem_mask::encode(const std::shared_ptr<H
 
 int ImageItem_mask::get_luma_bits_per_pixel() const
 {
-  auto mskC = get_file()->get_property<Box_mskC>(get_id());
+  auto mskC = get_property<Box_mskC>();
   if (!mskC) {
     return -1;
   }

--- a/libheif/image-items/overlay.cc
+++ b/libheif/image-items/overlay.cc
@@ -428,7 +428,7 @@ Result<std::shared_ptr<ImageItem_Overlay>> ImageItem_Overlay::add_new_overlay_it
   file->add_ispe_property(iovl_id, overlayspec.get_canvas_width(), overlayspec.get_canvas_height(), false);
 
   // Add PIXI property (copy from first image) - According to MIAF, all images shall have the same color information.
-  auto pixi = file->get_property<Box_pixi>(ref_ids[0]);
+  auto pixi = file->get_property_for_item<Box_pixi>(ref_ids[0]);
   file->add_property(iovl_id, pixi, true);
 
   // Set Brands

--- a/libheif/image-items/tiled.cc
+++ b/libheif/image-items/tiled.cc
@@ -540,6 +540,16 @@ Error ImageItem_Tiled::on_load_file()
     }
   }
 
+
+  // --- create a dummy image item for decoding tiles
+
+  auto infe_box = get_file()->add_new_infe_box(m_tild_header.get_parameters().compression_format_fourcc);
+  m_dummy_tile_item_id = infe_box->get_item_ID();
+
+  for (auto& tile_property : tilC_box->get_all_child_boxes()) {
+    get_file()->add_property(m_dummy_tile_item_id, tile_property, true);
+  }
+
   return Error::Ok;
 }
 
@@ -751,7 +761,7 @@ ImageItem_Tiled::decode_grid_tile(const heif_decoding_options& options, uint32_t
 
   // --- get compressed data
 
-  Result<std::vector<uint8_t>> dataResult = read_bitstream_configuration_data_override(get_id(), format);
+  Result<std::vector<uint8_t>> dataResult = read_bitstream_configuration_data_override(m_dummy_tile_item_id, format);
   if (dataResult.error) {
     return dataResult.error;
   }

--- a/libheif/image-items/tiled.h
+++ b/libheif/image-items/tiled.h
@@ -202,7 +202,7 @@ private:
   uint32_t mReadChunkSize_bytes = 64*1024; // 64 kiB
   bool m_preload_offset_table = false;
 
-  uint32_t m_dummy_tile_item_id = 0;
+  std::shared_ptr<ImageItem> m_tile_item;
   std::shared_ptr<class Decoder> m_tile_decoder;
 
   Result<std::shared_ptr<HeifPixelImage>> decode_grid_tile(const heif_decoding_options& options, uint32_t tx, uint32_t ty) const;

--- a/libheif/image-items/tiled.h
+++ b/libheif/image-items/tiled.h
@@ -23,6 +23,7 @@
 
 
 #include "image_item.h"
+#include "codecs/decoder.h"
 #include "box.h"
 #include <vector>
 #include <string>
@@ -204,6 +205,9 @@ private:
 
   std::shared_ptr<ImageItem> m_tile_item;
   std::shared_ptr<class Decoder> m_tile_decoder;
+
+  Result<DataExtent>
+  get_compressed_data_for_tile(uint32_t tx, uint32_t ty) const;
 
   Result<std::shared_ptr<HeifPixelImage>> decode_grid_tile(const heif_decoding_options& options, uint32_t tx, uint32_t ty) const;
 

--- a/libheif/image-items/tiled.h
+++ b/libheif/image-items/tiled.h
@@ -69,6 +69,10 @@ public:
 
   std::string dump(Indent&) const override;
 
+  std::vector<std::shared_ptr<Box>>& get_tile_properties() { return m_children; }
+
+  const std::vector<std::shared_ptr<Box>>& get_tile_properties() const { return m_children; }
+
 protected:
   Error parse(BitstreamRange& range, const heif_security_limits* limits) override;
 

--- a/libheif/image-items/tiled.h
+++ b/libheif/image-items/tiled.h
@@ -202,6 +202,7 @@ private:
   uint32_t mReadChunkSize_bytes = 64*1024; // 64 kiB
   bool m_preload_offset_table = false;
 
+  uint32_t m_dummy_tile_item_id = 0;
   std::shared_ptr<class Decoder> m_tile_decoder;
 
   Result<std::shared_ptr<HeifPixelImage>> decode_grid_tile(const heif_decoding_options& options, uint32_t tx, uint32_t ty) const;

--- a/libheif/image-items/unc_image.cc
+++ b/libheif/image-items/unc_image.cc
@@ -404,7 +404,7 @@ Result<std::shared_ptr<ImageItem_uncompressed>> ImageItem_uncompressed::add_unci
 
 Error ImageItem_uncompressed::add_image_tile(uint32_t tile_x, uint32_t tile_y, const std::shared_ptr<const HeifPixelImage>& image)
 {
-  std::shared_ptr<Box_uncC> uncC = get_file()->get_property<Box_uncC>(get_id());
+  std::shared_ptr<Box_uncC> uncC = get_property<Box_uncC>();
   assert(uncC);
 
   uint32_t tile_width = image->get_width();
@@ -417,8 +417,8 @@ Error ImageItem_uncompressed::add_image_tile(uint32_t tile_x, uint32_t tile_y, c
     return codedBitstreamResult.error;
   }
 
-  std::shared_ptr<Box_cmpC> cmpC = get_file()->get_property<Box_cmpC>(get_id());
-  std::shared_ptr<Box_icef> icef = get_file()->get_property<Box_icef>(get_id());
+  std::shared_ptr<Box_cmpC> cmpC = get_property<Box_cmpC>();
+  std::shared_ptr<Box_icef> icef = get_property<Box_icef>();
 
   if (!icef || !cmpC) {
     assert(!icef);
@@ -471,8 +471,8 @@ Error ImageItem_uncompressed::add_image_tile(uint32_t tile_x, uint32_t tile_y, c
 
 void ImageItem_uncompressed::get_tile_size(uint32_t& w, uint32_t& h) const
 {
-  auto ispe = get_file()->get_property<Box_ispe>(get_id());
-  auto uncC = get_file()->get_property<Box_uncC>(get_id());
+  auto ispe = get_property<Box_ispe>();
+  auto uncC = get_property<Box_uncC>();
 
   if (!ispe || !uncC) {
     w = h = 0;
@@ -488,8 +488,8 @@ heif_image_tiling ImageItem_uncompressed::get_heif_image_tiling() const
 {
   heif_image_tiling tiling{};
 
-  auto ispe = get_file()->get_property<Box_ispe>(get_id());
-  auto uncC = get_file()->get_property<Box_uncC>(get_id());
+  auto ispe = get_property<Box_ispe>();
+  auto uncC = get_property<Box_uncC>();
   assert(ispe && uncC);
 
   tiling.num_columns = uncC->get_number_of_tile_columns();
@@ -512,8 +512,8 @@ std::shared_ptr<Decoder> ImageItem_uncompressed::get_decoder() const
 
 Error ImageItem_uncompressed::on_load_file()
 {
-  std::shared_ptr<Box_cmpd> cmpd = get_file()->get_property<Box_cmpd>(get_id());
-  std::shared_ptr<Box_uncC> uncC = get_file()->get_property<Box_uncC>(get_id());
+  std::shared_ptr<Box_cmpd> cmpd = get_property<Box_cmpd>();
+  std::shared_ptr<Box_uncC> uncC = get_property<Box_uncC>();
 
   if (!uncC) {
     return Error{heif_error_Invalid_input,

--- a/libheif/image-items/vvc.cc
+++ b/libheif/image-items/vvc.cc
@@ -94,11 +94,11 @@ Result<ImageItem::CodedImageData> ImageItem_VVC::encode(const std::shared_ptr<He
 }
 
 
-Result<std::vector<uint8_t>> ImageItem_VVC::read_bitstream_configuration_data(heif_item_id itemId) const
+Result<std::vector<uint8_t>> ImageItem_VVC::read_bitstream_configuration_data() const
 {
   // --- get codec configuration
 
-  std::shared_ptr<Box_vvcC> vvcC_box = get_file()->get_property<Box_vvcC>(itemId);
+  std::shared_ptr<Box_vvcC> vvcC_box = get_property<Box_vvcC>();
   if (!vvcC_box)
   {
     assert(false);
@@ -124,7 +124,7 @@ std::shared_ptr<Decoder> ImageItem_VVC::get_decoder() const
 
 Error ImageItem_VVC::on_load_file()
 {
-  auto vvcC_box = get_file()->get_property<Box_vvcC>(get_id());
+  auto vvcC_box = get_property<Box_vvcC>();
   if (!vvcC_box) {
     return Error{heif_error_Invalid_input,
                  heif_suberror_No_av1C_box};

--- a/libheif/image-items/vvc.h
+++ b/libheif/image-items/vvc.h
@@ -53,7 +53,7 @@ public:
 protected:
   std::shared_ptr<Decoder> get_decoder() const override;
 
-  Result<std::vector<uint8_t>> read_bitstream_configuration_data(heif_item_id itemId) const override;
+  Result<std::vector<uint8_t>> read_bitstream_configuration_data() const override;
 
 private:
   std::shared_ptr<class Decoder_VVC> m_decoder;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,9 @@ set(TESTING_DATA_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data")
 set(LIBHEIFIO_TESTING_DATA_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data/heifio")
 configure_file(test-config.cc.in ${CMAKE_BINARY_DIR}/generated/test-config.cc)
 
-set_source_files_properties(catch_amalgamated.cpp PROPERTIES COMPILE_FLAGS -Wno-conversion)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set_source_files_properties(catch_amalgamated.cpp PROPERTIES COMPILE_FLAGS -Wno-conversion)
+endif()
 
 add_library(testframework STATIC ${CMAKE_BINARY_DIR}/generated/test-config.cc test_utils.cc catch_amalgamated.cpp)
 


### PR DESCRIPTION
This changes the file format of the `tili` image item such that the tile properties are stored as children of the `tilC` box.
