### PR TITLE
Fix: added <cstdio>

### DIFF
--- a/examples/sdl.cc
+++ b/examples/sdl.cc
@@ -25,7 +25,7 @@
 */
 
 #include "sdl.hh"
-#include <assert.h>
+#include <cassert>
 #include <cstdio>
 
 


### PR DESCRIPTION
```
sdl.cc: In member function 'bool SDL_YUV_Display::init(int, int, SDL_Chroma, const char*)':
sdl.cc:43:5: error: 'printf' was not declared in this scope
   43 |     printf("SDL_Init() failed: %s\n", SDL_GetError( ) );
      |     ^~~~~~
sdl.cc:29:1: note: 'printf' is defined in header '<cstdio>'; this is probably fixable by adding '#include <cstdio>'
   28 | #include <assert.h>
  +++ |+#include <cstdio>
```