### PR TITLE
Patch to avoid out of bounds assert with a debug build on Windows.

### DIFF
--- a/libheif/plugins/decoder_openh264.cc
+++ b/libheif/plugins/decoder_openh264.cc
@@ -130,6 +130,7 @@ struct heif_error openh264_decode_image(void* decoder_raw, struct heif_image** o
   std::vector<uint8_t> scdata;
 
   size_t idx = 0;
+  auto end = &indata[0];
   while (idx < indata.size()) {
     if (indata.size() - 4 < idx) {
       return kError_EOF;
@@ -162,7 +163,8 @@ struct heif_error openh264_decode_image(void* decoder_raw, struct heif_image** o
           scdata.push_back(0);
           scdata.push_back(3);
 
-          scdata.insert(scdata.end(), &indata[idx + 2], &indata[idx + i + 2]);
+          end = (&indata[idx + i + 1])+1;
+          scdata.insert(scdata.end(), &indata[idx + 2], end);
           idx += i + 2;
           size -= (uint32_t)(i + 2);
           found_start_code_emulation = true;
@@ -174,7 +176,8 @@ struct heif_error openh264_decode_image(void* decoder_raw, struct heif_image** o
     }
 
     assert(size > 0);
-    scdata.insert(scdata.end(), &indata[idx], &indata[idx + size]);
+    end = (&indata[idx + size - 1])+1;
+    scdata.insert(scdata.end(), &indata[idx], end);
 
     idx += size;
   }


### PR DESCRIPTION
This patch fixes an out of range assert with a debug build on Windows:

```c++
    _NODISCARD _CONSTEXPR20 const _Ty& operator[](const size_type _Pos) const noexcept /* strengthened */ {
        auto& _My_data = _Mypair._Myval2;
#if _CONTAINER_DEBUG_LEVEL > 0
        _STL_VERIFY(
            _Pos < static_cast<size_type>(_My_data._Mylast - _My_data._Myfirst), "vector subscript out of range");
#endif // _CONTAINER_DEBUG_LEVEL > 0

        return _My_data._Myfirst[_Pos];
    }
```

This happens when `idx + size == indata.size()` and can be avoided by getting the address of the last element and then adding `1` to the pointer.