### PR TITLE
Improve documentation on how to use SVT as a builtin encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,16 +256,16 @@ If you want to compile SVT-AV1 yourself,
 * Run the `svt.cmd` script in the `third-party` directory to download SVT-AV1
   and compile it.
 
-When running `cmake` or `configure`, make sure that the environment variable
+You have to enable SVT-AV1 with CMake.
+
+When running `cmake`, make sure that the environment variable
 `PKG_CONFIG_PATH` includes the absolute path to `third-party/SVT-AV1/Build/linux/install/lib/pkgconfig`.
 You may have to replace `linux` in this path with your system's identifier.
-
-You have to enable SVT-AV1 with CMake.
 
 ## Codec plugins
 
 Starting with v1.14.0, each codec backend can be compiled statically into libheif or as a dynamically loaded plugin.
-You can choose this individually for each codec backend in the CMake settings.
+You can choose this individually for each codec backend in the CMake settings using `WITH_{codec}_PLUGIN` options.
 Compiling a codec backend as dynamic plugin will generate a shared library that is installed in the system together with libheif.
 The advantage is that only the required plugins have to be installed and libheif has fewer dependencies.
 

--- a/third-party/svt.cmd
+++ b/third-party/svt.cmd
@@ -2,7 +2,7 @@
 
 : # cmake and ninja must be in your PATH for compiling.
 
-: # If you want to enable the SVT-AV1 encoder, please check that the WITH_SvtEnc and WITH_SvtEnc_BUILTIN CMake variables are set correctly.
+: # If you want to enable the SVT-AV1 encoder, please check that the WITH_SvtEnc and WITH_SvtEnc_PLUGIN CMake variables have correct values.
 : # You will also have to set the PKG_CONFIG_PATH to "third-party/SVT-AV1/Build/linux/Release" so that the local SVT-AV1 library is found.
 
 git clone -b v3.0.0 --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git


### PR DESCRIPTION
Simple PR to improve documentation on how to use SVT as a builtin encoder (ie not a plugin) with libheif.

Tbh, perhaps the only absolutely necessary change might be [the one in third-party/svt.cmd](https://github.com/strukturag/libheif/pull/1608/files#diff-f0becc742116ba8c1db2d3f2c07c57b65199f1995655ea976bed5bd801205e68R5).
Others are improvements that I think would've been helpful to me (image encoding noob) when I started configuring libheif with SVT and facing issues.