### PR TITLE
Improve build coverage for oss-fuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,6 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [x86_64, i386]
+        sanitizer: [address, undefined, memory]
+        # Remove combinations not supported by action.
+        exclude:
+          - architecture: i386
+            sanitizer: undefined
+          - architecture: i386
+            sanitizer: memory
     steps:
     - name: Build Fuzzers
       id: build
@@ -23,12 +30,14 @@ jobs:
         oss-fuzz-project-name: 'libheif'
         dry-run: false
         architecture: ${{ matrix.architecture }}
+        sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'libheif'
         fuzz-seconds: 600
         dry-run: false
+        sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
       uses: actions/upload-artifact@v7
       if: failure() && steps.build.outcome == 'success'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   Fuzzing:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: [x86_64, i386]
     steps:
     - name: Build Fuzzers
       id: build
@@ -18,6 +22,7 @@ jobs:
       with:
         oss-fuzz-project-name: 'libheif'
         dry-run: false
+        architecture: ${{ matrix.architecture }}
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:

--- a/scripts/build-oss-fuzz.sh
+++ b/scripts/build-oss-fuzz.sh
@@ -136,6 +136,7 @@ cmake -G "Unix Makefiles" \
 	-DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 	-DCMAKE_INSTALL_PREFIX="$DEPS_PATH" \
 	-DENABLE_SHARED:bool=off \
+	-DENABLE_ASSEMBLY:bool=off \
 	-DENABLE_CLI:bool=off \
 	-DX265_LATEST_TAG=TRUE \
 	../../source

--- a/scripts/build-oss-fuzz.sh
+++ b/scripts/build-oss-fuzz.sh
@@ -236,6 +236,7 @@ cd "$WORK/x264"
 	--prefix="$DEPS_PATH" \
 	--enable-static \
 	--disable-shared \
+	--disable-asm \
 	--disable-cli
 make -j"$(nproc)"
 make install


### PR DESCRIPTION
Should detect build issues for the different architectures / sanitizers and finally fix #1758.