### PR TITLE
Add support for Apple framework builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 # see here: https://stackoverflow.com/questions/7335420/global-git-ignore
 
 build
+_build
 third-party/SVT-AV1/
 third-party/dav1d/
 third-party/libwebp/
 third-party/rav1e/
+
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ third-party/SVT-AV1/
 third-party/dav1d/
 third-party/libwebp/
 third-party/rav1e/
-
-*.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if (HAVE_UNISTD_H)
   add_definitions(-DHAVE_UNISTD_H)
 endif()
 
+if (APPLE)
+  option(BUILD_FRAMEWORK "Build as Apple Frameworks" OFF)
+endif()
+
 set(CMAKE_COMPILE_WARNING_AS_ERROR ON CACHE BOOL "Treat compilation warning as error")
 
 if(NOT MSVC)

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -119,7 +119,7 @@ set(libheif_sources
         color-conversion/chroma_sampling.h
         ${libheif_headers})
 
-add_library(heif ${libheif_sources})
+add_library(heif ${libheif_sources} ${libheif_headers})
 
 if (ENABLE_PLUGIN_LOADING)
     if (WIN32)
@@ -154,10 +154,26 @@ set_target_properties(heif
         SOVERSION ${PROJECT_VERSION_MAJOR})
 
 if (APPLE)
-    set_target_properties(heif
-            PROPERTIES
+    set_target_properties(heif PROPERTIES
 	    LINK_FLAGS "-Wl,-compatibility_version,${MACOS_COMPATIBLE_VERSION}")
 endif ()
+
+if (BUILD_FRAMEWORK) 
+  set_target_properties(heif PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION "${PACKAGE_VERSION}"
+    PRODUCT_BUNDLE_IDENTIFIER "github.com/strukturag/libheif"
+    XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+    # OUTPUT_NAME "heif"
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
+    PUBLIC_HEADER "${libheif_headers}"
+    MACOSX_FRAMEWORK_IDENTIFIER "github.com/strukturag/libheif"
+    MACOSX_FRAMEWORK_BUNDLE_VERSION "${PACKAGE_VERSION}"
+    MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+    MACOSX_RPATH TRUE)
+endif()
 
 target_compile_definitions(heif
         PUBLIC
@@ -239,6 +255,7 @@ install(TARGETS heif EXPORT ${PROJECT_NAME}-config
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        FRAMEWORK DESTINATION Library/Frameworks COMPONENT runtime OPTIONAL
         )
 
 install(FILES ${libheif_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -119,7 +119,7 @@ set(libheif_sources
         color-conversion/chroma_sampling.h
         ${libheif_headers})
 
-add_library(heif ${libheif_sources} ${libheif_headers})
+add_library(heif ${libheif_sources})
 
 if (ENABLE_PLUGIN_LOADING)
     if (WIN32)


### PR DESCRIPTION
Greetings,

Similar to the [PR in libde265](https://github.com/strukturag/libde265/pull/466), I added the essential properties to the `heif` target to enable cross-compilation for iOS derived platforms.
Since libheif **depends on** [libde265](https://github.com/strukturag/libde265), the framework artifacts of libde265 must exist on local machine in order to cross compile libheif for a desired Apple platform. 


The following commands could be used to generate the frameworks for an iOS target:
```bash
cmake -S. -B build -DBUILD_FRAMEWORK=TRUE -DCMAKE_SYSTEM_NAME=iOS -DWITH_EXAMPLES=OFF

sudo cmake --build build --target install --config Release
```

Note that `WITH_EXAMPLES=OFF` has to be off since I didn't find it necessary to modify the properties of _Examples_.