### PR TITLE
Expose alpha related functions to javascript

### DIFF
--- a/libheif/api/libheif/heif_emscripten.h
+++ b/libheif/api/libheif/heif_emscripten.h
@@ -315,6 +315,8 @@ EMSCRIPTEN_BINDINGS(libheif) {
     EXPORT_HEIF_FUNCTION(heif_image_handle_get_height);
     EXPORT_HEIF_FUNCTION(heif_image_handle_is_primary_image);
     EXPORT_HEIF_FUNCTION(heif_image_release);
+    EXPORT_HEIF_FUNCTION(heif_image_handle_has_alpha_channel);
+    EXPORT_HEIF_FUNCTION(heif_image_handle_is_premultiplied_alpha);
 
     emscripten::enum_<heif_error_code>("heif_error_code")
     .value("heif_error_Ok", heif_error_Ok)

--- a/post.js
+++ b/post.js
@@ -53,6 +53,14 @@ HeifImage.prototype.is_primary = function() {
     return !!Module.heif_image_handle_is_primary_image(this.handle);
 }
 
+HeifImage.prototype.has_alpha_channel = function() {
+    return !!Module.heif_image_handle_has_alpha_channel(this.handle);
+}
+
+HeifImage.prototype.is_premultiplied_alpha = function() {
+    return !!Module.heif_image_handle_is_premultiplied_alpha(this.handle);
+}
+
 HeifImage.prototype.display = function(image_data, callback) {
     // Defer color conversion.
     var w = this.get_width();


### PR DESCRIPTION
Allow javascript code to call heif_image_handle_has_alpha_channel and heif_image_handle_is_premultiplied_alpha.