### PR TITLE
Uncompressed Signed Integer

### DIFF
--- a/libheif/codecs/uncompressed/unc_types.h
+++ b/libheif/codecs/uncompressed/unc_types.h
@@ -176,9 +176,16 @@ enum heif_uncompressed_component_format
   component_format_complex = 2,
 
   /**
+   * Signed integer.
+   *
+   * The component value is a two's complement signed integer.
+   */
+  component_format_signed = 3,
+
+  /**
    * Maximum valid component format identifier.
    */
-  component_format_max_valid = component_format_complex
+  component_format_max_valid = component_format_signed
 };
 
 


### PR DESCRIPTION
They latest amendment of ISO/IEC 23001-17 adds an enumeration for signed integers.

<img width="623" height="200" alt="image" src="https://github.com/user-attachments/assets/3e4d0855-9faf-4055-bf66-e3d0ceb92c91" />