### PR TITLE
decoders: guard against possible integer overflow

### DIFF
--- a/libheif/image/pixelimage.cc
+++ b/libheif/image/pixelimage.cc
@@ -1158,7 +1158,7 @@ void HeifPixelImage::zero_region(uint32_t x0, uint32_t y0, uint32_t w, uint32_t 
     size_t stride = 0;
     uint8_t* data = get_channel_memory(channel, &stride);
     uint32_t bytes_per_pixel = get_storage_bits_per_pixel(channel) / 8;
-    uint32_t width_bytes = cw * bytes_per_pixel;
+    size_t width_bytes = static_cast<size_t>(cw) * bytes_per_pixel;
 
     for (uint32_t y = 0; y < ch; y++) {
       memset(data + cx0 * bytes_per_pixel + (cy0 + y) * stride, 0, width_bytes);

--- a/libheif/plugins/decoder_aom.cc
+++ b/libheif/plugins/decoder_aom.cc
@@ -304,7 +304,7 @@ static heif_error get_next_image_from_decoder(aom_decoder* decoder,
     int bytes_per_pixel = (bpp + 7) / 8;
 
     for (int y = 0; y < h; y++) {
-      memcpy(dst_mem + y * dst_stride, data + y * stride, w * bytes_per_pixel);
+      memcpy(dst_mem + y * dst_stride, data + y * stride, static_cast<size_t>(w) * bytes_per_pixel);
     }
   }
 

--- a/libheif/plugins/decoder_dav1d.cc
+++ b/libheif/plugins/decoder_dav1d.cc
@@ -375,7 +375,7 @@ heif_error dav1d_decode_next_image2(void* decoder_raw, heif_image** out_img,
     const int bytes_per_pixel = (bpp + 7) / 8;
 
     for (uint32_t y = 0; y < h; y++) {
-      memcpy(dst_mem + y * dst_stride, data + y * stride, w * bytes_per_pixel);
+      memcpy(dst_mem + y * dst_stride, data + y * stride, static_cast<size_t>(w) * bytes_per_pixel);
     }
   }
 

--- a/libheif/plugins/decoder_ffmpeg.cc
+++ b/libheif/plugins/decoder_ffmpeg.cc
@@ -457,7 +457,7 @@ static heif_error ffmpeg_av_decode(ffmpeg_decoder* decoder, AVCodecContext* av_d
       int bytes_per_pixel = (bpp + 7) / 8;
 
       for (int y = 0; y < h; y++) {
-        memcpy(dst_mem + y * dst_stride, data + y * stride, w * bytes_per_pixel);
+        memcpy(dst_mem + y * dst_stride, data + y * stride, static_cast<size_t>(w) * bytes_per_pixel);
       }
     }
 

--- a/libheif/plugins/decoder_libde265.cc
+++ b/libheif/plugins/decoder_libde265.cc
@@ -161,7 +161,7 @@ static heif_error convert_libde265_image_to_heif_image(libde265_decoder* decoder
     int bytes_per_pixel = (bpp + 7) / 8;
 
     for (int y = 0; y < h; y++) {
-      memcpy(dst_mem + y * dst_stride, data + y * stride, w * bytes_per_pixel);
+      memcpy(dst_mem + y * dst_stride, data + y * stride, static_cast<size_t>(w) * bytes_per_pixel);
     }
   }
 

--- a/libheif/plugins/decoder_vvdec.cc
+++ b/libheif/plugins/decoder_vvdec.cc
@@ -377,7 +377,7 @@ heif_error vvdec_decode_next_image2(void* decoder_raw, heif_image** out_img,
     int bytes_per_pixel = (bpp + 7) / 8;
 
     for (int y = 0; y < h; y++) {
-      memcpy(dst_mem + y * dst_stride, data + y * stride, w * bytes_per_pixel);
+      memcpy(dst_mem + y * dst_stride, data + y * stride, static_cast<size_t>(w) * bytes_per_pixel);
     }
 
 #if 0


### PR DESCRIPTION
This keeps things consistent with other parts of the codebase where stride is typically represented as `size_t`.

I don't think this is exploitable, plus existing security limits guard should protect against it being reached, but this change at least silences static analysis tooling.