### PR TITLE
Load plugins in "get_filtered_encoder_descriptors".

### DIFF
--- a/libheif/plugin_registry.cc
+++ b/libheif/plugin_registry.cc
@@ -273,8 +273,6 @@ void register_encoder(const heif_encoder_plugin* encoder_plugin)
 
 const struct heif_encoder_plugin* get_encoder(enum heif_compression_format type)
 {
-  load_plugins_if_not_initialized_yet();
-
   auto filtered_encoder_descriptors = get_filtered_encoder_descriptors(type, nullptr);
   if (filtered_encoder_descriptors.size() > 0) {
     return filtered_encoder_descriptors[0]->plugin;
@@ -289,6 +287,8 @@ std::vector<const struct heif_encoder_descriptor*>
 get_filtered_encoder_descriptors(enum heif_compression_format format,
                                  const char* name)
 {
+  load_plugins_if_not_initialized_yet();
+
   std::vector<const struct heif_encoder_descriptor*> filtered_descriptors;
 
   for (const auto& descr : s_encoder_descriptors) {


### PR DESCRIPTION
The test "tai.cc" checks for HEVC encoding support by calling `heif_context_get_encoder_for_format` (through `get_encoder_or_skip_test`) which internally calls `get_filtered_encoder_descriptors`.

This however doesn't load the plugins, causing the test to be skipped if the HEVC encoder is provided by a plugin.