### PR TITLE
fix ABI break in enum heif_metadata_compression

### DIFF
--- a/libheif/api/libheif/heif.h
+++ b/libheif/api/libheif/heif.h
@@ -519,8 +519,8 @@ enum heif_metadata_compression
 {
   heif_metadata_compression_off = 0,
   heif_metadata_compression_auto = 1,
-  heif_metadata_compression_unknown = 2, // only used when reading unknown method from input file
-  heif_metadata_compression_deflate = 3,
+  heif_metadata_compression_deflate = 2,
+  heif_metadata_compression_unknown = 3, // only used when reading unknown method from input file
   heif_metadata_compression_zlib = 4,    // do not use for header data
   heif_metadata_compression_brotli = 5
 };


### PR DESCRIPTION
This fixes the ABI break introduced in ebf6c61260307b0514c134232f79b006a8960b49 .

Resolves #1387 .