### PR TITLE
heif_entity_groups: fix NULL deref on unknown grpl child types

### DIFF
--- a/libheif/api/libheif/heif_entity_groups.cc
+++ b/libheif/api/libheif/heif_entity_groups.cc
@@ -53,6 +53,7 @@ heif_entity_group* heif_context_get_entity_groups(const heif_context* ctx,
     }
 
     auto groupBox = std::dynamic_pointer_cast<Box_EntityToGroup>(group);
+    if (!groupBox) continue;
     const std::vector<heif_item_id>& items = groupBox->get_item_ids();
 
     if (item_filter != 0 && std::all_of(items.begin(), items.end(), [item_filter](heif_item_id item) {


### PR DESCRIPTION
# NULL pointer dereference in heif_context_get_entity_groups on malformed grpl box

## Summary

`heif_context_get_entity_groups()` crashes with a NULL pointer dereference when a HEIF file contains a `grpl` box with child boxes whose four-cc type is not one of the three registered `Box_EntityToGroup` types (`pymd`, `altr`, `ster`). The `dynamic_pointer_cast<Box_EntityToGroup>` returns `nullptr` for unrecognized types, and the result is dereferenced without a null check. Any application that calls this public C API on attacker-supplied HEIF input crashes.

## Reproduction

### Minimal PoC structure (505 bytes)

A HEIF file with a `grpl` box containing a `pict` child (or any four-cc not in `{pymd, altr, ster}`):

```
ftyp  heic / mif2heic
meta {
  grpl {
    pict { ... }    <-- not a Box_EntityToGroup subclass
  }
  pitm, iloc, iinf/infe(hvc1), iprp/ipco/{hvcC, ispe}, ipma
}
mdat ...
```

### Trigger code

```c
heif_context* ctx = heif_context_alloc();
heif_context_read_from_file(ctx, "poc.heif", NULL);
int num_groups = 0;
heif_entity_group* groups = heif_context_get_entity_groups(ctx, 0, 0, &num_groups);
// SEGV at Box_EntityToGroup::get_group_id(), reading this+0xa8
```

### PoC hex (first 64 bytes of 505-byte file)

```
00000000: 0000 0018 6674 7970 6865 6963 0000 0000  ....ftypheic....
00000010: 6d69 6632 6865 6963 0000 012e 6d65 7461  mif2heic....meta
00000020: 0000 0000 0000 0021 6772 706c 0000 0000  .......!grpl....
00000030: 0000 0000 7069 6374 0000 0000 0000 0000  ....pict........
```

## ASAN stack trace

```
==968283==ERROR: AddressSanitizer: SEGV on unknown address 0x0000000000a8
==968283==The signal is caused by a READ memory access.
    #0 Box_EntityToGroup::get_group_id() const          libheif/box.h:1104:54
    #1 heif_context_get_entity_groups                   libheif/api/libheif/heif_entity_groups.cc:74:43
    #2 LLVMFuzzerTestOneInput                           heif_gaps_fuzzer.cc:310:5
SUMMARY: AddressSanitizer: SEGV libheif/box.h:1104:54 in Box_EntityToGroup::get_group_id() const
```

## Root cause

**File**: `libheif/api/libheif/heif_entity_groups.cc:55-74`

```cpp
for (auto& group : all_entity_group_boxes) {
  auto groupBox = std::dynamic_pointer_cast<Box_EntityToGroup>(group);  // line 55: nullptr for unknown types
  const std::vector<heif_item_id>& items = groupBox->get_item_ids();    // line 56: NULL deref
  // ...
  entity_group_boxes.emplace_back(groupBox);                            // line 64: nullptr stored
}

for (size_t i = 0; i < entity_group_boxes.size(); i++) {
  groups[i].entity_group_id = entity_group_boxes[i]->get_group_id();    // line 74: SEGV at this+0xa8
}
```

The box dispatch table (`box.cc:557-579`) registers only `pymd`, `altr`, and `ster` as `Box_EntityToGroup` subclasses. All other four-cc types parse to `Box_other`, which does not inherit from `Box_EntityToGroup`. The cast correctly returns `nullptr`, but the function never checks.

## Impact

- **Who**: Any application calling `heif_context_get_entity_groups()` on untrusted HEIF files (thumbnailers, metadata extractors, image viewers surfacing stereo/pyramid/alternate-group info)
- **Severity**: DoS (crash). Not memory corruption -- `this` is a true nullptr, the read at `this+0xa8` lands on an unmapped page. No spray opportunity. Cannot chain to RCE.
- **OSS-Fuzz gap**: OSS-Fuzz's `file_fuzzer` never calls `heif_context_get_entity_groups()`. 207 crashes found in ~110 minutes of targeted fuzzing.

## Suggested Fix

One-line null check after the cast:

```cpp
// libheif/api/libheif/heif_entity_groups.cc:55
auto groupBox = std::dynamic_pointer_cast<Box_EntityToGroup>(group);
if (!groupBox) continue;  // <-- add this
const std::vector<heif_item_id>& items = groupBox->get_item_ids();
```

The second loop (line 70-85) becomes safe automatically once nullptrs are filtered before `emplace_back`.

## Environment

- libheif: current HEAD as of 2026-05-06
- Compiler: clang with ASan + AFL++ instrumentation
- Harness: AFL++, 4 instances, 29-seed corpus