### PR TITLE
fix: heap-buffer-overflow in heif_image_crop via coordinate remap underflow

### DIFF
--- a/libheif/api/libheif/heif_image.cc
+++ b/libheif/api/libheif/heif_image.cc
@@ -95,7 +95,16 @@ heif_error heif_image_crop(heif_image* img,
     };
   }
 
-  auto cropResult = img->image->crop(left, static_cast<int>(w) - 1 - right, top, static_cast<int>(h) - 1 - bottom, nullptr);
+  if (left < 0 || top < 0 || right < left || bottom < top ||
+      static_cast<uint32_t>(right) >= w || static_cast<uint32_t>(bottom) >= h) {
+    return heif_error{
+      heif_error_Usage_error,
+      heif_suberror_Invalid_parameter_value,
+      "Invalid crop coordinates"
+    };
+  }
+
+  auto cropResult = img->image->crop(left, right, top, bottom, nullptr);
   if (!cropResult) {
     return cropResult.error_struct(img->image.get());
   }


### PR DESCRIPTION
## Summary

Fixes #1746.

`heif_image_crop()` remaps coordinate-style crop arguments (`left, right, top, bottom`) to margin-style values before calling the internal `crop()` function. For certain valid-looking crop rectangles, this remap produces `right < left`, which causes unsigned integer underflow in `ImageComponent::crop()` at `pixelimage.cc:1625`. The resulting `memcpy` tries to read ~4 GB (`4294967284` bytes) past a 20,751-byte heap buffer.

## Root cause

The API function `heif_image_crop()` in `heif_image.cc:98` remaps coordinates like this:
```
crop(left, w-1-right, top, h-1-bottom)
```
But the internal `HeifPixelImage::crop()` expects coordinate endpoints, not margins. This semantic mismatch creates `right < left` for inputs that are perfectly valid as coordinates.

I added fprintf probes to trace the values through:
1. Harness called with `image_wh=72x72`, `crop_lrtb=(34,41,22,27)`, `crop_wh=(8,6)` - all valid
2. `heif_image_crop()` remapped to `left=34 right=30 top=22 bottom=44` - now `right < left`
3. `HeifPixelImage::crop()` computed `dst_wh=4294967293 x 23` (unsigned wrap of `30-34+1`)
4. `ImageComponent::crop` memcpy then read `4294967284` bytes past the buffer (confirmed by ASan)

So the problem is the remap in `heif_image_crop()` converting valid coordinates into invalid ones before the internal crop function sees them.

## Fix

Two changes in `heif_image_crop()` (`libheif/api/libheif/heif_image.cc`):
1. Added bounds validation: reject negative coords, enforce `right >= left` and `bottom >= top`, check `right < w` and `bottom < h`
2. Removed the margin remap and pass coordinates directly to `crop(left, right, top, bottom)`

## Why this approach

I looked at two places:
- **Guard in `ImageComponent::crop`** (crash site): would only protect this specific memcpy. Doesn't fix the upstream contract mismatch and could turn a loud crash into silent wrong behavior. Didn't go with this.
- **Fix the remap in `heif_image_crop`** (went with this): this is where the bad state is first created. Fixing the coordinate contract at the API boundary protects all downstream paths. Returns a clean `heif_error` through the existing error flow.

## Verification

Tested with ASan-instrumented build (`-fsanitize=address`, `detect_leaks=1`):
- **Before**: `SUMMARY: AddressSanitizer: heap-buffer-overflow /src/libheif/libheif/pixelimage.cc:1625:5` (READ of size 4294967284, exit=1)
- **After**: no heap-buffer-overflow, crop completes successfully (`heif_image_crop code=0 sub=0`, exit=0)
