### PR TITLE
Ignore missing / incomplete tiles if not strict decoding.

### DIFF
--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -290,6 +290,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
 
   int progress_counter = 0;
   bool cancelled = false;
+  std::vector<Error> warnings;
 
   for (uint32_t y = 0; y < grid.get_rows() && !cancelled; y++) {
     uint32_t x0 = 0;
@@ -300,11 +301,33 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
 
       std::shared_ptr<const ImageItem> tileImg = get_context()->get_image(tileID, true);
       if (!tileImg) {
+        if (!options.strict_decoding && reference_idx != 0) {
+          // Skip missing tiles (unless it's the first one).
+          warnings.push_back(Error{
+            heif_error_Invalid_input,
+            heif_suberror_Missing_grid_images,
+          });
+          reference_idx++;
+          x0 += tile_width;
+          continue;
+        }
+
         return Error{heif_error_Invalid_input,
                      heif_suberror_Missing_grid_images,
                      "Nonexistent grid image referenced"};
       }
       if (auto error = tileImg->get_item_error()) {
+        if (!options.strict_decoding && reference_idx != 0) {
+          // Skip missing tiles (unless it's the first one).
+          warnings.push_back(Error{
+            heif_error_Invalid_input,
+            heif_suberror_Missing_grid_images,
+          });
+          reference_idx++;
+          x0 += tile_width;
+          continue;
+        }
+
         return error;
       }
 
@@ -419,6 +442,8 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
     return Error{heif_error_Canceled, heif_suberror_Unspecified, "Decoding the image was canceled"};
   }
 
+  img->add_warnings(warnings);
+
   return img;
 }
 
@@ -430,6 +455,11 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
   std::shared_ptr<HeifPixelImage> tile_img;
 
   auto tileItem = get_context()->get_image(tileID, true);
+  if (!tileItem && !options.strict_decoding) {
+    // We ignore missing images.
+    return Error::Ok;
+  }
+
   assert(tileItem);
   if (auto error = tileItem->get_item_error()) {
     return error;

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -290,7 +290,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
 
   int progress_counter = 0;
   bool cancelled = false;
-  std::vector<Error> warnings;
+  std::shared_ptr<std::vector<Error> > warnings(new std::vector<Error>());
 
   for (uint32_t y = 0; y < grid.get_rows() && !cancelled; y++) {
     uint32_t x0 = 0;
@@ -303,7 +303,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
       if (!tileImg) {
         if (!options.strict_decoding && reference_idx != 0) {
           // Skip missing tiles (unless it's the first one).
-          warnings.push_back(Error{
+          warnings->push_back(Error{
             heif_error_Invalid_input,
             heif_suberror_Missing_grid_images,
           });
@@ -319,7 +319,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
       if (auto error = tileImg->get_item_error()) {
         if (!options.strict_decoding && reference_idx != 0) {
           // Skip missing tiles (unless it's the first one).
-          warnings.push_back(error);
+          warnings->push_back(error);
           reference_idx++;
           x0 += tile_width;
           continue;
@@ -415,7 +415,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
       errs.push_back(std::async(std::launch::async,
                                 &ImageItem_Grid::decode_and_paste_tile_image, this,
                                 data.tileID, data.x_origin, data.y_origin, std::ref(img), options,
-                                std::ref(progress_counter), std::ref(warnings)));
+                                std::ref(progress_counter), warnings));
     }
 
     // check for decoding errors in remaining tiles
@@ -440,7 +440,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
   }
 
   if (img) {
-    img->add_warnings(warnings);
+    img->add_warnings(*warnings.get());
   }
 
   return img;
@@ -461,7 +461,8 @@ static Error progress_and_return_ok(const heif_decoding_options& options, int& p
 Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t x0, uint32_t y0,
                                                   std::shared_ptr<HeifPixelImage>& inout_image,
                                                   const heif_decoding_options& options,
-                                                  int& progress_counter, std::vector<Error>& warnings) const
+                                                  int& progress_counter,
+                                                  std::shared_ptr<std::vector<Error> > warnings) const
 {
   std::shared_ptr<HeifPixelImage> tile_img;
 #if ENABLE_PARALLEL_TILE_DECODING
@@ -474,7 +475,7 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
 #if ENABLE_PARALLEL_TILE_DECODING
     std::lock_guard<std::mutex> lock(warningsMutex);
 #endif
-    warnings.push_back(Error{
+    warnings->push_back(Error{
       heif_error_Invalid_input,
       heif_suberror_Missing_grid_images,
     });
@@ -493,7 +494,7 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
 #if ENABLE_PARALLEL_TILE_DECODING
       std::lock_guard<std::mutex> lock(warningsMutex);
 #endif
-      warnings.push_back(decodeResult.error());
+      warnings->push_back(decodeResult.error());
       return progress_and_return_ok(options, progress_counter);
     }
 

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -447,6 +447,18 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
   return img;
 }
 
+static Error progress_and_return_ok(const heif_decoding_options& options, int& progress_counter) {
+  if (options.on_progress) {
+#if ENABLE_PARALLEL_TILE_DECODING
+    static std::mutex progressMutex;
+    std::lock_guard<std::mutex> lock(progressMutex);
+#endif
+
+    options.on_progress(heif_progress_step_total, ++progress_counter, options.progress_user_data);
+  }
+  return Error::Ok;
+}
+
 Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t x0, uint32_t y0,
                                                   std::shared_ptr<HeifPixelImage>& inout_image,
                                                   const heif_decoding_options& options,
@@ -457,7 +469,7 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
   auto tileItem = get_context()->get_image(tileID, true);
   if (!tileItem && !options.strict_decoding) {
     // We ignore missing images.
-    return Error::Ok;
+    return progress_and_return_ok(options, progress_counter);
   }
 
   assert(tileItem);
@@ -467,6 +479,11 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
 
   auto decodeResult = tileItem->decode_image(options, false, 0, 0);
   if (!decodeResult) {
+    if (!options.strict_decoding) {
+      // We ignore broken tiles.
+      return progress_and_return_ok(options, progress_counter);
+    }
+
     return decodeResult.error();
   }
 
@@ -519,16 +536,7 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
 
   inout_image->copy_image_to(tile_img, x0, y0);
 
-  if (options.on_progress) {
-#if ENABLE_PARALLEL_TILE_DECODING
-    static std::mutex progressMutex;
-    std::lock_guard<std::mutex> lock(progressMutex);
-#endif
-
-    options.on_progress(heif_progress_step_total, ++progress_counter, options.progress_user_data);
-  }
-
-  return Error::Ok;
+  return progress_and_return_ok(options, progress_counter);
 }
 
 

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -319,10 +319,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
       if (auto error = tileImg->get_item_error()) {
         if (!options.strict_decoding && reference_idx != 0) {
           // Skip missing tiles (unless it's the first one).
-          warnings.push_back(Error{
-            heif_error_Invalid_input,
-            heif_suberror_Missing_grid_images,
-          });
+          warnings.push_back(error);
           reference_idx++;
           x0 += tile_width;
           continue;
@@ -496,10 +493,7 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
 #if ENABLE_PARALLEL_TILE_DECODING
       std::lock_guard<std::mutex> lock(warningsMutex);
 #endif
-      warnings.push_back(Error{
-        heif_error_Invalid_input,
-        heif_suberror_Missing_grid_images,
-      });
+      warnings.push_back(decodeResult.error());
       return progress_and_return_ok(options, progress_counter);
     }
 

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -442,7 +442,9 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
     return Error{heif_error_Canceled, heif_suberror_Unspecified, "Decoding the image was canceled"};
   }
 
-  img->add_warnings(warnings);
+  if (img) {
+    img->add_warnings(warnings);
+  }
 
   return img;
 }
@@ -469,6 +471,12 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
   auto tileItem = get_context()->get_image(tileID, true);
   if (!tileItem && !options.strict_decoding) {
     // We ignore missing images.
+    if (inout_image) {
+      inout_image->add_warning(Error{
+        heif_error_Invalid_input,
+        heif_suberror_Missing_grid_images,
+      });
+    }
     return progress_and_return_ok(options, progress_counter);
   }
 
@@ -481,6 +489,12 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
   if (!decodeResult) {
     if (!options.strict_decoding) {
       // We ignore broken tiles.
+      if (inout_image) {
+        inout_image->add_warning(Error{
+          heif_error_Invalid_input,
+          heif_suberror_Missing_grid_images,
+        });
+      }
       return progress_and_return_ok(options, progress_counter);
     }
 

--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -370,7 +370,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
           }
         }
 
-        err = decode_and_paste_tile_image(tileID, x0, y0, img, options, progress_counter);
+        err = decode_and_paste_tile_image(tileID, x0, y0, img, options, progress_counter, warnings);
         if (err) {
           return err;
         }
@@ -418,7 +418,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_full_grid_image(c
       errs.push_back(std::async(std::launch::async,
                                 &ImageItem_Grid::decode_and_paste_tile_image, this,
                                 data.tileID, data.x_origin, data.y_origin, std::ref(img), options,
-                                std::ref(progress_counter)));
+                                std::ref(progress_counter), std::ref(warnings)));
     }
 
     // check for decoding errors in remaining tiles
@@ -464,19 +464,23 @@ static Error progress_and_return_ok(const heif_decoding_options& options, int& p
 Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t x0, uint32_t y0,
                                                   std::shared_ptr<HeifPixelImage>& inout_image,
                                                   const heif_decoding_options& options,
-                                                  int& progress_counter) const
+                                                  int& progress_counter, std::vector<Error>& warnings) const
 {
   std::shared_ptr<HeifPixelImage> tile_img;
+#if ENABLE_PARALLEL_TILE_DECODING
+  static std::mutex warningsMutex;
+#endif
 
   auto tileItem = get_context()->get_image(tileID, true);
   if (!tileItem && !options.strict_decoding) {
     // We ignore missing images.
-    if (inout_image) {
-      inout_image->add_warning(Error{
-        heif_error_Invalid_input,
-        heif_suberror_Missing_grid_images,
-      });
-    }
+#if ENABLE_PARALLEL_TILE_DECODING
+    std::lock_guard<std::mutex> lock(warningsMutex);
+#endif
+    warnings.push_back(Error{
+      heif_error_Invalid_input,
+      heif_suberror_Missing_grid_images,
+    });
     return progress_and_return_ok(options, progress_counter);
   }
 
@@ -489,12 +493,13 @@ Error ImageItem_Grid::decode_and_paste_tile_image(heif_item_id tileID, uint32_t 
   if (!decodeResult) {
     if (!options.strict_decoding) {
       // We ignore broken tiles.
-      if (inout_image) {
-        inout_image->add_warning(Error{
-          heif_error_Invalid_input,
-          heif_suberror_Missing_grid_images,
-        });
-      }
+#if ENABLE_PARALLEL_TILE_DECODING
+      std::lock_guard<std::mutex> lock(warningsMutex);
+#endif
+      warnings.push_back(Error{
+        heif_error_Invalid_input,
+        heif_suberror_Missing_grid_images,
+      });
       return progress_and_return_ok(options, progress_counter);
     }
 

--- a/libheif/image-items/grid.h
+++ b/libheif/image-items/grid.h
@@ -167,7 +167,8 @@ private:
 
   Error decode_and_paste_tile_image(heif_item_id tileID, uint32_t x0, uint32_t y0,
                                     std::shared_ptr<HeifPixelImage>& inout_image,
-                                    const heif_decoding_options& options, int& progress_counter) const;
+                                    const heif_decoding_options& options, int& progress_counter,
+                                    std::vector<Error>& warnings) const;
 };
 
 

--- a/libheif/image-items/grid.h
+++ b/libheif/image-items/grid.h
@@ -168,7 +168,7 @@ private:
   Error decode_and_paste_tile_image(heif_item_id tileID, uint32_t x0, uint32_t y0,
                                     std::shared_ptr<HeifPixelImage>& inout_image,
                                     const heif_decoding_options& options, int& progress_counter,
-                                    std::vector<Error>& warnings) const;
+                                    std::shared_ptr<std::vector<Error> > warnings) const;
 };
 
 

--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -708,6 +708,10 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem::decode_image(const heif_decod
   }
 
   auto img = *decodingResult;
+  if (!img) {
+    // Can happen if missing tiled image is decoded in non-strict mode.
+    return Error(heif_error_Decoder_plugin_error, heif_suberror_Unspecified);
+  }
 
   std::shared_ptr<HeifFile> file = m_heif_context->get_heif_file();
 


### PR DESCRIPTION
I though about adding a dedicated flag but probably `strict_decoding` is fine to use for these cases.

Feel free to ping me for example images.