### PR TITLE
yuv2rgb: improve performance of 4:2:0 YUV to RGB conversion by ~15%

### DIFF
--- a/libheif/color-conversion/yuv2rgb.cc
+++ b/libheif/color-conversion/yuv2rgb.cc
@@ -365,14 +365,33 @@ Op_YCbCr420_to_RGB24::convert_colorspace(const std::shared_ptr<const HeifPixelIm
 
   uint32_t x, y;
   for (y = 0; y < height; y++) {
-    for (x = 0; x < width; x++) {
-      int yv = (in_y[y * in_y_stride + x]);
-      int cb = (in_cb[y / 2 * in_cb_stride + x / 2] - 128);
-      int cr = (in_cr[y / 2 * in_cr_stride + x / 2] - 128);
+    // Row pointers for input and output
+    const uint8_t* y_row = &in_y[y * in_y_stride];
+    const uint8_t* cb_row = &in_cb[(y / 2) * in_cb_stride];
+    const uint8_t* cr_row = &in_cr[(y / 2) * in_cr_stride];
+    uint8_t* out_row = &out_p[y * out_p_stride];
 
-      out_p[y * out_p_stride + 3 * x + 0] = clip_int_u8(yv + ((r_cr * cr + 128) >> 8));
-      out_p[y * out_p_stride + 3 * x + 1] = clip_int_u8(yv + ((g_cb * cb + g_cr * cr + 128) >> 8));
-      out_p[y * out_p_stride + 3 * x + 2] = clip_int_u8(yv + ((b_cb * cb + 128) >> 8));
+    // Offsets for first pixel
+    int cb = cb_row[0] - 128;
+    int cr = cr_row[0] - 128;
+    int r_offset = ((r_cr * cr + 128) >> 8);
+    int g_offset = ((g_cb * cb + g_cr * cr + 128) >> 8);
+    int b_offset = ((b_cb * cb + 128) >> 8);
+
+    for (x = 0; x < width; x++) {
+      // Update offsets every other pixel
+      if (x > 0 && (x & 1) == 0) {
+        cb = cb_row[x / 2] - 128;
+        cr = cr_row[x / 2] - 128;
+        r_offset = ((r_cr * cr + 128) >> 8);
+        g_offset = ((g_cb * cb + g_cr * cr + 128) >> 8);
+        b_offset = ((b_cb * cb + 128) >> 8);
+      }
+      int yv = y_row[x];
+      uint8_t* rgb = &out_row[3 * x];
+      rgb[0] = clip_int_u8(yv + r_offset);
+      rgb[1] = clip_int_u8(yv + g_offset);
+      rgb[2] = clip_int_u8(yv + b_offset);
     }
   }
 


### PR DESCRIPTION
I've been doing to profiling of libvips with various formats and the (relatively common) subsampled YUV to RGB colour conversion logic is a hot code path when calling `heif_decode_image` with `heif_colorspace_RGB`.

At first glance this PR appears to make things look slightly more complex, but in my testing the following changes allow the compiler (I'm using gcc) to optimise and auto-vectorise the inner loop more easily:

- Move row pointer calculations out of the inner loop
- Only update offsets every other pixel due to use of sub-sampling

I tested with `-DCMAKE_BUILD_TYPE=Release`, which I think is equivalent to `-O3`, using a 12 megapixel image from https://heic.digital/samples/

Before (best time over 10 runs):
```
$ time vips copy greyhounds-looking-for-a-table.heic out.v

real	0m0.264s
user	0m0.435s
sys	0m0.091s
```

Before (callgrind instruction count):
```
657,897,290 (17.29%)  ???:Op_YCbCr420_to_RGB24::convert_colorspace(std::shared_ptr<HeifPixelImage const> const&, ColorState const&, ColorState const&, heif_color_conversion_options const&, heif_color_conversion_options_ext const&, heif_security_limits const*) const [/usr/local/lib/libheif.so.1.19.8]
483,338,701 (12.70%)  ???:0x000000000002b5d0 [/usr/lib/x86_64-linux-gnu/libde265.so.0.1.8]
```

After (best time over 10 runs):
```
$ time vips copy greyhounds-looking-for-a-table.heic out.v

real	0m0.252s
user	0m0.429s
sys	0m0.089s
```

After (callgrind instruction count):
```
560,347,083 (15.11%)  ???:Op_YCbCr420_to_RGB24::convert_colorspace(std::shared_ptr<HeifPixelImage const> const&, ColorState const&, ColorState const&, heif_color_conversion_options const&, heif_color_conversion_options_ext const&, heif_security_limits const*) const [/usr/local/lib/libheif.so.1.19.8]
483,338,701 (13.04%)  ???:0x000000000002b5d0 [/usr/lib/x86_64-linux-gnu/libde265.so.0.1.8]
```

That's a ~15% reduction in CPU instructions for colour conversion specifically, with the full decode/encode round trip approximately ~5% faster. The output pixel values before and after remain identical.

For full disclosure purposes this PR was partially aided by the Claude Sonnet 3.7 LLM; I understand any desire to reject such changes.
