### PR TITLE
grid: fix OOB read in decode_grid_tile when grid exceeds tile count

### DIFF
--- a/libheif/image-items/grid.cc
+++ b/libheif/image-items/grid.cc
@@ -583,7 +583,11 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem_Grid::decode_grid_tile(const h
 {
   uint32_t idx = ty * m_grid_spec.get_columns() + tx;
 
-  assert(idx < m_grid_tile_ids.size());
+  if (idx >= m_grid_tile_ids.size()) {
+    return Error{heif_error_Invalid_input,
+                 heif_suberror_Missing_grid_images,
+                 "Grid tile coordinate out of range"};
+  }
 
   heif_item_id tile_id = m_grid_tile_ids[idx];
   std::shared_ptr<const ImageItem> tile_item = get_context()->get_image(tile_id, true);


### PR DESCRIPTION
# Out-of-bounds heap read in decode_grid_tile on malformed grid dimensions

## Summary

`ImageItem_Grid::decode_grid_tile()` indexes its `m_grid_tile_ids` vector with `ty * columns + tx`, guarded only by an `assert()` that is compiled out in Release builds (`-DNDEBUG`). When the grid header declares `cols x rows` larger than the actual `dimg` iref tile count, the computed index exceeds the vector size, causing a heap out-of-bounds read. On ASAN builds this is a SEGV; on production builds the OOB read returns heap garbage which is then used as a `heif_item_id` for a lookup that will likely return nullptr (triggering the sibling null-deref bug one line later).

## Reproduction

### Trigger condition

A HEIF file where the grid spec declares more tiles (cols * rows) than the `dimg` iref actually references. The `heif_image_handle_decode_image_tile()` API does not validate tile coordinates against the actual vector size.

### Trigger code

```c
heif_image* tile_img = NULL;
heif_error err = heif_image_handle_decode_image_tile(handle, &tile_img,
                                                     heif_colorspace_YCbCr,
                                                     heif_chroma_420,
                                                     NULL, /*x0=*/0, /*y0=*/0);
// SEGV at grid.cc:588 -- OOB read on m_grid_tile_ids
```

### PoC file

`grid_oob_repro.heif` -- deterministic crash at the same heap offset across 2 independent AFL++ instances.

## ASAN stack trace

```
==2912223==ERROR: AddressSanitizer: SEGV on unknown address 0x510400001100 (READ)
    #0 ImageItem_Grid::decode_grid_tile(...)       libheif/image-items/grid.cc:588:26
    #1 ImageItem_Grid::decode_compressed_image(...) libheif/image-items/grid.cc:224:12
    #2 ImageItem::decode_image(...)                 libheif/image-items/image_item.cc:747:60
    #3 HeifContext::decode_image(...)               libheif/context.cc:1404:34
    #4 heif_image_handle_decode_image_tile          libheif/api/libheif/heif_tiling.cc:108:81
```

Register state: `rcx = 0x0000510000001140` (vector data pointer), crash address `0x510400001100` -- approximately 1 GiB past the vector's heap allocation.

## Root cause

**File**: `libheif/image-items/grid.cc:584-588`

```cpp
uint32_t idx = ty * m_grid_spec.get_columns() + tx;    // can exceed vector size
assert(idx < m_grid_tile_ids.size());                   // NOP in Release (-DNDEBUG)
heif_item_id tile_id = m_grid_tile_ids[idx];            // OOB read
```

The sibling API `heif_image_handle_get_grid_image_tile_id()` (heif_tiling.cc:74) correctly rejects `tile_x >= columns || tile_y >= rows`. But `heif_image_handle_decode_image_tile()` (heif_tiling.cc:92) passes coordinates straight through without validation.

## Impact

- **Who**: Same attack surface as the sibling null-deref -- any app using per-tile HEIF decoding on untrusted input.
- **Severity**: DoS (crash on ASAN/debug builds; on production builds, the OOB read of a 4-byte `heif_item_id` is unlikely to be exploitable but reads heap contents). Not memory corruption in the write sense.
- **OSS-Fuzz gap**: Same as sibling -- `file_fuzzer` never calls the tile-by-tile API.

## Suggested Fix

Replace the debug-only assert with a runtime bounds check:

```cpp
uint32_t idx = ty * m_grid_spec.get_columns() + tx;

if (idx >= m_grid_tile_ids.size()) {
  return Error{heif_error_Invalid_input,
               heif_suberror_Unspecified,
               "Grid tile coordinate out of range"};
}

heif_item_id tile_id = m_grid_tile_ids[idx];
```

Additionally, for parity with `heif_image_handle_get_grid_image_tile_id()`, add coordinate validation at the public API entry point `heif_image_handle_decode_image_tile()` (heif_tiling.cc:92):

```cpp
if (auto gridItem = std::dynamic_pointer_cast<ImageItem_Grid>(in_handle->image)) {
  const ImageGrid& gridspec = gridItem->get_grid_spec();
  if (x0 >= gridspec.get_columns() || y0 >= gridspec.get_rows()) {
    return {heif_error_Usage_error, heif_suberror_Unspecified, "Grid tile index out of range"};
  }
}
```

## Environment

- libheif: current HEAD as of 2026-05-07
- Compiler: clang with ASan + AFL++ instrumentation
- Harness: AFL++, 4 instances, ~18.6h runtime