### PR TITLE
Fix SDL YV12 buffer overflow when converting 444 into 420

### DIFF
--- a/examples/sdl.cc
+++ b/examples/sdl.cc
@@ -251,7 +251,7 @@ void SDL_YUV_Display::display444as420(const unsigned char *Y,
     }
 
   uint8_t *startV = mPixels + (rect.h*mStride);
-  uint8_t *startU = startV + (rect.h*mStride/2);
+  uint8_t *startU = startV + (rect.h*mStride/4);
   for (int y=0;y<rect.h;y+=2)
     {
       uint8_t* u = startU + y/2*mStride/2;


### PR DESCRIPTION
This function is pointing base of U plane to the end of U plane, causing a buffer overflow.