### PR TITLE
Fix clang++ missing field 'request_range' initializer warnings

### DIFF
--- a/libheif/api/libheif/heif_cxx.h
+++ b/libheif/api/libheif/heif_cxx.h
@@ -552,7 +552,11 @@ namespace heif {
           heif_reader_trampoline_get_position,
           heif_reader_trampoline_read,
           heif_reader_trampoline_seek,
-          heif_reader_trampoline_wait_for_file_size
+          heif_reader_trampoline_wait_for_file_size,
+          NULL,
+          NULL,
+          NULL,
+          NULL,
       };
 
   inline void Context::read_from_reader(Reader& reader, const ReadingOptions& /*opts*/)


### PR DESCRIPTION
Clang++ on macOS will display the following warning message:

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/5fe4003e-5017-4a00-876a-0ccd484ce340" />

Clang++ version: Apple clang version 17.0.0 (clang-1700.0.13.5)
libheif version: 1.20.1 (homebrew)

We can eliminate this warning by explicitly specifying the initialization of all struct members.