### PR TITLE
Fix missing orientation properties (irot/imir) on grid images

### DIFF
--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -729,6 +729,9 @@ Result<std::shared_ptr<ImageItem_Grid>> ImageItem_Grid::add_new_grid_item(HeifCo
   heif_item_id grid_id = *grid_id_result;
   grid_image = std::make_shared<ImageItem_Grid>(ctx, grid_id);
   grid_image->set_encoding_options(encoding_options);
+  // Override image_orientation to normal for tiles — orientation is applied
+  // to the grid item, not to individual tiles.
+  grid_image->override_encoding_option_image_orientation(heif_orientation_normal);
   grid_image->set_grid_spec(grid);
   grid_image->set_resolution(output_width, output_height);
 
@@ -745,6 +748,9 @@ Result<std::shared_ptr<ImageItem_Grid>> ImageItem_Grid::add_new_grid_item(HeifCo
 
   // Add ISPE property
   file->add_ispe_property(grid_id, output_width, output_height, false);
+
+  // Add orientation properties (irot/imir) to the grid item.
+  file->add_orientation_properties(grid_id, encoding_options->image_orientation);
 
   // PIXI property will be added when the first tile is set
 

--- a/libheif/image-items/grid.h
+++ b/libheif/image-items/grid.h
@@ -119,6 +119,10 @@ public:
     heif_encoding_options_copy(m_encoding_options, options);
   }
 
+  void override_encoding_option_image_orientation(heif_orientation orientation) {
+    m_encoding_options->image_orientation = orientation;
+  }
+
   const heif_encoding_options* get_encoding_options() const { return m_encoding_options; }
 
   Result<Encoder::CodedImageData> encode(const std::shared_ptr<HeifPixelImage>& image,


### PR DESCRIPTION
Hello! During adding support to pillow_heif for tiling image encoding  I have maybe found a bug that`add_new_grid_item()` does not call `add_orientation_properties()` on the grid item.
When `image_orientation` is set in encoding options `encode_to_item()` adds `irot`/`imir` to individual tiles instead. Since tiles are hidden items, their orientation properties are applied during tile decoding but never propagated to the grid from what I see.

 Note: maybe `add_and_encode_full_grid()` has the same issue (and also leaks orientation onto tiles).

There may be a better or more comprehensive approach to fix this - I would appreciate any feedback on this proposal.


Steps to reproduce:

```bash
heif-enc /tmp/test.jpg -o /tmp/single.heif -q 90
heif-enc /tmp/test.jpg -o /tmp/grid.heif -q 90 --cut-tiles 64
```

```
heif-info -d /tmp/single.heif
MIME type: image/heic
main brand: heic
compatible brands: mif1, heic, miaf
Box: ftyp ----- (File Type)
size: 28   (header size: 8)
major brand: heic
minor version: 0
compatible brands: mif1,heic,miaf

Box: meta ----- (Metadata)
size: 413   (header size: 12)
| Box: hdlr ----- (Handler Reference)
| size: 33   (header size: 12)
| pre_defined: 0
| handler_type: pict
| name: 
| 
| Box: iloc ----- (Item Location)
| size: 52   (header size: 12)
| item ID: 1
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 449
|   extents: 0,3408 
| item ID: 2
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 3857
|   extents: 0,30 
| 
| Box: iinf ----- (Item Information)
| size: 56   (header size: 12)
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 1
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: false
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 2
| | item_protection_index: 0
| | item_type: Exif
| | item_name: 
| | hidden item: true
| 
| Box: pitm ----- (Primary Item)
| size: 14   (header size: 12)
| item_ID: 1
| 
| Box: iprp ----- (Item Properties)
| size: 220   (header size: 8)
| | Box: ipco ----- (Item Property Container)
| | size: 188   (header size: 8)
| | | index: 1
| | | Box: hvcC ----- (HEVC Configuration Item)
| | | size: 116   (header size: 8)
| | | configuration_version: 1
| | | general_profile_space: 0
| | | general_tier_flag: 0
| | | general_profile_idc: 3
| | | general_profile_compatibility_flags: 0111.0000 0000.0000 0000.0000 0000.0000 
| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
| | | general_level_idc: 30
| | | min_spatial_segmentation_idc: 0
| | | parallelism_type: 0
| | | chroma_format: 4:2:0
| | | bit_depth_luma: 8
| | | bit_depth_chroma: 8
| | | avg_frame_rate: 0
| | | constant_frame_rate: 0
| | | num_temporal_layers: 1
| | | temporal_id_nested: 1
| | | length_size: 4
| | | <array>
| | | | array_completeness: 1
| | | | NAL_unit_type: 32
| | | | 40 01 0c 01 ff ff 03 70 00 00 03 00 90 00 00 03 00 00 03 00 1e ba 02 40 
| | | <array>
| | | | array_completeness: 1
| | | | NAL_unit_type: 33
| | | | 42 01 01 03 70 00 00 03 00 90 00 00 03 00 00 03 00 1e a0 08 08 18 59 6e a4 92 9a e6 c0 80 00 00 0c 80 00 00 03 00 84 
| | | <array>
| | | | array_completeness: 1
| | | | NAL_unit_type: 34
| | | | 44 01 c1 72 b0 62 40 
| | | 
| | | index: 2
| | | Box: colr -----
| | | size: 19   (header size: 8)
| | | colour_type: nclx
| | | colour_primaries: 1
| | | transfer_characteristics: 13
| | | matrix_coefficients: 6
| | | full_range_flag: 1
| | | 
| | | index: 3
| | | Box: ispe ----- (Image Spatial Extents)
| | | size: 20   (header size: 12)
| | | image width: 256
| | | image height: 96
| | | 
| | | index: 4
| | | Box: pixi ----- (Pixel Information)
| | | size: 16   (header size: 12)
| | | bits_per_channel: 8,8,8
| | | 
| | | index: 5
| | | Box: irot ----- (Image Rotation)
| | | size: 9   (header size: 8)
| | | rotation: 270 degrees (CCW)
| | 
| | Box: ipma ----- (Item Property Association)
| | size: 24   (header size: 12)
| | associations for item ID: 1
| | | property index: 1 (essential: true)    # hvcC
| | | property index: 2 (essential: false)   # colr
| | | property index: 3 (essential: false)   # ispe
| | | property index: 4 (essential: false)   # pixi
| | | property index: 5 (essential: true)    # irot
| 
| Box: iref ----- (Item Reference)
| size: 26   (header size: 12)
| reference with type 'cdsc' from ID: 2 to IDs: 1
```

```
heif-info -d /tmp/grid.heif
MIME type: image/heic
main brand: heic
compatible brands: mif1, heic, miaf
Box: ftyp ----- (File Type)
size: 28   (header size: 8)
major brand: heic
minor version: 0
compatible brands: mif1,heic,miaf

Box: meta ----- (Metadata)
size: 872   (header size: 12)
| Box: hdlr ----- (Handler Reference)
| size: 33   (header size: 12)
| pre_defined: 0
| handler_type: pict
| name: 
| 
| Box: idat ----- (Item Data)
| size: 16   (header size: 8)
| number of data bytes: 8
| 
| Box: iloc ----- (Item Location)
| size: 216   (header size: 12)
| item ID: 1
|   construction method: 1
|   data_reference_index: 0
|   base_offset: 0
|   extents: 0,8 
| item ID: 2
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 908
|   extents: 0,165 
| item ID: 3
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 1073
|   extents: 0,729 
| item ID: 4
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 1802
|   extents: 0,873 
| item ID: 5
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 2675
|   extents: 0,122 
| item ID: 6
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 2797
|   extents: 0,169 
| item ID: 7
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 2966
|   extents: 0,698 
| item ID: 8
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 3664
|   extents: 0,816 
| item ID: 9
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 4480
|   extents: 0,94 
| item ID: 10
|   construction method: 0
|   data_reference_index: 0
|   base_offset: 4574
|   extents: 0,30 
| 
| Box: iinf ----- (Item Information)
| size: 224   (header size: 12)
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 1
| | item_protection_index: 0
| | item_type: grid
| | item_name: 
| | hidden item: false
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 2
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 3
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 4
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 5
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 6
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 7
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 8
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 9
| | item_protection_index: 0
| | item_type: hvc1
| | item_name: 
| | hidden item: true
| | 
| | Box: infe ----- (Item Info Entry)
| | size: 21   (header size: 12)
| | item_ID: 10
| | item_protection_index: 0
| | item_type: Exif
| | item_name: 
| | hidden item: true
| 
| Box: pitm ----- (Primary Item)
| size: 14   (header size: 12)
| item_ID: 1
| 
| Box: iprp ----- (Item Properties)
| size: 303   (header size: 8)
| | Box: ipco ----- (Item Property Container)
| | size: 209   (header size: 8)
| | | index: 1
| | | Box: ispe ----- (Image Spatial Extents)
| | | size: 20   (header size: 12)
| | | image width: 256
| | | image height: 96
| | | 
| | | index: 2
| | | Box: hvcC ----- (HEVC Configuration Item)
| | | size: 117   (header size: 8)
| | | configuration_version: 1
| | | general_profile_space: 0
| | | general_tier_flag: 0
| | | general_profile_idc: 3
| | | general_profile_compatibility_flags: 0111.0000 0000.0000 0000.0000 0000.0000 
| | | general_constraint_indicator_flags: 00000000 00000000 00000000 00000000 00000000 00000000 
| | | general_level_idc: 30
| | | min_spatial_segmentation_idc: 0
| | | parallelism_type: 0
| | | chroma_format: 4:2:0
| | | bit_depth_luma: 8
| | | bit_depth_chroma: 8
| | | avg_frame_rate: 0
| | | constant_frame_rate: 0
| | | num_temporal_layers: 1
| | | temporal_id_nested: 1
| | | length_size: 4
| | | <array>
| | | | array_completeness: 1
| | | | NAL_unit_type: 32
| | | | 40 01 0c 01 ff ff 03 70 00 00 03 00 90 00 00 03 00 00 03 00 1e ba 02 40 
| | | <array>
| | | | array_completeness: 1
| | | | NAL_unit_type: 33
| | | | 42 01 01 03 70 00 00 03 00 90 00 00 03 00 00 03 00 1e a0 20 81 05 96 ea 49 29 ae 6c 08 00 00 03 00 c8 00 00 03 00 08 40 
| | | <array>
| | | | array_completeness: 1
| | | | NAL_unit_type: 34
| | | | 44 01 c1 72 b0 22 40 
| | | 
| | | index: 3
| | | Box: colr -----
| | | size: 19   (header size: 8)
| | | colour_type: nclx
| | | colour_primaries: 1
| | | transfer_characteristics: 13
| | | matrix_coefficients: 6
| | | full_range_flag: 1
| | | 
| | | index: 4
| | | Box: ispe ----- (Image Spatial Extents)
| | | size: 20   (header size: 12)
| | | image width: 64
| | | image height: 64
| | | 
| | | index: 5
| | | Box: pixi ----- (Pixel Information)
| | | size: 16   (header size: 12)
| | | bits_per_channel: 8,8,8
| | | 
| | | index: 6
| | | Box: irot ----- (Image Rotation)
| | | size: 9   (header size: 8)
| | | rotation: 270 degrees (CCW)
| | 
| | Box: ipma ----- (Item Property Association)
| | size: 86   (header size: 12)
| | associations for item ID: 1
| | | property index: 1 (essential: false)   # ispe
| | | property index: 5 (essential: true)    # pixi
| | | property index: 3 (essential: false)   # colr
| | associations for item ID: 2
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)     # **irot** here ?
| | associations for item ID: 3
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)
| | associations for item ID: 4
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)
| | associations for item ID: 5
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)
| | associations for item ID: 6
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)
| | associations for item ID: 7
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)
| | associations for item ID: 8
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)
| | associations for item ID: 9
| | | property index: 2 (essential: true)
| | | property index: 3 (essential: false)
| | | property index: 4 (essential: false)
| | | property index: 5 (essential: false)
| | | property index: 6 (essential: true)
| 
| Box: iref ----- (Item Reference)
| size: 54   (header size: 12)
| reference with type 'dimg' from ID: 1 to IDs: 2 3 4 5 6 7 8 9 
| reference with type 'cdsc' from ID: 10 to IDs: 1 
```