### PR TITLE
Optional Primary Item

### DIFF
--- a/libheif/file.cc
+++ b/libheif/file.cc
@@ -176,10 +176,8 @@ void HeifFile::init_for_image()
   m_iloc_box = std::make_shared<Box_iloc>();
   m_iinf_box = std::make_shared<Box_iinf>();
   m_iprp_box = std::make_shared<Box_iprp>();
-  m_pitm_box = std::make_shared<Box_pitm>();
 
   m_meta_box->append_child_box(m_hdlr_box);
-  m_meta_box->append_child_box(m_pitm_box);
   m_meta_box->append_child_box(m_iloc_box);
   m_meta_box->append_child_box(m_iinf_box);
   m_meta_box->append_child_box(m_iprp_box);


### PR DESCRIPTION
Sometimes, we want a meta box with no primary item.

For example, a GIMI sequence may have a track and a file-level metabox with a single item (the security markings as a mime item). I suppose you could mark it as the primary item, but it's not intended for display.

The current behavior of libheif writes a 'pitm' to item id 0, which is always invalid and leads to parsing errors.

ISO/IEC 23001-17 8.11.4 indicates that the 'pitm' box is NOT mandatory, but I'm not sure if any particular brand requires it.