### PR TITLE
Fix undefined symbol "Error::Ok" in svtenc plugin.

### DIFF
--- a/libheif/plugins/CMakeLists.txt
+++ b/libheif/plugins/CMakeLists.txt
@@ -66,7 +66,7 @@ set(AOM_ENCODER_extra_plugin_sources ../error.cc ../common_utils.cc ../common_ut
 plugin_compilation(aomenc AOM AOM_ENCODER_FOUND AOM_ENCODER AOM_ENCODER)
 
 set(SvtEnc_sources encoder_svt.cc encoder_svt.h)
-set(SvtEnc_extra_plugin_sources ../common_utils.cc ../common_utils.h)
+set(SvtEnc_extra_plugin_sources ../error.cc ../common_utils.cc ../common_utils.h)
 plugin_compilation(svtenc SvtEnc SvtEnc_FOUND SvtEnc SvtEnc)
 
 set(RAV1E_sources encoder_rav1e.cc encoder_rav1e.h)


### PR DESCRIPTION
While packaging libheif 1.20.1 for Debian, I noticed this error while running the tests:
```
7: dlopen: /build/libheif-1.20.1/obj-x86_64-linux-gnu/libheif/plugins/libheif-svtenc.so: undefined symbol: _ZN5Error2OkE
```

Similar to #1541, the plugin needs linking to `error.cc`.

Maybe there should be an internal common static library that is linked by all plugins, so you have to specify these dependencies (together with `common_utils.{cc,h}`) only once.