### PR TITLE
Forward warnings to output image.

### DIFF
--- a/libheif/color-conversion/colorconversion.cc
+++ b/libheif/color-conversion/colorconversion.cc
@@ -492,6 +492,8 @@ Result<std::shared_ptr<HeifPixelImage>> ColorConversionPipeline::convert_image(c
     in = out;
   }
 
+  out->add_warnings(input->get_warnings());
+
   return out;
 }
 

--- a/libheif/pixelimage.cc
+++ b/libheif/pixelimage.cc
@@ -1074,6 +1074,8 @@ Result<std::shared_ptr<HeifPixelImage>> HeifPixelImage::rotate_ccw(int angle_deg
   out_img->set_color_profile_nclx(get_color_profile_nclx());
   out_img->set_color_profile_icc(get_color_profile_icc());
 
+  out_img->add_warnings(get_warnings());
+
   return out_img;
 }
 
@@ -1285,6 +1287,8 @@ Result<std::shared_ptr<HeifPixelImage>> HeifPixelImage::crop(uint32_t left, uint
 
   out_img->set_color_profile_nclx(get_color_profile_nclx());
   out_img->set_color_profile_icc(get_color_profile_icc());
+
+  out_img->add_warnings(get_warnings());
 
   return out_img;
 }


### PR DESCRIPTION
Noticed this while working on #1616. Warnings are no longer present in the output image if this is processed (e.g. rotated) before being returned.