### PR TITLE
bufix: dereference Result<heif_item_id>

### DIFF
--- a/libheif/api/libheif/heif_items.cc
+++ b/libheif/api/libheif/heif_items.cc
@@ -289,7 +289,7 @@ struct heif_error heif_context_add_mime_item(struct heif_context* ctx,
   Result<heif_item_id> result = ctx->context->get_heif_file()->add_infe_mime(content_type, content_encoding, (const uint8_t*) data, size);
 
   if (result && out_item_id) {
-    *out_item_id = result;
+    *out_item_id = *result;
     return heif_error_success;
   }
   else {


### PR DESCRIPTION
The `heif_context_add_mime_item()` function wasn't returning the correct `heif_item_id`.