### PR TITLE
Print kvazaar version if such function is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,9 @@ if (WITH_KVAZAAR)
     else ()
         add_definitions(-DHAVE_KVAZAAR_ENABLE_LOGGING=0)
     endif ()
+    if (HAVE_KVAZAAR_VERSION_STRING)
+        add_definitions(-DHAVE_KVAZAAR_VERSION_STRING=1)
+    endif ()
 endif ()
 
 # uvg266

--- a/cmake/modules/Findkvazaar.cmake
+++ b/cmake/modules/Findkvazaar.cmake
@@ -1,5 +1,6 @@
 include(LibFindMacros)
 include(CheckStructHasMember)
+include(CheckSymbolExists)
 
 libfind_pkg_check_modules(KVAZAAR_PKGCONF kvazaar)
 
@@ -19,9 +20,13 @@ set(KVAZAAR_PROCESS_INCLUDES KVAZAAR_INCLUDE_DIR)
 libfind_process(KVAZAAR)
 
 set(CMAKE_REQUIRED_INCLUDES ${KVAZAAR_INCLUDE_DIR})
+set(CMAKE_REQUIRED_LIBRARIES ${KVAZAAR_LIBRARY})
 CHECK_STRUCT_HAS_MEMBER("struct kvz_config" enable_logging_output kvazaar.h
                         HAVE_KVAZAAR_ENABLE_LOGGING LANGUAGE CXX)
+check_symbol_exists(kvz_get_version_string kvazaar.h
+                        HAVE_KVAZAAR_VERSION_STRING)
 unset(CMAKE_REQUIRED_INCLUDES)
+unset(CMAKE_REQUIRED_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(kvazaar

--- a/libheif/plugins/encoder_kvazaar.cc
+++ b/libheif/plugins/encoder_kvazaar.cc
@@ -102,7 +102,11 @@ static void kvazaar_set_default_parameters(void* encoder);
 
 static const char* kvazaar_plugin_name()
 {
+#if HAVE_KVAZAAR_VERSION_STRING
+  snprintf(plugin_name, MAX_PLUGIN_NAME_LENGTH, "kvazaar HEVC encoder %s", kvz_get_version_string());
+#else
   strcpy(plugin_name, "kvazaar HEVC encoder");
+#endif
   return plugin_name;
 }
 


### PR DESCRIPTION
The latest kvazaar version now supports getting version string in runtime. 
So I added version information to the kvazaar plugin, when libheif is compiled with the latest kvazaar version. Support of the version function is cheched in cmake.

<img width="454" height="106" alt="image" src="https://github.com/user-attachments/assets/2feac5a3-5c32-4039-8faa-f8fc9fdf04a5" />
