### PR TITLE
Support versions of libsdl2-dev before 2.0.18

### DIFF
--- a/examples/heif_view.cc
+++ b/examples/heif_view.cc
@@ -56,6 +56,10 @@
 #include "getopt.h"
 #endif
 
+#if !SDL_VERSION_ATLEAST(2, 0, 18)
+#define SDL_GetTicks64 SDL_GetTicks
+#endif
+
 #define UNUSED(x) (void)x
 
 


### PR DESCRIPTION
SDL_GetTicks64 was introduced in SDL 2.0.18 but Ubuntu 20.04 still ships 2.0.10