### PR TITLE
pixelimage: ensure access to ICC profile in colr box

### DIFF
--- a/libheif/pixelimage.cc
+++ b/libheif/pixelimage.cc
@@ -168,7 +168,7 @@ std::shared_ptr<Box_colr> ImageExtraData::get_colr_box_nclx() const
 
 std::shared_ptr<Box_colr> ImageExtraData::get_colr_box_icc() const
 {
-  if (!has_nclx_color_profile()) {
+  if (!has_icc_color_profile()) {
     return {};
   }
 


### PR DESCRIPTION
See commit 1dee796, which appears to have introduced a guard but using the wrong profile type.