### PR TITLE
Support Hyperspectral Imagery

### DIFF
--- a/libheif/api/libheif/heif_experimental.cc
+++ b/libheif/api/libheif/heif_experimental.cc
@@ -343,9 +343,11 @@ void heif_pyramid_layer_info_release(heif_pyramid_layer_info* infos)
 heif_error heif_image_add_channel(heif_image* image,
                                   heif_channel channel,
                                   int width, int height,
-                                  heif_channel_datatype datatype, int bit_depth)
+                                  heif_channel_datatype datatype,
+                                  int bit_depth,
+                                  size_t* out_index)
 {
-  if (auto err = image->image->add_channel(channel, width, height, datatype, bit_depth, nullptr)) {
+  if (auto err = image->image->add_channel(channel, width, height, datatype, bit_depth, nullptr, out_index)) {
     return err.error_struct(image->image.get());
   }
   else {
@@ -470,3 +472,23 @@ heif_error heif_context_add_tiled_image(heif_context* ctx,
   return heif_error_success;
 }
 #endif
+
+int16_t* heif_image_get_channel_int16(heif_image* image,
+                                      size_t channel_index,
+                                      size_t* out_stride)
+{
+  if (!out_stride) {
+    return nullptr;
+  }
+
+  if (!image || !image->image) {
+    *out_stride = 0;
+    return nullptr;
+  }
+
+  size_t stride;
+  uint8_t* p = image->image->get_plane(channel_index, &stride);
+  
+  *out_stride = stride / sizeof(int16_t);
+  return reinterpret_cast<int16_t*>(p);
+}

--- a/libheif/api/libheif/heif_experimental.h
+++ b/libheif/api/libheif/heif_experimental.h
@@ -194,7 +194,10 @@ heif_error heif_image_add_channel(heif_image* image,
                                   enum heif_channel channel,
                                   int width, int height,
                                   enum heif_channel_datatype datatype,
-                                  int bit_depth);
+                                  int bit_depth,
+                                  size_t* out_index);
+
+
 
 
 LIBHEIF_API
@@ -289,7 +292,7 @@ uint64_t* heif_image_get_channel_uint64(heif_image*,
 
 LIBHEIF_API
 int16_t* heif_image_get_channel_int16(heif_image*,
-                                      enum heif_channel channel,
+                                      size_t channel_index,
                                       size_t* out_stride);
 
 LIBHEIF_API

--- a/libheif/codecs/uncompressed/unc_codec.cc
+++ b/libheif/codecs/uncompressed/unc_codec.cc
@@ -980,7 +980,9 @@ Error fill_cmpd_and_uncC(std::shared_ptr<Box_cmpd>& cmpd,
   }
   else if (colourspace == heif_colorspace_monochrome) {
     Box_cmpd::Component monoComponent = {component_type_monochrome};
-    cmpd->add_component(monoComponent);
+    for (size_t i = 0; i < image->get_channel_count(); i++) {
+      cmpd->add_component(monoComponent);
+    }    
 
     if (save_alpha_channel && image->has_channel(heif_channel_Alpha)) {
       Box_cmpd::Component alphaComponent = {component_type_alpha};
@@ -990,7 +992,10 @@ Error fill_cmpd_and_uncC(std::shared_ptr<Box_cmpd>& cmpd,
     int bpp = image->get_bits_per_pixel(heif_channel_Y);
     heif_uncompressed_component_format format = to_unc_component_format(image, heif_channel_Y);
     Box_uncC::Component component0 = {0, (uint8_t) (bpp), (uint8_t) format, 0};
-    uncC->add_component(component0);
+    for (size_t i = 0; i < image->get_channel_count(); i++) {
+      // TODO: don't assume all channels have the same bpp and format
+      uncC->add_component(component0);
+    }
 
     if (save_alpha_channel && image->has_channel(heif_channel_Alpha)) {
       heif_uncompressed_component_format format_alpha = to_unc_component_format(image, heif_channel_Alpha);

--- a/libheif/codecs/uncompressed/unc_codec.cc
+++ b/libheif/codecs/uncompressed/unc_codec.cc
@@ -989,13 +989,13 @@ Error fill_cmpd_and_uncC(std::shared_ptr<Box_cmpd>& cmpd,
 
     int bpp = image->get_bits_per_pixel(heif_channel_Y);
     heif_uncompressed_component_format format = to_unc_component_format(image, heif_channel_Y);
-    Box_uncC::Component component0 = {0, (uint8_t) (bpp), format, 0};
+    Box_uncC::Component component0 = {0, (uint8_t) (bpp), (uint8_t) format, 0};
     uncC->add_component(component0);
 
     if (save_alpha_channel && image->has_channel(heif_channel_Alpha)) {
       heif_uncompressed_component_format format_alpha = to_unc_component_format(image, heif_channel_Alpha);
       bpp = image->get_bits_per_pixel(heif_channel_Alpha);
-      Box_uncC::Component component1 = {1, (uint8_t) (bpp), format_alpha, 0};
+      Box_uncC::Component component1 = {1, (uint8_t) (bpp), (uint8_t) format_alpha, 0};
       uncC->add_component(component1);
     }
 

--- a/libheif/codecs/uncompressed/unc_codec.cc
+++ b/libheif/codecs/uncompressed/unc_codec.cc
@@ -988,12 +988,14 @@ Error fill_cmpd_and_uncC(std::shared_ptr<Box_cmpd>& cmpd,
     }
 
     int bpp = image->get_bits_per_pixel(heif_channel_Y);
-    Box_uncC::Component component0 = {0, (uint8_t) (bpp), component_format_unsigned, 0};
+    heif_uncompressed_component_format format = to_unc_component_format(image, heif_channel_Y);
+    Box_uncC::Component component0 = {0, (uint8_t) (bpp), format, 0};
     uncC->add_component(component0);
 
     if (save_alpha_channel && image->has_channel(heif_channel_Alpha)) {
+      heif_uncompressed_component_format format_alpha = to_unc_component_format(image, heif_channel_Alpha);
       bpp = image->get_bits_per_pixel(heif_channel_Alpha);
-      Box_uncC::Component component1 = {1, (uint8_t) (bpp), component_format_unsigned, 0};
+      Box_uncC::Component component1 = {1, (uint8_t) (bpp), format_alpha, 0};
       uncC->add_component(component1);
     }
 
@@ -1017,4 +1019,30 @@ Error fill_cmpd_and_uncC(std::shared_ptr<Box_cmpd>& cmpd,
                  "Unsupported colourspace");
   }
   return Error::Ok;
+}
+
+heif_uncompressed_component_format to_unc_component_format(heif_channel_datatype channel_datatype)
+{
+  switch (channel_datatype) {
+    case heif_channel_datatype_signed_integer:
+      return component_format_signed;
+
+    case heif_channel_datatype_floating_point:
+      return component_format_float;
+
+    case heif_channel_datatype_complex_number:
+      return component_format_complex;
+
+    case heif_channel_datatype_unsigned_integer:
+    case heif_channel_datatype_undefined:
+    default:
+      return component_format_unsigned;
+  }
+}
+
+heif_uncompressed_component_format to_unc_component_format(const std::shared_ptr<const HeifPixelImage>& image, heif_channel channel)
+{
+    heif_channel_datatype datatype = image->get_datatype(channel);
+    heif_uncompressed_component_format component_format = to_unc_component_format(datatype);
+    return component_format;
 }

--- a/libheif/codecs/uncompressed/unc_codec.h
+++ b/libheif/codecs/uncompressed/unc_codec.h
@@ -53,6 +53,9 @@ bool map_uncompressed_component_to_channel(const std::shared_ptr<const Box_cmpd>
                                            Box_uncC::Component component,
                                            heif_channel *channel);
 
+heif_uncompressed_component_format to_unc_component_format(heif_channel_datatype);
+
+heif_uncompressed_component_format to_unc_component_format(const std::shared_ptr<const HeifPixelImage>&, heif_channel);
 
 class UncompressedImageCodec
 {

--- a/libheif/image-items/unc_image.cc
+++ b/libheif/image-items/unc_image.cc
@@ -288,18 +288,10 @@ Result<std::vector<uint8_t>> encode_image_tile(const std::shared_ptr<const HeifP
   {
     uint64_t offset = 0;
     std::vector<heif_channel> channels;
-    if (src_image->has_channel(heif_channel_Alpha))
-    {
-      channels = {heif_channel_Y, heif_channel_Alpha};
-    }
-    else
-    {
-      channels = {heif_channel_Y};
-    }
-    for (heif_channel channel : channels)
-    {
+    size_t channel_count = src_image->get_channel_count();
+    for (size_t i = 0; i < channel_count; i++) {
       size_t src_stride;
-      const uint8_t* src_data = src_image->get_plane(channel, &src_stride);
+      const uint8_t* src_data = src_image->get_plane(i, &src_stride);
       uint64_t out_size = static_cast<uint64_t>(src_image->get_height()) * src_stride;
       data.resize(data.size() + out_size);
       memcpy(data.data() + offset, src_data, out_size);

--- a/libheif/pixelimage.cc
+++ b/libheif/pixelimage.cc
@@ -619,10 +619,9 @@ Error HeifPixelImage::extend_to_size_with_zero(uint32_t width, uint32_t height, 
 
 bool HeifPixelImage::has_channel(heif_channel channel) const
 {
-  for (const auto& plane : m_planes) {
-    if (plane.m_channel == channel) {
-      return true;
-    }
+  const ImagePlane* plane = get_first_plane_by_channel(channel);
+  if (plane) {
+    return true;
   }
   return false;
 }
@@ -639,10 +638,9 @@ bool HeifPixelImage::has_alpha() const
 
 uint32_t HeifPixelImage::get_width(enum heif_channel channel) const 
 {
-  for (const auto& plane : m_planes) {
-    if (plane.m_channel == channel) {
-      return plane.m_width;
-    }
+  const ImagePlane* plane = get_first_plane_by_channel(channel);
+  if (plane) {
+    return plane->m_width;
   }
   return 0;
 }
@@ -651,10 +649,9 @@ uint32_t HeifPixelImage::get_width(enum heif_channel channel) const
 
 uint32_t HeifPixelImage::get_height(enum heif_channel channel) const
 {
-  for (const auto& plane : m_planes) {
-    if (plane.m_channel == channel) {
-      return plane.m_height;
-    }
+  const ImagePlane* plane = get_first_plane_by_channel(channel);
+  if (plane) {
+    return plane->m_height;
   }
   return 0;
 }
@@ -665,7 +662,7 @@ std::set<heif_channel> HeifPixelImage::get_channel_set() const
   std::set<heif_channel> channels;
 
   for (const auto& plane : m_planes) {
-    channels.insert(plane.first);
+    channels.insert(plane.m_channel);
   }
 
   return channels;
@@ -701,12 +698,11 @@ uint8_t HeifPixelImage::get_storage_bits_per_pixel(enum heif_channel channel) co
 
 uint8_t HeifPixelImage::get_bits_per_pixel(enum heif_channel channel) const
 {
-  auto iter = m_planes.find(channel);
-  if (iter == m_planes.end()) {
-    return -1;
+  const ImagePlane *plane = get_first_plane_by_channel(channel);
+  if (plane) {
+    return plane->m_bit_depth;
   }
-
-  return iter->second.m_bit_depth;
+  return -1;
 }
 
 
@@ -745,23 +741,23 @@ uint8_t HeifPixelImage::get_visual_image_bits_per_pixel() const
 
 heif_channel_datatype HeifPixelImage::get_datatype(enum heif_channel channel) const
 {
-  auto iter = m_planes.find(channel);
-  if (iter == m_planes.end()) {
-    return heif_channel_datatype_undefined;
+  const ImagePlane* plane = get_first_plane_by_channel(channel);
+  if (plane) {
+    return plane->m_datatype;
   }
 
-  return iter->second.m_datatype;
+  return heif_channel_datatype_undefined;
 }
 
 
 int HeifPixelImage::get_number_of_interleaved_components(heif_channel channel) const
 {
-  auto iter = m_planes.find(channel);
-  if (iter == m_planes.end()) {
-    return 0;
+  const ImagePlane* plane = get_first_plane_by_channel(channel);
+  if (plane) {
+    return plane->m_num_interleaved_components;
   }
 
-  return iter->second.m_num_interleaved_components;
+  return 0;
 }
 
 

--- a/libheif/pixelimage.h
+++ b/libheif/pixelimage.h
@@ -260,6 +260,8 @@ public:
   uint8_t* get_plane(heif_channel channel, size_t* out_stride) { return get_channel<uint8_t>(channel, out_stride); }
   
   uint8_t* get_plane(size_t index, size_t* out_stride) { return get_channel<uint8_t>(index, out_stride); }
+  
+  const uint8_t* get_plane(size_t index, size_t* out_stride) const { return get_channel<uint8_t>(index, out_stride); }
 
 
   const uint8_t* get_plane(heif_channel channel, size_t* out_stride) const { return get_channel<uint8_t>(channel, out_stride); }
@@ -309,6 +311,13 @@ public:
 
     return static_cast<T*>(plane.mem);
   }
+
+  template <typename T>
+  const T* get_channel(size_t index, size_t* out_stride) const {
+    return const_cast<HeifPixelImage*>(this)->get_channel<T>(index, out_stride);
+  }
+
+  size_t get_channel_count() const { return m_planes.size(); }
 
   Error copy_new_plane_from(const std::shared_ptr<const HeifPixelImage>& src_image,
                             heif_channel src_channel,

--- a/libheif/pixelimage.h
+++ b/libheif/pixelimage.h
@@ -354,6 +354,7 @@ private:
                 const heif_security_limits* limits,
                 MemoryHandle& memory_handle);
 
+    heif_channel m_channel = heif_channel_Y;
     heif_channel_datatype m_datatype = heif_channel_datatype_unsigned_integer;
     uint8_t m_bit_depth = 0;
     uint8_t m_num_interleaved_components = 1;
@@ -386,7 +387,8 @@ private:
   heif_colorspace m_colorspace = heif_colorspace_undefined;
   heif_chroma m_chroma = heif_chroma_undefined;
 
-  std::map<heif_channel, ImagePlane> m_planes;
+  // std::map<heif_channel, ImagePlane> m_planes;
+  std::vector<ImagePlane> m_planes;
   MemoryHandle m_memory_handle;
 
   uint32_t m_sample_duration = 0; // duration of a sequence frame

--- a/libheif/pixelimage.h
+++ b/libheif/pixelimage.h
@@ -394,6 +394,7 @@ private:
   uint32_t m_sample_duration = 0; // duration of a sequence frame
 
   std::vector<Error> m_warnings;
+  const ImagePlane* get_first_plane_by_channel(heif_channel channel) const;
 };
 
 #endif

--- a/libheif/pixelimage.h
+++ b/libheif/pixelimage.h
@@ -264,8 +264,8 @@ public:
   template <typename T>
   T* get_channel(heif_channel channel, size_t* out_stride)
   {
-    auto iter = m_planes.find(channel);
-    if (iter == m_planes.end()) {
+    ImagePlane* plane = get_first_plane_by_channel(channel);
+    if (!plane) {
       if (out_stride)
         *out_stride = 0;
 
@@ -273,12 +273,12 @@ public:
     }
 
     if (out_stride) {
-      *out_stride = static_cast<int>(iter->second.stride / sizeof(T));
+      *out_stride = static_cast<int>(plane->stride / sizeof(T));
     }
 
     //assert(sizeof(T) == iter->second.get_bytes_per_pixel());
 
-    return static_cast<T*>(iter->second.mem);
+    return static_cast<T*>(plane->mem);
   }
 
   template <typename T>
@@ -382,6 +382,26 @@ private:
     void crop(uint32_t left, uint32_t right, uint32_t top, uint32_t bottom, int bytes_per_pixel, ImagePlane& out_plane) const;
   };
 
+  ImagePlane* get_first_plane_by_channel(heif_channel channel)
+  {
+    for (auto& plane : m_planes) {
+      if (plane.m_channel == channel) {
+        return &plane;
+      }
+    }
+    return nullptr;
+  }
+
+  const ImagePlane* get_first_plane_by_channel(heif_channel channel) const
+  {
+    for (const auto& plane : m_planes) {
+      if (plane.m_channel == channel) {
+        return &plane;
+      }
+    }
+    return nullptr;
+  }
+
   uint32_t m_width = 0;
   uint32_t m_height = 0;
   heif_colorspace m_colorspace = heif_colorspace_undefined;
@@ -394,7 +414,6 @@ private:
   uint32_t m_sample_duration = 0; // duration of a sequence frame
 
   std::vector<Error> m_warnings;
-  const ImagePlane* get_first_plane_by_channel(heif_channel channel) const;
 };
 
 #endif


### PR DESCRIPTION
Refactors the `m_planes` variable from an `std::map` to an `std::vector` to support multiple components per channel.