### PR TITLE
CMake: add option to disable heif-thumbnailer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libheif.pc
 # ---
 
 option(WITH_EXAMPLES "Build examples" ON)
+option(WITH_EXAMPLE_HEIF_THUMB "Build heif-thumbnailer tool" ON)
 option(WITH_EXAMPLE_HEIF_VIEW "Build heif-view tool" ON)
 option(WITH_GDK_PIXBUF "Build gdk-pixbuf plugin" ON)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -52,7 +52,7 @@ if (WITH_HEADER_COMPRESSION)
 endif ()
 
 
-if (PNG_FOUND)
+if (WITH_EXAMPLE_HEIF_THUMB AND PNG_FOUND)
     add_executable(heif-thumbnailer ${getopt_sources}
             heif_thumbnailer.cc
             common.cc


### PR DESCRIPTION
Modern distros have lately been increasingly switching to sandboxed [glycin](https://gitlab.gnome.org/GNOME/glycin) for thumbnail generation, so this is just an option for streamlined builds...