### PR TITLE
Fix: Set dav1d thread count before opening decoder

### DIFF
--- a/libheif/plugins/decoder_dav1d.cc
+++ b/libheif/plugins/decoder_dav1d.cc
@@ -108,13 +108,13 @@ heif_error dav1d_new_decoder2(void** dec, const heif_decoder_plugin_options* opt
 
   decoder->settings.all_layers = 0;
 
+  if (options->num_threads) {
+    decoder->settings.n_threads = options->num_threads;
+  }
+
   if (dav1d_open(&decoder->context, &decoder->settings) != 0) {
     delete decoder;
     return {heif_error_Decoder_plugin_error, heif_suberror_Unspecified, kSuccess};
-  }
-
-  if (options->num_threads) {
-    decoder->settings.n_threads = options->num_threads;
   }
 
   *dec = decoder;


### PR DESCRIPTION
The `num_threads` setting was being applied after dav1d_open(), which meant the thread configuration was ignored. Moving the thread count assignment to occur **before** opening the decoder (just like it's done in other decoders like [decoder_aom](https://github.com/strukturag/libheif/blob/master/libheif/plugins/decoder_aom.cc#L119-L126)) so that the setting takes effect.