### PR TITLE
seq_boxes: check for sbgp read errors within loop

### DIFF
--- a/libheif/sequences/seq_boxes.cc
+++ b/libheif/sequences/seq_boxes.cc
@@ -1302,6 +1302,9 @@ Error Box_sbgp::parse(BitstreamRange& range, const heif_security_limits* limits)
     e.sample_count = range.read32();
     e.group_description_index = range.read32();
     m_entries.push_back(e);
+    if (range.error()) {
+      return range.get_error();
+    }
   }
 
   return range.get_error();


### PR DESCRIPTION
Ensures the same fail-fast approach as used with the other boxes parsed by this file.