### PR TITLE
Add climits includes

### DIFF
--- a/libheif/api/libheif/heif_image_handle.cc
+++ b/libheif/api/libheif/heif_image_handle.cc
@@ -20,6 +20,7 @@
 
 #include "heif_image_handle.h"
 #include "api_structs.h"
+#include <climits>
 #include <string>
 
 


### PR DESCRIPTION
Fixes:
../libheif/api/libheif/heif_image_handle.cc: In function 'int heif_image_handle_get_width(const heif_image_handle*)': ../libheif/api/libheif/heif_image_handle.cc:48:13: error: 'INT_MAX' was not declared in this scope
   48 |     if (w > INT_MAX) {
      |             ^~~~~~~
../libheif/api/libheif/heif_image_handle.cc:23:1: note: 'INT_MAX' is defined in header '<climits>'; this is probably fixable by adding '#include <climits>'
   22 | #include "api_structs.h"
  +++ |+#include <climits>
   23 | #include <string>