### PR TITLE
Add static flag to libheif.pc

### DIFF
--- a/libheif.pc.in
+++ b/libheif.pc.in
@@ -12,3 +12,4 @@ Requires.private: @REQUIRES_PRIVATE@
 Libs: -L${libdir} -lheif
 Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}
+Cflags.private: -DLIBHEIF_STATIC_BUILD


### PR DESCRIPTION
This is just one (small) step in addressing e.g. #513 and #902 for _clients_ of the static library (for which the correct OOTB _build_ of on Windows still needs to be handled).

This is not gated by WIN32 anywhere (i.e. placeholder to be conditionally substituted by CMake), but it doesn't affect other platforms, so might as well hard code it...