### PR TITLE
consolidate property extraction code

### DIFF
--- a/libheif/api/libheif/heif_experimental.cc
+++ b/libheif/api/libheif/heif_experimental.cc
@@ -38,32 +38,19 @@ struct heif_property_camera_intrinsic_matrix
 
 struct heif_error heif_item_get_property_camera_intrinsic_matrix(const struct heif_context* context,
                                                                  heif_item_id itemId,
-                                                                 heif_property_id propertyId,
                                                                  struct heif_property_camera_intrinsic_matrix** out_matrix)
 {
   if (!out_matrix || !context) {
     return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value, "NULL passed"};
   }
 
-  auto file = context->context->get_heif_file();
-
-  std::vector<std::shared_ptr<Box>> properties;
-  Error err = file->get_properties(itemId, properties);
-  if (err) {
-    return err.error_struct(context->context.get());
-  }
-
-  if (propertyId < 1 || propertyId - 1 >= properties.size()) {
-    return {heif_error_Usage_error, heif_suberror_Invalid_property, "property index out of range"};
-  }
-
-  auto cmin = std::dynamic_pointer_cast<Box_cmin>(properties[propertyId - 1]);
+  auto cmin = context->context->find_property<Box_cmin>(itemId);
   if (!cmin) {
-    return {heif_error_Usage_error, heif_suberror_Invalid_property, "wrong property type"};
+    return cmin.error.error_struct(context->context.get());
   }
 
   *out_matrix = new heif_property_camera_intrinsic_matrix;
-  (*out_matrix)->matrix = cmin->get_intrinsic_matrix();
+  (*out_matrix)->matrix = cmin.value->get_intrinsic_matrix();
 
   return heif_error_success;
 }
@@ -206,25 +193,13 @@ struct heif_error heif_item_get_property_camera_extrinsic_matrix(const struct he
     return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value, "NULL passed"};
   }
 
-  auto file = context->context->get_heif_file();
-
-  std::vector<std::shared_ptr<Box>> properties;
-  Error err = file->get_properties(itemId, properties);
-  if (err) {
-    return err.error_struct(context->context.get());
-  }
-
-  if (propertyId < 1 || propertyId - 1 >= properties.size()) {
-    return {heif_error_Usage_error, heif_suberror_Invalid_property, "property index out of range"};
-  }
-
-  auto cmex = std::dynamic_pointer_cast<Box_cmex>(properties[propertyId - 1]);
+  auto cmex = context->context->find_property<Box_cmex>(itemId, propertyId);
   if (!cmex) {
-    return {heif_error_Usage_error, heif_suberror_Invalid_property, "wrong property type"};
+    return cmex.error.error_struct(context->context.get());
   }
 
   *out_matrix = new heif_property_camera_extrinsic_matrix;
-  (*out_matrix)->matrix = cmex->get_extrinsic_matrix();
+  (*out_matrix)->matrix = cmex.value->get_extrinsic_matrix();
 
   return heif_error_success;
 }

--- a/libheif/api/libheif/heif_properties.h
+++ b/libheif/api/libheif/heif_properties.h
@@ -112,17 +112,30 @@ enum heif_transform_mirror_direction
 };
 
 // Will return 'heif_transform_mirror_direction_invalid' in case of error.
+// DEPRECATED - use version that does not take a propertyId since there can only ever be one imir property
 LIBHEIF_API
 enum heif_transform_mirror_direction heif_item_get_property_transform_mirror(const heif_context* context,
                                                                              heif_item_id itemId,
                                                                              heif_property_id propertyId);
 
+// Will return 'heif_transform_mirror_direction_invalid' in case of error.
+LIBHEIF_API
+enum heif_transform_mirror_direction heif_item_get_property_transform_mirror2(const heif_context* context,
+                                                                              heif_item_id itemId);
+
 // Returns only 0, 90, 180, or 270 angle values.
 // Returns -1 in case of error (but it will only return an error in case of wrong usage).
+// DEPRECATED - use version that does not take a propertyId since there can only ever be one irot property
 LIBHEIF_API
 int heif_item_get_property_transform_rotation_ccw(const heif_context* context,
                                                   heif_item_id itemId,
                                                   heif_property_id propertyId);
+
+// Returns only 0, 90, 180, or 270 angle values.
+// Returns -1 in case of error (but it will only return an error in case of wrong usage).
+LIBHEIF_API
+int heif_item_get_property_transform_rotation_ccw2(const heif_context* context,
+                                                   heif_item_id itemId);
 
 // Returns the number of pixels that should be removed from the four edges.
 // Because of the way this data is stored, you have to pass the image size at the moment of the crop operation
@@ -133,6 +146,16 @@ void heif_item_get_property_transform_crop_borders(const heif_context* context,
                                                    heif_property_id propertyId,
                                                    int image_width, int image_height,
                                                    int* left, int* top, int* right, int* bottom);
+
+// Returns the number of pixels that should be removed from the four edges.
+// Because of the way this data is stored, you have to pass the image size at the moment of the crop operation
+// to compute the cropped border sizes.
+// DEPRECATED - use version that does not take a propertyId since there can only ever be one clap property
+LIBHEIF_API
+void heif_item_get_property_transform_crop_borders2(const heif_context* context,
+                                                    heif_item_id itemId,
+                                                    int image_width, int image_height,
+                                                    int* left, int* top, int* right, int* bottom);
 
 /**
  * @param context     The heif_context for the file


### PR DESCRIPTION
This consolidates some duplicate code where we extract properties from items.

It prepares for the text item extended language property, which had more of the duplication.

It does require a "embed the implementation in the header" so that the specialisation is visible, which is slightly ugly.