### PR TITLE
Add support for handling 'tmap' items

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,6 +54,7 @@
         "WITH_VVDEC_PLUGIN" : "OFF",
         "WITH_VVENC" : "ON",
         "WITH_VVENC_PLUGIN" : "OFF",
+        "WITH_EXPERIMENTAL_GAIN_MAP" : "OFF",
 
         "WITH_REDUCED_VISIBILITY" : "OFF",
         "WITH_HEADER_COMPRESSION" : "ON",
@@ -110,6 +111,7 @@
         "WITH_VVDEC_PLUGIN" : "ON",
         "WITH_VVENC" : "ON",
         "WITH_VVENC_PLUGIN" : "ON",
+        "WITH_EXPERIMENTAL_GAIN_MAP" : "OFF",
 
         "WITH_REDUCED_VISIBILITY" : "ON",
         "WITH_HEADER_COMPRESSION" : "ON",
@@ -148,6 +150,7 @@
         "WITH_UVG266" : "OFF",
         "WITH_VVDEC" : "OFF",
         "WITH_VVENC" : "OFF",
+        "WITH_EXPERIMENTAL_GAIN_MAP" : "OFF",
 
         "WITH_REDUCED_VISIBILITY" : "ON",
         "WITH_HEADER_COMPRESSION" : "OFF",

--- a/libheif/CMakeLists.txt
+++ b/libheif/CMakeLists.txt
@@ -249,6 +249,10 @@ if (ENABLE_EXPERIMENTAL_MINI_FORMAT)
             mini.cc)
 endif ()
 
+if (WITH_EXPERIMENTAL_GAIN_MAP)
+    target_compile_definitions(heif PUBLIC WITH_EXPERIMENTAL_GAIN_MAP=1)
+endif ()
+
 write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY ExactVersion)
 
 install(TARGETS heif EXPORT ${PROJECT_NAME}-config

--- a/libheif/api/libheif/heif.h
+++ b/libheif/api/libheif/heif.h
@@ -884,6 +884,13 @@ typedef uint32_t heif_brand2;
 */
 #define heif_brand2_1pic   heif_fourcc('1','p','i','c')
 
+/**
+ * HEIF tone map brand (`tmap`).
+ *
+ * This is a compatible brand indicating the file contains a gainmap image.
+ */
+#define heif_brand2_tmap heif_fourcc('t', 'm', 'a', 'p')
+
 // input data should be at least 12 bytes
 LIBHEIF_API
 heif_brand2 heif_read_main_brand(const uint8_t* data, int len);
@@ -1453,6 +1460,42 @@ struct heif_error heif_image_handle_get_auxiliary_image_handle(const struct heif
                                                                heif_item_id auxiliary_id,
                                                                struct heif_image_handle** out_auxiliary_handle);
 
+#if WITH_EXPERIMENTAL_GAIN_MAP
+
+// ------------------------- gain map images -------------------------
+
+// Get the gain map image associated with the main image. If no gain map image is available, this
+// method will return error.
+LIBHEIF_API
+struct heif_error heif_image_handle_get_gain_map_image_handle(
+    const struct heif_image_handle* handle, struct heif_image_handle** gain_map_handle);
+
+// Get the gain map metadata size associated with the main image. If no gain map image is available,
+// this method will return 0
+LIBHEIF_API
+size_t heif_image_handle_get_gain_map_metadata_size(const struct heif_image_handle* handle);
+
+// Get the gain map metadata associated with the main image. if no gain map image is available, this
+// method will return error
+LIBHEIF_API
+struct heif_error heif_image_handle_get_gain_map_metadata(const struct heif_image_handle* handle,
+                                                          void* out_data);
+
+// Get nclx color profile for derived image
+LIBHEIF_API
+struct heif_error heif_image_handle_get_derived_image_nclx_color_profile(
+    const struct heif_image_handle* handle, struct heif_color_profile_nclx** out_data);
+
+// Get raw color profile for derived image
+LIBHEIF_API
+size_t heif_image_handle_get_derived_image_raw_color_profile_size(
+    const struct heif_image_handle* handle);
+
+LIBHEIF_API
+struct heif_error heif_image_handle_get_derived_image_raw_color_profile(
+    const struct heif_image_handle* handle, void* out_data);
+
+#endif
 
 // ------------------------- metadata (Exif / XMP) -------------------------
 
@@ -2619,6 +2662,22 @@ int heif_encoder_descriptor_supportes_lossy_compression(const struct heif_encode
 // DEPRECATED, typo in function name
 LIBHEIF_API
 int heif_encoder_descriptor_supportes_lossless_compression(const struct heif_encoder_descriptor*);
+
+
+
+#if WITH_EXPERIMENTAL_GAIN_MAP
+
+// Compress the gain map image and write metadata.
+// Returns a handle to the coded image in 'out_image_handle' unless out_image_handle = NULL.
+LIBHEIF_API
+struct heif_error heif_context_encode_gain_map_image(
+    struct heif_context* ctx, const struct heif_image_handle* base_image_handle,
+    struct heif_encoder* encoder, const struct heif_image* gain_map_image,
+    const struct heif_encoding_options* input_options, const uint8_t* gain_map_metadata,
+    int gain_map_metadata_len, const struct heif_color_profile_nclx* derived_image_nclx,
+    struct heif_image_handle** out_image_handle);
+
+#endif
 
 
 #ifdef __cplusplus

--- a/libheif/api/libheif/heif_plugin.h
+++ b/libheif/api/libheif/heif_plugin.h
@@ -129,6 +129,9 @@ enum heif_image_input_class
   heif_image_input_class_alpha = 2,
   heif_image_input_class_depth = 3,
   heif_image_input_class_thumbnail = 4
+#if WITH_EXPERIMENTAL_GAIN_MAP
+  , heif_image_input_class_gain_map = 5
+#endif
 };
 
 

--- a/libheif/context.h
+++ b/libheif/context.h
@@ -47,6 +47,7 @@ class StreamWriter;
 
 class ImageItem;
 
+class ImageMetadata;
 
 // This is a higher-level view than HeifFile.
 // Images are grouped logically into main images and their thumbnails.
@@ -146,6 +147,14 @@ public:
   heif_property_id add_property(heif_item_id targetItem, std::shared_ptr<Box> property, bool essential);
 
   Result<heif_item_id> add_pyramid_group(const std::vector<heif_item_id>& layers);
+
+#if WITH_EXPERIMENTAL_GAIN_MAP
+  Error add_tmap_item(const std::vector<uint8_t>& metadata, heif_item_id& item_id);
+
+  Error link_gain_map(const std::shared_ptr<ImageItem>& primary_image,
+                      const std::shared_ptr<ImageItem>& gain_map_image, const heif_item_id tmap_id);
+#endif
+
 
   // --- region items
 

--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -192,6 +192,9 @@ void HeifFile::set_brand(heif_compression_format format, bool miaf_compatible)
       m_ftyp_box->set_minor_version(0);
       m_ftyp_box->add_compatible_brand(heif_brand2_mif1);
       m_ftyp_box->add_compatible_brand(heif_brand2_heic);
+#if WITH_EXPERIMENTAL_GAIN_MAP
+      m_ftyp_box->add_compatible_brand(heif_brand2_tmap);
+#endif
       break;
 
     case heif_compression_AV1:
@@ -199,6 +202,9 @@ void HeifFile::set_brand(heif_compression_format format, bool miaf_compatible)
       m_ftyp_box->set_minor_version(0);
       m_ftyp_box->add_compatible_brand(heif_brand2_avif);
       m_ftyp_box->add_compatible_brand(heif_brand2_mif1);
+#if WITH_EXPERIMENTAL_GAIN_MAP
+      m_ftyp_box->add_compatible_brand(heif_brand2_tmap);
+#endif
       break;
 
     case heif_compression_VVC:
@@ -352,6 +358,9 @@ Error HeifFile::parse_heif_file()
       !m_ftyp_box->has_compatible_brand(heif_brand2_1pic) &&
 #if ENABLE_EXPERIMENTAL_MINI_FORMAT
       !(m_ftyp_box->get_major_brand() == heif_brand2_mif3) &&
+#endif
+#if WITH_EXPERIMENTAL_GAIN_MAP
+      !(m_ftyp_box->get_major_brand() == heif_brand2_tmap) &&
 #endif
       !m_ftyp_box->has_compatible_brand(heif_brand2_jpeg)) {
     std::stringstream sstr;

--- a/libheif/plugins/encoder_aom.cc
+++ b/libheif/plugins/encoder_aom.cc
@@ -1073,7 +1073,12 @@ struct heif_error aom_encode_image(void* encoder_raw, const struct heif_image* i
 
   if (nclx &&
       (input_class == heif_image_input_class_normal ||
+#if WITH_EXPERIMENTAL_GAIN_MAP
+       input_class == heif_image_input_class_thumbnail ||
+       input_class == heif_image_input_class_gain_map)) {
+#else
        input_class == heif_image_input_class_thumbnail)) {
+#endif
     aom_error = aom_codec_control(&codec, AV1E_SET_COLOR_PRIMARIES, nclx->color_primaries); CHECK_ERROR
     aom_error = aom_codec_control(&codec, AV1E_SET_MATRIX_COEFFICIENTS, nclx->matrix_coefficients); CHECK_ERROR;
     aom_error = aom_codec_control(&codec, AV1E_SET_TRANSFER_CHARACTERISTICS, nclx->transfer_characteristics); CHECK_ERROR;

--- a/libheif/plugins/encoder_kvazaar.cc
+++ b/libheif/plugins/encoder_kvazaar.cc
@@ -567,7 +567,12 @@ static struct heif_error kvazaar_encode_image(void* encoder_raw, const struct he
 
   if (nclx &&
       (input_class == heif_image_input_class_normal ||
+#if WITH_EXPERIMENTAL_GAIN_MAP
+       input_class == heif_image_input_class_thumbnail ||
+       input_class == heif_image_input_class_gain_map)) {
+#else
        input_class == heif_image_input_class_thumbnail)) {
+#endif
     config->vui.colorprim = nclx->color_primaries;
     config->vui.transfer = nclx->transfer_characteristics;
     config->vui.colormatrix = nclx->matrix_coefficients;

--- a/libheif/plugins/encoder_rav1e.cc
+++ b/libheif/plugins/encoder_rav1e.cc
@@ -550,7 +550,12 @@ struct heif_error rav1e_encode_image(void* encoder_raw, const struct heif_image*
 
   if (nclx &&
       (input_class == heif_image_input_class_normal ||
+#if WITH_EXPERIMENTAL_GAIN_MAP
+       input_class == heif_image_input_class_thumbnail ||
+       input_class == heif_image_input_class_gain_map)) {
+#else
        input_class == heif_image_input_class_thumbnail)) {
+#endif
     if (rav1e_config_set_color_description(rav1eConfig.get(),
                                            (RaMatrixCoefficients) nclx->matrix_coefficients,
                                            (RaColorPrimaries) nclx->color_primaries,

--- a/libheif/plugins/encoder_x265.cc
+++ b/libheif/plugins/encoder_x265.cc
@@ -806,7 +806,12 @@ static struct heif_error x265_encode_image(void* encoder_raw, const struct heif_
 
   if (nclx &&
       (input_class == heif_image_input_class_normal ||
+#if WITH_EXPERIMENTAL_GAIN_MAP
+       input_class == heif_image_input_class_thumbnail ||
+       input_class == heif_image_input_class_gain_map)) {
+#else
        input_class == heif_image_input_class_thumbnail)) {
+#endif
 
     {
       std::stringstream sstr;


### PR DESCRIPTION
Gain map technology offers a way to create an image (henceforth referred
as derived image) from one base input image and a secondary input image
called as a gainmap input image. Reconstruction is done by applying the
gain map to the base image according to iso 21496-1 section 6.

This change provides API to read, write base input image, gain map input
image, gain map metadata. Third party applications can make use of this
API to render only base image or reconstruct the derived image and
render the same.

By default these API is disabled and can be enabled at configure time
using option -DWITH_EXPERIMENTAL_GAIN_MAP=1

TODO: add plugins for encoding, decoding uhdr images