### PR TITLE
Add support for cICP, cLLI and mDCV PNG chunks encoding

### DIFF
--- a/heifio/encoder_png.cc
+++ b/heifio/encoder_png.cc
@@ -158,9 +158,9 @@ bool PngEncoder::Encode(const heif_image_handle* handle,
         // Setting matrix coefficients to 0 (RGB) and full range flag to 1 (full range)
         // because data is converted into RGB specified by PngEncoder::colorspace (heif_colorspace_RGB)
         png_set_cICP(png_ptr, info_ptr, nclx->color_primaries, nclx->transfer_characteristics, 0, 1);
-        heif_nclx_color_profile_free(nclx);
     }
 #endif
+  }
   }
   }
 


### PR DESCRIPTION
This change adds encoding support for `cICP` and `cLLI` PNG chunks from HEIC files. With this change, the reference tool `heif-dec` can convert a 10-bit HEIC file to a PNG file with correct metadata, and both files display the same.

PNG is currently the only intermediate file format supported by `heif-dec` and `heif-enc` and supports HDR.
 I also added support for these chunks in `decoder_png.cc` but that will be a separate patch. I'm a newcomer, if I made a mistake, please let me know!