### PR TITLE
Fix call to heif_image_handle_is_primary_image

### DIFF
--- a/post.js
+++ b/post.js
@@ -50,7 +50,7 @@ HeifImage.prototype.get_height = function() {
 };
 
 HeifImage.prototype.is_primary = function() {
-    return !!heif_image_handle_is_primary_image(this.handle);
+    return !!Module.heif_image_handle_is_primary_image(this.handle);
 }
 
 HeifImage.prototype.display = function(image_data, callback) {


### PR DESCRIPTION
The call to heif_image_handle_is_primary_image in HeifImage.prototype.is_primary was missing "Module.", so the function isn't able to be called successfully.