### PR TITLE
region: ensure offset is incremented after parsing inline mask

### DIFF
--- a/libheif/region.cc
+++ b/libheif/region.cc
@@ -496,6 +496,7 @@ Error RegionGeometry_InlineMask::parse(const std::vector<uint8_t>& data,
 
   mask_data.resize(bytes_for_mask);
   std::copy(data.begin() + *dataOffset, data.begin() + *dataOffset + static_cast<ptrdiff_t>(bytes_for_mask), mask_data.begin());
+  *dataOffset += static_cast<unsigned int>(bytes_for_mask);
   return Error::Ok;
 }
 


### PR DESCRIPTION
Most region parsers rely on `parse_unsigned` to increment `dataOffset` but inline masks are slightly different in that they involve copying data into a buffer. I think this means we need to manually increment the offset before further parsing.

Disclosure: I used LLM-based tooling to help find this bug but the (attempt at a) fix is mine.