### PR TITLE
Ensure float-to-int cast-and-clip inline functions use the same 32-bit int precision on all platforms

### DIFF
--- a/libheif/common_utils.h
+++ b/libheif/common_utils.h
@@ -93,7 +93,7 @@ inline uint16_t clip_int_u16(int32_t x, uint16_t maxi)
 
 inline uint16_t clip_f_u16(float fx, int32_t maxi)
 {
-  long x = (long int) (fx + 0.5f);
+  int32_t x = (int32_t) (fx + 0.5f);
   if (x < 0) return 0;
   if (x > maxi) return (uint16_t) maxi;
   return static_cast<uint16_t>(x);
@@ -101,7 +101,7 @@ inline uint16_t clip_f_u16(float fx, int32_t maxi)
 
 inline uint8_t clip_f_u8(float fx)
 {
-  long x = (long int) (fx + 0.5f);
+  int32_t x = (int32_t) (fx + 0.5f);
   if (x < 0) return 0;
   if (x > 255) return 255;
   return static_cast<uint8_t>(x);


### PR DESCRIPTION
The small change in this PR forces 64-bit Linux and macOS to behave consistently with Windows, which uses 32-bit precision for the `long` data type.

Doing so allows compilers to optimise these hot inline functions to use smaller 32-bit instructions and register access.

Testing via callgrind suggests the colour conversion functions might be up to ~20% faster as a result. Note the instruction count reduction when encoding a 1024 pixel RGB image:

Before:
```
80,184 ( 0.09%)  ???:Op_RGB24_32_to_YCbCr::convert_colorspace(std::shared_ptr<HeifPixelImage const> const&, ColorState const&, ColorState const&, heif_color_conversion_options const&, heif_color_conversion_options_ext const&, heif_security_limits const*) const
```

After:
```
61,154 ( 0.07%)  ???:Op_RGB24_32_to_YCbCr::convert_colorspace(std::shared_ptr<HeifPixelImage const> const&, ColorState const&, ColorState const&, heif_color_conversion_options const&, heif_color_conversion_options_ext const&, heif_security_limits const*) const
```