### PR TITLE
decoder_aom: ensure security limits apply to all frames

### DIFF
--- a/libheif/plugins/decoder_aom.cc
+++ b/libheif/plugins/decoder_aom.cc
@@ -335,7 +335,7 @@ heif_error aom_push_data2(void* decoder_raw, const void* frame_data, size_t fram
   for (;;) {
     heif_image* img;
     uintptr_t out_user_data;
-    heif_error err = get_next_image_from_decoder(decoder, &iter, &img, &out_user_data, nullptr); // TODO: send limits);
+    heif_error err = get_next_image_from_decoder(decoder, &iter, &img, &out_user_data, heif_get_global_security_limits());
     if (err.code) {
       return err;
     }


### PR DESCRIPTION
It looks like these were being ignored for animated AVIF sequences as `nullptr` skips the check here:

https://github.com/strukturag/libheif/blob/7283380ec21003a6812d8a1e7e4328bdda8b2026/libheif/pixelimage.cc#L654

I'm unsure if applying the "global" limits is the correct way to implement this but that's probably better than not having any limits. An alternative approach might be to modify the `heif_decoder_plugin_options` struct to add custom `limits` and pass it along that way.