### PR TITLE
Move check for "bit" header to cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,15 @@ include(GNUInstallDirs)
 # The version number.
 set (PACKAGE_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 
-# Check for unistd.h
+# Check for header files.
+include (${CMAKE_ROOT}/Modules/CheckIncludeFileCXX.cmake)
 
-include (${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
+CHECK_INCLUDE_FILE_CXX(bit HAVE_BIT)
+if (HAVE_BIT)
+  add_definitions(-DHAVE_BIT)
+endif()
 
-CHECK_INCLUDE_FILE(unistd.h HAVE_UNISTD_H)
-
+CHECK_INCLUDE_FILE_CXX(unistd.h HAVE_UNISTD_H)
 if (HAVE_UNISTD_H)
   add_definitions(-DHAVE_UNISTD_H)
 endif()

--- a/libheif/bitstream.cc
+++ b/libheif/bitstream.cc
@@ -24,7 +24,7 @@
 #include <cstring>
 #include <cassert>
 
-#if ((defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__PGI)) && __GNUC__ < 9) || (defined(__clang__) && __clang_major__ < 10)
+#if !defined(HAVE_BIT)
 #include <type_traits>
 #else
 #include <bit>


### PR DESCRIPTION
This fixes an issue when building on older OSX with clang (reported as `Apple LLVM version 10.0.1 (clang-1001.0.46.1)` but doesn't provide the `bit` header.