### PR TITLE
Fix duplicate warnings after color conversion.

### DIFF
--- a/libheif/color-conversion/colorconversion.cc
+++ b/libheif/color-conversion/colorconversion.cc
@@ -492,8 +492,6 @@ Result<std::shared_ptr<HeifPixelImage>> ColorConversionPipeline::convert_image(c
     in = out;
   }
 
-  out->add_warnings(input->get_warnings());
-
   return out;
 }
 


### PR DESCRIPTION
Wrongly introduced in #1620, color conversion already copies the warnings here:
https://github.com/strukturag/libheif/blob/520067e122408beba9792e56972736722d193326/libheif/color-conversion/colorconversion.cc#L487-L490