### PR TITLE
Fix bad rounding resulting in an out-of-bounds read

### DIFF
--- a/libheif/pixelimage.cc
+++ b/libheif/pixelimage.cc
@@ -1087,6 +1087,9 @@ Result<std::shared_ptr<HeifPixelImage>> HeifPixelImage::crop(uint32_t left, uint
     uint32_t plane_top = get_subsampled_size_v(top, channel, m_chroma, scaling_mode::is_divisible); // is always divisible
     uint32_t plane_bottom = get_subsampled_size_v(bottom, channel, m_chroma, scaling_mode::round_up); // keep more chroma
 
+    plane_right = std::min(plane_right, plane.m_width - 1u);
+    plane_bottom = std::min(plane_bottom, plane.m_height - 1u);
+
     auto err = out_img->add_channel(channel,
                                     plane_right - plane_left + 1,
                                     plane_bottom - plane_top + 1,


### PR DESCRIPTION
We stumbled across an image that produced an out-of-bounds read in `HeifPixelImage::ImagePlane::crop`
See [this valgrind output](https://github.com/user-attachments/files/20941402/valgrind_2.txt)

The problem seems to be caused by using a rounded-up image plane size without checking it against the actual bounds of the source plane.