### PR TITLE
Add a plugin based on WebCodecs (hardware decoding w/ webassembly)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ option(WITH_UNCOMPRESSED_CODEC " Support internal ISO/IEC 23001-17 uncompressed 
 message("\n=== Summary of compiled codecs ===")
 plugin_compilation_info(LIBDE265 LIBDE265 "libde265 HEVC decoder")
 plugin_compilation_info(FFMPEG_DECODER FFMPEG_avcodec "FFMPEG HEVC decoder (HW acc)")
+plugin_compilation_info(WEBCODECS WEBCODECS "WebCodecs HEVC decoder")
 plugin_compilation_info(X265 X265 "x265 HEVC encoder")
 plugin_compilation_info(KVAZAAR KVAZAAR "Kvazaar HEVC encoder")
 plugin_compilation_info(AOM_DECODER AOM_DECODER "AOM AV1 decoder")
@@ -332,7 +333,7 @@ macro(format_compilation_info formatName decoding_supported encoding_supported)
 endmacro()
 
 
-if (LIBDE265_FOUND OR FFMPEG_avcodec_FOUND)
+if (LIBDE265_FOUND OR FFMPEG_avcodec_FOUND OR WITH_WEBCODECS)
     set(SUPPORTS_HEIC_DECODING TRUE)
 endif()
 if (X265_FOUND OR KVAZAAR_FOUND)

--- a/build-emscripten.sh
+++ b/build-emscripten.sh
@@ -23,6 +23,8 @@ ENABLE_LIBDE265="${ENABLE_LIBDE265:-1}"
 LIBDE265_VERSION="${LIBDE265_VERSION:-1.0.15}"
 ENABLE_AOM="${ENABLE_AOM:-0}"
 AOM_VERSION="${AOM_VERSION:-3.6.1}"
+# Webcodecs is not on by default b/c asyncify increases the binary size considerably
+ENABLE_WEBCODECS="${ENABLE_WEBCODECS:-0}"
 STANDALONE="${STANDALONE:-0}"
 DEBUG="${DEBUG:-0}"
 USE_ES6="${USE_ES6:-0}"
@@ -88,6 +90,11 @@ if [ "$ENABLE_AOM" = "1" ]; then
     LIBRARY_LINKER_FLAGS="$LIBRARY_LINKER_FLAGS -L${AOM_DIR} -laom"
 fi
 
+CONFIGURE_ARGS_WEBCODECS=""
+if [ "$ENABLE_WEBCODECS" = "1" ]; then
+    CONFIGURE_ARGS_WEBCODECS="-DWITH_WEBCODECS=ON"
+fi
+
 EXTRA_EXE_LINKER_FLAGS="-lembind"
 EXTRA_COMPILER_FLAGS=""
 if [ "$STANDALONE" = "1" ]; then
@@ -102,7 +109,8 @@ emcmake cmake ${SRCDIR} $CONFIGURE_ARGS \
     -DCMAKE_CXX_FLAGS="${EXTRA_COMPILER_FLAGS}" \
     -DCMAKE_EXE_LINKER_FLAGS="${LIBRARY_LINKER_FLAGS} ${EXTRA_EXE_LINKER_FLAGS}" \
     $CONFIGURE_ARGS_LIBDE265 \
-    $CONFIGURE_ARGS_AOM
+    $CONFIGURE_ARGS_AOM \
+    $CONFIGURE_ARGS_WEBCODECS
 
 VERBOSE=1 emmake make -j${CORES}
 
@@ -112,6 +120,10 @@ EXPORTED_FUNCTIONS=$($EMSDK/upstream/bin/llvm-nm $LIBHEIFA --format=just-symbols
 echo "Running Emscripten..."
 
 BUILD_FLAGS="-lembind -o libheif.js --post-js ${SRCDIR}/post.js -sWASM=$USE_WASM -sDYNAMIC_EXECUTION=$USE_UNSAFE_EVAL"
+
+if [ "$ENABLE_WEBCODECS" = "1" ]; then
+    BUILD_FLAGS="$BUILD_FLAGS -sASYNCIFY -sASYNCIFY_IMPORTS=['decode_with_browser_hevc']"
+fi
 
 if [ "$USE_TYPESCRIPT" = "1" ]; then
     BUILD_FLAGS="$BUILD_FLAGS --emit-tsd libheif.d.ts"
@@ -140,12 +152,8 @@ emcc -Wl,--whole-archive "$LIBHEIFA" -Wl,--no-whole-archive \
     -sEXPORT_NAME="libheif" \
     -sWASM_ASYNC_COMPILATION=0 \
     -sALLOW_MEMORY_GROWTH \
-    # Asyncify options need to be included to use webcodecs decoder
-    # -sASYNCIFY=1 \
-    # -sASYNCIFY_IMPORTS=[decode_with_browser_hevc] \
     -std=c++11 \
     $LIBRARY_INCLUDE_FLAGS \
     $LIBRARY_LINKER_FLAGS \
     $BUILD_FLAGS \
     $RELEASE_BUILD_FLAGS
-

--- a/build-emscripten.sh
+++ b/build-emscripten.sh
@@ -140,8 +140,12 @@ emcc -Wl,--whole-archive "$LIBHEIFA" -Wl,--no-whole-archive \
     -sEXPORT_NAME="libheif" \
     -sWASM_ASYNC_COMPILATION=0 \
     -sALLOW_MEMORY_GROWTH \
+    # Asyncify options need to be included to use webcodecs decoder
+    # -sASYNCIFY=1 \
+    # -sASYNCIFY_IMPORTS=[decode_with_browser_hevc] \
     -std=c++11 \
     $LIBRARY_INCLUDE_FLAGS \
     $LIBRARY_LINKER_FLAGS \
     $BUILD_FLAGS \
     $RELEASE_BUILD_FLAGS
+

--- a/libheif/api/libheif/heif_emscripten.h
+++ b/libheif/api/libheif/heif_emscripten.h
@@ -336,7 +336,7 @@ static emscripten::val heif_js_decode_image2(struct heif_image_handle* handle,
     return emscripten::val(err);
   }
 
-  result.set("image", image);
+  result.set("image", image, emscripten::allow_raw_pointers());
 
   int width = heif_image_handle_get_width(handle);
   result.set("width", width);

--- a/libheif/plugin_registry.cc
+++ b/libheif/plugin_registry.cc
@@ -25,6 +25,9 @@
 #include "plugin_registry.h"
 #include "init.h"
 
+#if HAVE_WEBCODECS
+#include "third_party/libheif/libheif/plugins/decoder_webcodecs.h"
+#endif
 
 #if HAVE_LIBDE265
 #include "plugins/decoder_libde265.h"
@@ -140,6 +143,10 @@ public:
 
 void register_default_plugins()
 {
+#if HAVE_WEBCODECS
+  register_decoder(get_decoder_plugin_webcodecs());
+#endif
+
 #if HAVE_LIBDE265
   register_decoder(get_decoder_plugin_libde265());
 #endif

--- a/libheif/plugins/CMakeLists.txt
+++ b/libheif/plugins/CMakeLists.txt
@@ -105,6 +105,10 @@ set(UVG266_sources encoder_uvg266.cc encoder_uvg266.h)
 set(UVG266_extra_plugin_sources)
 plugin_compilation(uvg266 UVG266 UVG266_FOUND UVG266 UVG266)
 
+set(WEBCODECS_sources decoder_webcodecs.h decoder_webcodecs.cc)
+set(WEBCODECS_extra_plugin_sources ../error.cc nalu_utils.cc)
+plugin_compilation(webcodecs WEBCODECS WEBCODECS_FOUND WEBCODECS WEBCODECS)
+
 set(VVDEC_sources decoder_vvdec.cc decoder_vvdec.h)
 set(VVDEC_extra_plugin_sources)
 plugin_compilation(vvdec vvdec vvdec_FOUND VVDEC VVDEC)

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -83,13 +83,6 @@ EM_JS(emscripten::EM_VAL, decode_with_browser_hevc, (const char *codec_ptr, uint
     }
 
     function handleEmptyFormat(decoded) {
-      if (typeof OffscreenCanvas === 'undefined') {
-        returnError(new Error('OffscreenCanvas is not available, but is required to decode this HEIC image.'));
-
-        decoded.close();
-        return;
-      }
-
       const canvas = new OffscreenCanvas(decoded.codedWidth, decoded.codedHeight);
       const context = canvas.getContext('2d');
       context.drawImage(decoded, 0, 0);
@@ -106,6 +99,12 @@ EM_JS(emscripten::EM_VAL, decode_with_browser_hevc, (const char *codec_ptr, uint
       }));
 
       decoded.close();
+    }
+
+    if (typeof VideoDecoder === 'undefined') {
+      returnError(new Error('VideoDecoder API is not available'));
+
+      return;
     }
 
     const decoder = new VideoDecoder({

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -749,10 +749,10 @@ const struct heif_decoder_plugin* get_decoder_plugin_webcodecs()
   return &decoder_webcodecs;
 }
 
-// #if PLUGIN_WEBCODECS
+#if PLUGIN_WEBCODECS
 heif_plugin_info plugin_info {
   1,
   heif_plugin_type_decoder,
   &decoder_webcodecs
 };
-// #endif
+#endif

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -1,0 +1,700 @@
+/*
+ * HEIF codec.
+ * Copyright (c) 2017 Dirk Farin <dirk.farin@gmail.com>
+ *
+ * This file is part of libheif.
+ *
+ * libheif is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * libheif is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libheif.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libheif/heif.h"
+#include "libheif/heif_plugin.h"
+#include "decoder_webcodecs.h"
+#include "libheif/codecs/hevc_boxes.h"
+#include "libheif/bitstream.h"
+
+#include <assert.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/bind.h>
+#include <memory>
+#include <cstring>
+#include <queue>
+#include <sstream>
+#include <iomanip>
+
+#include "third_party/libheif/libheif/plugins/nalu_utils.h"
+
+struct NALUnit {
+  void* data;
+  size_t size;
+};
+
+struct webcodecs_decoder
+{
+  std::queue<NALUnit> data_queue;
+};
+
+static const char kEmptyString[] = "";
+static const char kSuccess[] = "Success";
+
+static const int WEBCODECS_PLUGIN_PRIORITY = 80;
+
+#define MAX_PLUGIN_NAME_LENGTH 80
+
+static char plugin_name[MAX_PLUGIN_NAME_LENGTH];
+
+/** 
+ * Decodes a HEVC frame using the browser's WebCodecs API. This implementation
+ * prefers hardware decoding when available.
+ *
+ * As of this writing, most HEIC images will be decoded directly into the NV12
+ * pixel format. For images returned in NV12 format, the format will be
+ * preserved when returning the data to C++.
+ *
+ * Any other image format returned by the WebCodecs API will be converted to
+ * RGBA before being returned to C++ to ensure that the result can be
+ * property interpreted by the plugin.
+ * 
+ * Note that the WebCodecs API don't support converting into NV12 format in
+ * cases where the native pixel format is something else. That's why RGBA is
+ * used as a fallback format, b/c the browser can always convert to it.
+ */
+EM_JS(emscripten::EM_VAL, decode_with_browser_hevc, (const char *codec_ptr, uintptr_t hvcc_record_ptr, size_t hvcc_record_size, uintptr_t data_ptr, size_t data_size), {
+  return Asyncify.handleSleep((callback) => {
+    const codec = UTF8ToString(codec_ptr);
+    const data = HEAPU8.subarray(data_ptr, data_ptr + data_size);
+    const description = HEAPU8.subarray(hvcc_record_ptr, hvcc_record_ptr + hvcc_record_size);
+    let returnedError = false;
+
+    function returnError(err) {
+      if (!returnedError) {
+        returnedError = true;
+
+        console.error(err);
+        callback({'error': err.stack});
+      }
+    }
+
+    const decoder = new VideoDecoder({
+      output: (decoded) => {
+        const format = decoded.format === 'NV12' ? 'NV12' : 'RGBA';
+        const formatOptions = format === 'NV12' ?
+          {} :
+          {'format': format, 'colorSpace': 'srgb'};
+        const bufferSize = format === 'NV12' ?
+          decoded.allocationSize() :
+          decoded.codedWidth * decoded.codedHeight * 4;
+        const buffer = new Uint8Array(bufferSize);
+
+        Promise.resolve().then(
+          () => decoded.copyTo(buffer, formatOptions)
+        ).then((planes) => {
+          callback(Emval.toHandle({
+            'buffer': buffer,
+            'format': format,
+            'planes': planes,
+            'codedWidth': decoded.codedWidth, 
+            'codedHeight': decoded.codedHeight,
+          }));
+
+          decoded.close();
+        }).catch((e) => {
+          returnError(e);
+        });
+      },
+      error: (e) => {
+        returnError(e);
+      }
+    });
+
+    try {
+      decoder.configure({
+        codec,
+        hardwareAcceleration: 'prefer-hardware',
+        optimizeForLatency: true,
+        description,
+      });
+
+      const chunk = new EncodedVideoChunk({
+        timestamp: 0,
+        type: 'key',
+        data: data,
+      });
+
+      decoder.decode(chunk);
+      decoder.flush();
+    } catch (e) {
+      returnError(e);
+    }
+  });
+});
+
+
+static std::vector<uint8_t> remove_start_code_emulation2(const uint8_t* sps, size_t size)
+{
+  std::vector<uint8_t> out_data;
+
+  for (size_t i = 0; i < size; i++) {
+    if (i + 2 < size &&
+        sps[i] == 0 &&
+        sps[i + 1] == 0 &&
+        sps[i + 2] == 3) {
+      out_data.push_back(0);
+      out_data.push_back(0);
+      i += 2;
+    }
+    else {
+      out_data.push_back(sps[i]);
+    }
+  }
+
+  return out_data;
+}
+
+
+Error parse_sps_for_hvcC_configuration2(const uint8_t* sps, size_t size,
+                                       HEVCDecoderConfigurationRecord* config,
+                                       int* width, int* height)
+{
+  // remove start-code emulation bytes from SPS header stream
+
+  std::vector<uint8_t> sps_no_emul = remove_start_code_emulation2(sps, size);
+
+  sps = sps_no_emul.data();
+  size = sps_no_emul.size();
+
+
+  BitReader reader(sps, (int) size);
+
+  // skip NAL header
+  reader.skip_bits(2 * 8);
+
+  // skip VPS ID
+  reader.skip_bits(4);
+
+  uint8_t nMaxSubLayersMinus1 = reader.get_bits8(3);
+
+  config->temporal_id_nested = reader.get_bits8(1);
+
+  // --- profile_tier_level ---
+
+  config->general_profile_space = reader.get_bits8(2);
+  config->general_tier_flag = reader.get_bits8(1);
+  config->general_profile_idc = reader.get_bits8(5);
+  config->general_profile_compatibility_flags = reader.get_bits32(32);
+
+  reader.skip_bits(16); // skip reserved bits
+  reader.skip_bits(16); // skip reserved bits
+  reader.skip_bits(16); // skip reserved bits
+
+  config->general_level_idc = reader.get_bits8(8);
+
+  std::vector<bool> layer_profile_present(nMaxSubLayersMinus1);
+  std::vector<bool> layer_level_present(nMaxSubLayersMinus1);
+
+  for (int i = 0; i < nMaxSubLayersMinus1; i++) {
+    layer_profile_present[i] = reader.get_bits(1);
+    layer_level_present[i] = reader.get_bits(1);
+  }
+
+  if (nMaxSubLayersMinus1 > 0) {
+    for (int i = nMaxSubLayersMinus1; i < 8; i++) {
+      reader.skip_bits(2);
+    }
+  }
+
+  for (int i = 0; i < nMaxSubLayersMinus1; i++) {
+    if (layer_profile_present[i]) {
+      reader.skip_bits(2 + 1 + 5);
+      reader.skip_bits(32);
+      reader.skip_bits(16);
+    }
+
+    if (layer_level_present[i]) {
+      reader.skip_bits(8);
+    }
+  }
+
+
+  // --- SPS continued ---
+
+  int dummy, value;
+  reader.get_uvlc(&dummy); // skip seq_parameter_seq_id
+
+  reader.get_uvlc(&value);
+  config->chroma_format = (uint8_t) value;
+
+  if (config->chroma_format == 3) {
+    reader.skip_bits(1);
+  }
+
+  reader.get_uvlc(width);
+  reader.get_uvlc(height);
+
+  bool conformance_window = reader.get_bits(1);
+  if (conformance_window) {
+    int left, right, top, bottom;
+    reader.get_uvlc(&left);
+    reader.get_uvlc(&right);
+    reader.get_uvlc(&top);
+    reader.get_uvlc(&bottom);
+
+    //printf("conformance borders: %d %d %d %d\n",left,right,top,bottom);
+
+    int subH = 1, subV = 1;
+    if (config->chroma_format == 1) {
+      subV = 2;
+      subH = 2;
+    }
+    if (config->chroma_format == 2) { subH = 2; }
+
+    *width -= subH * (left + right);
+    *height -= subV * (top + bottom);
+  }
+
+  reader.get_uvlc(&value);
+  config->bit_depth_luma = (uint8_t) (value + 8);
+
+  reader.get_uvlc(&value);
+  config->bit_depth_chroma = (uint8_t) (value + 8);
+
+
+
+  // --- init static configuration fields ---
+
+  config->configuration_version = 1;
+  config->min_spatial_segmentation_idc = 0; // TODO: get this value from the VUI, 0 should be safe
+  config->parallelism_type = 0; // TODO, 0 should be safe
+  config->avg_frame_rate = 0; // makes no sense for HEIF
+  config->constant_frame_rate = 0; // makes no sense for HEIF
+  config->num_temporal_layers = 1; // makes no sense for HEIF
+
+  return Error::Ok;
+}
+
+
+static const char* webcodecs_plugin_name()
+{
+  strcpy(plugin_name, "Webcodecs HEVC decoder");
+
+  const char* webcodecs_version = "1";
+
+  if (strlen(webcodecs_version) + 10 < MAX_PLUGIN_NAME_LENGTH) {
+    strcat(plugin_name, ", version ");
+    strcat(plugin_name, webcodecs_version);
+  }
+
+  return plugin_name;
+}
+
+
+static void webcodecs_init_plugin()
+{
+
+}
+
+
+static void webcodecs_deinit_plugin()
+{
+
+}
+
+
+static int webcodecs_does_support_format(enum heif_compression_format format)
+{
+  if (format == heif_compression_HEVC) {
+    return WEBCODECS_PLUGIN_PRIORITY;
+  }
+  else {
+    return 0;
+  }
+}
+
+
+static struct heif_error webcodecs_new_decoder(void** dec)
+{
+  struct webcodecs_decoder* decoder = new webcodecs_decoder();
+  struct heif_error err = {heif_error_Ok, heif_suberror_Unspecified, kSuccess};
+
+  *dec = decoder;
+  return err;
+}
+
+
+static void webcodecs_free_decoder(void* decoder_raw)
+{
+  struct webcodecs_decoder* decoder = (struct webcodecs_decoder*) decoder_raw;
+
+  delete decoder;
+}
+
+
+static struct heif_error webcodecs_push_data(void* decoder_raw, const void* data, size_t size)
+{
+  struct webcodecs_decoder* decoder = (struct webcodecs_decoder*) decoder_raw;
+
+  const uint8_t* cdata = (const uint8_t*) data;
+
+  size_t ptr = 0;
+  while (ptr < size) {
+    if (4 > size - ptr) {
+      struct heif_error err = {heif_error_Decoder_plugin_error,
+                               heif_suberror_End_of_data,
+                               kEmptyString};
+      return err;
+    }
+
+    uint32_t nal_size = static_cast<uint32_t>((cdata[ptr] << 24) | (cdata[ptr + 1] << 16) | (cdata[ptr + 2] << 8) | (cdata[ptr + 3]));
+    ptr += 4;
+
+    if (nal_size > size - ptr) {
+      struct heif_error err = {heif_error_Decoder_plugin_error,
+                               heif_suberror_End_of_data,
+                               kEmptyString};
+      return err;
+    }
+
+    NALUnit nal_unit = {(void*)(cdata + ptr), nal_size};
+    decoder->data_queue.push(nal_unit);
+    ptr += nal_size;
+  }
+
+
+  struct heif_error err = {heif_error_Ok, heif_suberror_Unspecified, kSuccess};
+  return err;
+}
+
+
+static struct heif_error convert_webcodecs_result_to_heif_image(const std::unique_ptr<uint8_t[]>& buffer,
+                                                    int width, int height,
+                                                    int y_offset, int y_src_stride,
+                                                    int uv_offset, int uv_src_stride,
+                                                    struct heif_image** out_img) {
+  heif_error err;
+  err = heif_image_create(width,
+                          height,
+                          heif_colorspace_YCbCr,
+                          heif_chroma_420,
+                          out_img);
+  if (err.code) {
+    return err;
+  }
+
+  err = heif_image_add_plane(*out_img, heif_channel_Y, width, height, 8);
+  if (err.code) {
+    heif_image_release(*out_img);
+    return err;
+  }
+
+  err = heif_image_add_plane(*out_img, heif_channel_Cb, width / 2, height / 2, 8);
+  if (err.code) {
+    heif_image_release(*out_img);
+    return err;
+  }
+
+  err = heif_image_add_plane(*out_img, heif_channel_Cr, width / 2, height / 2, 8);
+  if (err.code) {
+    heif_image_release(*out_img);
+    return err;
+  }
+
+  int y_stride;
+  uint8_t* y_dst = heif_image_get_plane(*out_img, heif_channel_Y, &y_stride);
+
+  for (int i = 0; i < height; ++i) {
+    memcpy(y_dst + i * y_stride,
+           buffer.get() + y_offset + i * y_src_stride,
+           width);
+  }
+
+  int u_stride;
+  uint8_t* u_dst = heif_image_get_plane(*out_img, heif_channel_Cb, &u_stride);
+  int v_stride;
+  uint8_t* v_dst = heif_image_get_plane(*out_img, heif_channel_Cr, &v_stride);
+
+  for (int i = 0; i < height / 2; ++i) {
+    uint8_t* uv_src = buffer.get() + uv_offset + i * uv_src_stride;
+    for (int j = 0; j < width / 2; ++j) {
+      u_dst[i * u_stride + j] = uv_src[j * 2];
+      v_dst[i * v_stride + j] = uv_src[j * 2 + 1];
+    }
+  }
+
+  return {heif_error_Ok, heif_suberror_Unspecified, kSuccess};
+}
+
+/** 
+ * Generates a HEVC codec string as defined in ISO/IEC 14496-15 specification,
+ * Annex E.3.
+ */
+static std::string get_hevc_codec_string(const HEVCDecoderConfigurationRecord& config) {
+  std::string codec_string = "hvc1.";
+
+  // Profile IDC
+  codec_string += std::to_string(config.general_profile_idc);
+  codec_string += ".";
+
+  // Profile Compatibility Flags
+  uint32_t profile_compatibility_flags = config.general_profile_compatibility_flags;
+  char buffer[9];
+  snprintf(buffer, sizeof(buffer), "%X", profile_compatibility_flags);
+  codec_string += buffer;
+  codec_string += ".";
+
+  // Tier and Level
+  codec_string += (config.general_tier_flag ? "H" : "L");
+  codec_string += std::to_string(config.general_level_idc);
+  codec_string += ".";
+
+  // Constraint Indicator Flags
+  uint64_t constraint_flags = 0;
+  for (int i = 0; i < 48; ++i) {
+    if (config.general_constraint_indicator_flags[i]) {
+      constraint_flags |= (1ULL << (47 - i));
+    }
+  }
+  snprintf(buffer, sizeof(buffer), "%06X", (unsigned int)(constraint_flags >> 24));
+  codec_string += buffer;
+
+  return codec_string;
+}
+
+static void convert_rgba_to_nv12(const uint8_t* rgba_buffer, int width, int height, int rgba_stride,
+                                 uint8_t* y_buffer, uint8_t* uv_buffer, int y_stride, int uv_stride) {
+  for (int i = 0; i < height; ++i) {
+    for (int j = 0; j < width; ++j) {
+      const uint8_t* pixel = rgba_buffer + i * rgba_stride + j * 4;
+      uint8_t r = pixel[0];
+      uint8_t g = pixel[1];
+      uint8_t b = pixel[2];
+
+      y_buffer[i * y_stride + j] = static_cast<uint8_t>(0.299 * r + 0.587 * g + 0.114 * b);
+
+      if (i % 2 == 0 && j % 2 == 0) {
+        uv_buffer[(i / 2) * uv_stride + j] = static_cast<uint8_t>(-0.168736 * r - 0.331264 * g + 0.5 * b + 128);
+        uv_buffer[(i / 2) * uv_stride + j + 1] = static_cast<uint8_t>(0.5 * r - 0.418688 * g - 0.081312 * b + 128);
+      }
+    }
+  }
+}
+
+
+static struct heif_error webcodecs_decode_image(void* decoder_raw,
+                                                  struct heif_image** out_img)
+{
+  struct webcodecs_decoder* decoder = (struct webcodecs_decoder*) decoder_raw;
+  *out_img = nullptr;
+
+  if (decoder->data_queue.size() < 4) {
+    return {heif_error_Decoder_plugin_error,
+            heif_suberror_End_of_data,
+            "Not enough NAL units in queue"};
+  }
+
+  // This code assumes that the NAL units are in the following order: VPS, SPS,
+  // PPS, and then the HEVC binary data for the frame. If it's possible for the
+  // ordering of NAL units to be different, then this could would need to be
+  // updated to handle that.
+  NALUnit vps_nal_unit = decoder->data_queue.front();
+  decoder->data_queue.pop();
+  NALUnit sps_nal_unit = decoder->data_queue.front();
+  decoder->data_queue.pop();
+  NALUnit pps_nal_unit = decoder->data_queue.front();
+  decoder->data_queue.pop();
+  NALUnit data_unit = decoder->data_queue.front();
+
+  HEVCDecoderConfigurationRecord config;
+  int w, h;
+  Error err = parse_sps_for_hvcC_configuration2((const uint8_t*)sps_nal_unit.data, sps_nal_unit.size, &config, &w, &h);
+  if (err != Error::Ok) {
+    return {heif_error_Decoder_plugin_error,
+            heif_suberror_Unspecified,
+            "Failed to parse SPS"};
+  }
+
+  config.m_nal_array.push_back(HEVCDecoderConfigurationRecord::NalArray{0, NAL_UNIT_VPS_NUT, {std::vector<uint8_t>((uint8_t*)vps_nal_unit.data, (uint8_t*)vps_nal_unit.data + vps_nal_unit.size)}});
+  config.m_nal_array.push_back(HEVCDecoderConfigurationRecord::NalArray{0, NAL_UNIT_SPS_NUT, {std::vector<uint8_t>((uint8_t*)sps_nal_unit.data, (uint8_t*)sps_nal_unit.data + sps_nal_unit.size)}});
+  config.m_nal_array.push_back(HEVCDecoderConfigurationRecord::NalArray{0, NAL_UNIT_PPS_NUT, {std::vector<uint8_t>((uint8_t*)pps_nal_unit.data, (uint8_t*)pps_nal_unit.data + pps_nal_unit.size)}});
+
+  StreamWriter writer;
+  config.write(writer);
+  std::vector<uint8_t> hvcc_record = writer.get_data();
+
+  // The WebCodecs API expects the NAL unit to be prefixed with its size (4 bytes, big-endian).
+  size_t nal_size = data_unit.size;
+  std::vector<uint8_t> data_with_size(4 + nal_size);
+  // Write length in Big Endian
+  data_with_size[0] = (nal_size >> 24) & 0xFF;
+  data_with_size[1] = (nal_size >> 16) & 0xFF;
+  data_with_size[2] = (nal_size >> 8) & 0xFF;
+  data_with_size[3] = nal_size & 0xFF;
+  // Append NAL payload
+  memcpy(data_with_size.data() + 4, data_unit.data, nal_size);
+
+  std::string codec_string = get_hevc_codec_string(config);
+
+  emscripten::val result = emscripten::val::take_ownership(
+    decode_with_browser_hevc(
+      codec_string.c_str(),
+      (uintptr_t)hvcc_record.data(),
+      hvcc_record.size(),
+      (uintptr_t)data_with_size.data(),
+      data_with_size.size()
+    )
+  );
+
+  if (!result["error"].isUndefined()) {
+    static char error_message[256];
+    std::string error_str = result["error"].as<std::string>();
+    snprintf(error_message, sizeof(error_message), "%s", error_str.c_str());
+    return {heif_error_Decoder_plugin_error,
+            heif_suberror_Unspecified,
+            error_message};
+  }
+
+  if (result.isUndefined()) {
+    return {heif_error_Decoder_plugin_error,
+            heif_suberror_Unspecified,
+            "Decoding failed: decode_with_browser_hevc returned undefined"};
+  }
+
+  emscripten::val js_array = result["buffer"];
+  if (js_array.isUndefined()) {
+    return {heif_error_Decoder_plugin_error,
+            heif_suberror_Unspecified,
+            "Decoding failed: result.buffer is undefined"};
+  }
+
+  const size_t len = js_array["length"].as<size_t>();
+  std::unique_ptr<uint8_t[]> buffer(new uint8_t[len]);
+  emscripten::val memory_view(emscripten::typed_memory_view(len, buffer.get()));
+  memory_view.call<void>("set", js_array);
+
+  const int width = result["codedWidth"].as<int>();
+  const int height = result["codedHeight"].as<int>();
+  std::string format = result["format"].as<std::string>();
+
+  emscripten::val planes = result["planes"];
+  if (planes.isUndefined() || !planes.isArray()) {
+    return {heif_error_Decoder_plugin_error,
+            heif_suberror_Unspecified,
+            "Decoding failed: result.planes is undefined or not an array"};
+  }
+
+  // Most HEIC images in the browser will be decoded natively in NV12 pixel
+  // format. Using the bytes directly helps retain the original image fidelity.
+  if (format == "NV12") {
+    if (planes["length"].as<size_t>() < 2) {
+      return {heif_error_Decoder_plugin_error,
+              heif_suberror_Unspecified,
+              "Decoding failed: NV12 format requires at least 2 planes"};
+    }
+
+    emscripten::val y_plane = planes[0];
+    if (y_plane.isUndefined()) {
+      return {heif_error_Decoder_plugin_error,
+              heif_suberror_Unspecified,
+              "Decoding failed: result.planes[0] is undefined"};
+    }
+
+    emscripten::val uv_plane = planes[1];
+    if (uv_plane.isUndefined()) {
+      return {heif_error_Decoder_plugin_error,
+              heif_suberror_Unspecified,
+              "Decoding failed: result.planes[1] is undefined"};
+    }
+
+    const int y_offset = y_plane["offset"].as<int>();
+    const int y_src_stride = y_plane["stride"].as<int>();
+    const int uv_offset = uv_plane["offset"].as<int>();
+    const int uv_src_stride = uv_plane["stride"].as<int>();
+
+    return convert_webcodecs_result_to_heif_image(buffer, width, height, y_offset, y_src_stride, uv_offset, uv_src_stride, out_img);
+  } else if (format == "RGBA") {
+    // Also handle RGBA images as a fallback in cases where the browser returns
+    // something other than NV12. As of now only RGBA is handled as an
+    // alternative format for simplicity's sake, but other formats could be
+    // handled explicitly in the future.
+
+    if (planes["length"].as<size_t>() < 1) {
+      return {heif_error_Decoder_plugin_error,
+              heif_suberror_Unspecified,
+              "Decoding failed: RGBA format requires at least 1 plane"};
+    }
+
+    emscripten::val rgba_plane = planes[0];
+    if (rgba_plane.isUndefined()) {
+      return {heif_error_Decoder_plugin_error,
+              heif_suberror_Unspecified,
+              "Decoding failed: result.planes[0] is undefined"};
+    }
+
+    const int rgba_offset = rgba_plane["offset"].as<int>();
+    const int rgba_src_stride = rgba_plane["stride"].as<int>();
+
+    size_t y_size = width * height;
+    size_t uv_size = width * height / 2;
+    std::unique_ptr<uint8_t[]> nv12_buffer(new uint8_t[y_size + uv_size]);
+    uint8_t* y_buffer = nv12_buffer.get();
+    uint8_t* uv_buffer = nv12_buffer.get() + y_size;
+
+    // The image is converted to NV12 in order to minimize memory usage, and
+    // also allows for code reuse of convert_webcodecs_result_to_heif_image.
+    convert_rgba_to_nv12(buffer.get() + rgba_offset, width, height, rgba_src_stride,
+                         y_buffer, uv_buffer, width, width);
+
+    return convert_webcodecs_result_to_heif_image(nv12_buffer, width, height, 0, width, y_size, width, out_img);
+  } else {
+    return {heif_error_Decoder_plugin_error,
+            heif_suberror_Unsupported_color_conversion,
+            "Decoding failed: format is not NV12 or RGBA"};
+  }
+}
+
+
+void webcodecs_set_strict_decoding(void* decoder_raw, int flag)
+{
+
+}
+
+
+static const struct heif_decoder_plugin decoder_webcodecs
+    {
+        1,
+        webcodecs_plugin_name,
+        webcodecs_init_plugin,
+        webcodecs_deinit_plugin,
+        webcodecs_does_support_format,
+        webcodecs_new_decoder,
+        webcodecs_free_decoder,
+        webcodecs_push_data,
+        webcodecs_decode_image,
+        webcodecs_set_strict_decoding,
+        "webcodecs"
+    };
+
+
+
+const struct heif_decoder_plugin* get_decoder_plugin_webcodecs()
+{
+  return &decoder_webcodecs;
+}
+
+// #if PLUGIN_WEBCODECS
+heif_plugin_info plugin_info {
+  1,
+  heif_plugin_type_decoder,
+  &decoder_webcodecs
+};
+// #endif

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -107,7 +107,7 @@ EM_JS(emscripten::EM_VAL, decode_with_browser_hevc, (const char *codec_ptr, uint
         // case the VideoFrame.copyTo API doesn't work, however, it does work
         // to draw the VideoFrame to a Canvas and then extract the image bytes.
         // Drawing to a canvas is slower than copyTo, so only use it when
-        //necessary.
+        // necessary.
         if (!decoded.format) {
           handleEmptyFormat(decoded);
           return;

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -1,6 +1,6 @@
 /*
  * HEIF codec.
- * Copyright (c) 2017 Dirk Farin <dirk.farin@gmail.com>
+ * Copyright (c) 2025 Dirk Farin <dirk.farin@gmail.com>
  *
  * This file is part of libheif.
  *
@@ -18,22 +18,18 @@
  * along with libheif.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "libheif/heif.h"
-#include "libheif/heif_plugin.h"
 #include "decoder_webcodecs.h"
+#include "libheif/heif_plugin.h"
 #include "libheif/codecs/hevc_boxes.h"
 #include "libheif/bitstream.h"
+#include "libheif/plugins/nalu_utils.h"
 
 #include <assert.h>
+#include <cstring>
 #include <emscripten/emscripten.h>
 #include <emscripten/bind.h>
 #include <memory>
-#include <cstring>
-#include <queue>
-#include <sstream>
-#include <iomanip>
 
-#include "third_party/libheif/libheif/plugins/nalu_utils.h"
 
 struct NALUnit {
   void* data;

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -409,6 +409,8 @@ static struct heif_error convert_webcodecs_result_to_heif_image(const std::uniqu
     return err;
   }
 
+  // The y plane can be reused as-is.
+
   int y_stride;
   uint8_t* y_dst = heif_image_get_plane(*out_img, heif_channel_Y, &y_stride);
 
@@ -417,6 +419,10 @@ static struct heif_error convert_webcodecs_result_to_heif_image(const std::uniqu
            buffer.get() + y_offset + i * y_src_stride,
            width);
   }
+
+  // In the NV12 format, the U and V planes are interleaved (UVUVUV...), whereas
+  // in libheif they are two separate planes. This code splits the interleaved UV
+  // bytes into two separate planes for use in libheif.
 
   int u_stride;
   uint8_t* u_dst = heif_image_get_plane(*out_img, heif_channel_Cb, &u_stride);

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -64,7 +64,7 @@ static char plugin_name[MAX_PLUGIN_NAME_LENGTH];
  *
  * Any other image format returned by the WebCodecs API will be converted to
  * RGBA before being returned to C++ to ensure that the result can be
- * property interpreted by the plugin.
+ * properly interpreted by the plugin.
  * 
  * Note that the WebCodecs API don't support converting into NV12 format in
  * cases where the native pixel format is something else. That's why RGBA is

--- a/libheif/plugins/decoder_webcodecs.cc
+++ b/libheif/plugins/decoder_webcodecs.cc
@@ -83,6 +83,13 @@ EM_JS(emscripten::EM_VAL, decode_with_browser_hevc, (const char *codec_ptr, uint
     }
 
     function handleEmptyFormat(decoded) {
+      if (typeof OffscreenCanvas === 'undefined') {
+        returnError(new Error('OffscreenCanvas is not available, but is required to decode this HEIC image.'));
+
+        decoded.close();
+        return;
+      }
+
       const canvas = new OffscreenCanvas(decoded.codedWidth, decoded.codedHeight);
       const context = canvas.getContext('2d');
       context.drawImage(decoded, 0, 0);

--- a/libheif/plugins/decoder_webcodecs.h
+++ b/libheif/plugins/decoder_webcodecs.h
@@ -1,0 +1,14 @@
+#ifndef THIRD_PARTY_LIBHEIF_LIBHEIF_PLUGINS_DECODER_WEBCODECS_H_
+#define THIRD_PARTY_LIBHEIF_LIBHEIF_PLUGINS_DECODER_WEBCODECS_H_
+
+#include "common_utils.h"
+
+const struct heif_decoder_plugin* get_decoder_plugin_webcodecs();
+
+#if PLUGIN_WEBCODECS
+extern "C" {
+MAYBE_UNUSED LIBHEIF_API extern heif_plugin_info plugin_info;
+}
+#endif
+
+#endif  // THIRD_PARTY_LIBHEIF_LIBHEIF_PLUGINS_DECODER_WEBCODECS_H_

--- a/libheif/plugins/nalu_utils.h
+++ b/libheif/plugins/nalu_utils.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include "libheif/heif.h"
 
+static const int NAL_UNIT_MAX_VCL    = 31;
 static const int NAL_UNIT_VPS_NUT    = 32;
 static const int NAL_UNIT_SPS_NUT    = 33;
 static const int NAL_UNIT_PPS_NUT    = 34;

--- a/post.js
+++ b/post.js
@@ -66,12 +66,12 @@ HeifImage.prototype.display = function(image_data, callback) {
     var w = this.get_width();
     var h = this.get_height();
 
-    setTimeout(function() {
+    setTimeout(async function() {
 
         // If image hasn't been loaded yet, decode the image
 
         if (!this.img) {
-            var img = Module.heif_js_decode_image2(this.handle,
+            var img = await Module.heif_js_decode_image2(this.handle,
               Module.heif_colorspace.heif_colorspace_RGB, Module.heif_chroma.heif_chroma_interleaved_RGBA);
             if (!img || img.code) {
                 console.log("Decoding image failed", this.handle, img);


### PR DESCRIPTION
Decodes images using the VideoDecoder API when run from webassembly in a browser.

The plugin calls inlined Javascript code (`decode_with_browser_hevc`) to perform the decoding. The javascript code will either return NV12 (YCbCr) or RGBA formatted data. NV12 is preferred if available.

In order to call the Javascript VideoDecoder API, 3 things are required:

* A ISO/IEC 14496-15 codec string (e.g. "hvc1.3.E.L93.B0")
* A binary serialized HEVCDecoderConfigurationRecord
* The image data (w/ VPS, SPS, PPS NAL unit stripped), prepended with 4 bytes describing the length

The codec string and HEVCDecoderConfigurationRecord are built from information in the NAL units that are pushed into the plugin. In the case of RGBA output, it is used directly (accounting for potentially differing strides), and NV12 input is converted to the YCbCr format used by libheif by de-interlacing the UV planes.

Tested:

* 3 different generations of iPhone photos
* A `heix` image (RGBA output)
* A `mif1` image (examples/example.heic)