### PR TITLE
Update API versions table for v1.20.x

### DIFF
--- a/libheif/api/libheif/heif_library.h
+++ b/libheif/api/libheif/heif_library.h
@@ -47,6 +47,7 @@ extern "C" {
 //  1.16           5            6             1             1            1            1
 //  1.18           5            7             1             1            1            1
 //  1.19           6            7             2             1            1            1
+//  1.20           7            7             2             1            1            1
 
 #if (defined(_WIN32) || defined __CYGWIN__) && !defined(LIBHEIF_STATIC_BUILD)
 #ifdef LIBHEIF_EXPORTS


### PR DESCRIPTION
Compared to v1.19.x, only the `heif_decoding_options` version was incremented; see commit a18cc33fdeefecdcb99a242281911e22d44c794b.