### PR TITLE
Remove an invalid assertion that triggers fuzzers

### DIFF
--- a/libheif/bitstream.cc
+++ b/libheif/bitstream.cc
@@ -166,7 +166,6 @@ BitstreamRange::BitstreamRange(std::shared_ptr<StreamReader> istr,
   : m_istr(std::move(istr)), m_remaining(end)
 {
   bool success = m_istr->seek(start);
-  assert(success);
   (void)success; // TODO
 }
 


### PR DESCRIPTION
Found by libvips' fuzz tests.
```console
$ heif-dec clusterfuzz-testcase-minimized-jpegsave_file_fuzzer-5001583624781824
heif-dec: /builddir/build/BUILD/libheif-1.19.7/libheif/bitstream.cc:169: BitstreamRange::BitstreamRange(std::shared_ptr<StreamReader>, size_t, size_t): Assertion `success' failed.
Aborted (core dumped)
```

See: https://github.com/libvips/libvips/pull/4424.