### PR TITLE
heif_track_info_release() - Seg Fault

### DIFF
--- a/libheif/api/libheif/heif_sequences.cc
+++ b/libheif/api/libheif/heif_sequences.cc
@@ -306,7 +306,6 @@ void heif_track_info_release(struct heif_track_info* info)
 {
   if (info) {
     heif_tai_clock_info_release(info->tai_clock_info);
-    delete[] info->gimi_track_content_id;
 
     delete info;
   }


### PR DESCRIPTION
The following throws a segmentation fault:
```C++
  heif_track_info *track_info = heif_track_info_alloc();
  track_info->with_gimi_track_content_id = true;
  track_info->gimi_track_content_id = "urn:uuid:47df9863-6731-4115-bec2-2073a8da3420";
  heif_track_info_release(track_info);

```
```C++
void heif_track_info_release(struct heif_track_info* info)
{
  if (info) {
    heif_tai_clock_info_release(info->tai_clock_info);
    delete[] info->gimi_track_content_id; // SEGMENTATION FAULT

```

Since `gimi_track_content_id` doesn't dynamically allocate memory, there's no need to call delete on it.