### PR TITLE
fix: typo correction in function name

### DIFF
--- a/libheif/codecs/hevc_boxes.cc
+++ b/libheif/codecs/hevc_boxes.cc
@@ -184,7 +184,7 @@ bool HEVCDecoderConfigurationRecord::get_general_profile_compatibility_flag(int 
 }
 
 
-bool HEVCDecoderConfigurationRecord::is_profile_compatibile(Profile profile) const
+bool HEVCDecoderConfigurationRecord::is_profile_compatible(Profile profile) const
 {
   return (general_profile_idc == profile ||
           get_general_profile_compatibility_flag(profile));

--- a/libheif/codecs/hevc_boxes.h
+++ b/libheif/codecs/hevc_boxes.h
@@ -83,7 +83,7 @@ struct HEVCDecoderConfigurationRecord
 
   bool get_general_profile_compatibility_flag(int idx) const;
 
-  bool is_profile_compatibile(Profile) const;
+  bool is_profile_compatible(Profile) const;
 };
 
 

--- a/libheif/image-items/hevc.cc
+++ b/libheif/image-items/hevc.cc
@@ -84,13 +84,13 @@ heif_brand2 ImageItem_HEVC::get_compatible_brand() const
   }
 
   const auto& config = hvcC->get_configuration();
-  if (config.is_profile_compatibile(HEVCDecoderConfigurationRecord::Profile_Main) ||
-      config.is_profile_compatibile(HEVCDecoderConfigurationRecord::Profile_MainStillPicture)) {
+  if (config.is_profile_compatible(HEVCDecoderConfigurationRecord::Profile_Main) ||
+      config.is_profile_compatible(HEVCDecoderConfigurationRecord::Profile_MainStillPicture)) {
     return heif_brand2_heic;
   }
 
-  if (config.is_profile_compatibile(HEVCDecoderConfigurationRecord::Profile_Main10) ||
-      config.is_profile_compatibile(HEVCDecoderConfigurationRecord::Profile_RExt)) {
+  if (config.is_profile_compatible(HEVCDecoderConfigurationRecord::Profile_Main10) ||
+      config.is_profile_compatible(HEVCDecoderConfigurationRecord::Profile_RExt)) {
     return heif_brand2_heix;
   }
 

--- a/libheif/sequences/track_visual.cc
+++ b/libheif/sequences/track_visual.cc
@@ -690,8 +690,8 @@ heif_brand2 Track_Visual::get_compatible_brand() const
       if (!hvcC) { return 0; }
 
       const auto& config = hvcC->get_configuration();
-      if (config.is_profile_compatibile(HEVCDecoderConfigurationRecord::Profile_Main) ||
-          config.is_profile_compatibile(HEVCDecoderConfigurationRecord::Profile_MainStillPicture)) {
+      if (config.is_profile_compatible(HEVCDecoderConfigurationRecord::Profile_Main) ||
+          config.is_profile_compatible(HEVCDecoderConfigurationRecord::Profile_MainStillPicture)) {
         return heif_brand2_hevc;
       }
       else {


### PR DESCRIPTION
This fixes a typo I noted when looking at the `heic` vs `heix` major brand change.

No functional or API change.