### PR TITLE
Security: ensure max_size_entity_group limit is enforced

### DIFF
--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -3849,6 +3849,9 @@ Error Box_EntityToGroup::parse(BitstreamRange& range, const heif_security_limits
     std::stringstream sstr;
     sstr << "entity group box contains " << nEntities << " entities, but the security limit is set to " << limits->max_size_entity_group << " entities.";
 
+    return {heif_error_Invalid_input,
+            heif_suberror_End_of_data,
+            sstr.str()};
   }
 
   entity_ids.resize(nEntities);


### PR DESCRIPTION
Commit https://github.com/strukturag/libheif/commit/41ccc4e82dfd7e0e2f40b27a959ade9ead8304a8 added support for limiting `max_size_entity_group` as part of libheif v0.19.0. This PR adds the necessary return to enforce that limit.