### PR TITLE
Include "bit" header for "std::endian".

### DIFF
--- a/libheif/codecs/uncompressed/unc_encoder_component_interleave.cc
+++ b/libheif/codecs/uncompressed/unc_encoder_component_interleave.cc
@@ -20,6 +20,7 @@
 
 #include "unc_encoder_component_interleave.h"
 
+#include <bit>
 #include <cstring>
 
 #include "pixelimage.h"


### PR DESCRIPTION
Fixes broken AppVeyor build.