### PR TITLE
Ignore CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 build
 _build
+CMakeUserPresets.json
 third-party/SVT-AV1/
 third-party/dav1d/
 third-party/libwebp/


### PR DESCRIPTION
Users can override the provided `CMakePresets.json` with their own custom `CMakeUserPresets.json`, which should not be tracked by git.