### PR TITLE
heif_properties.h: fix "bad_pixels" type

### DIFF
--- a/libheif/api/libheif/heif_properties.h
+++ b/libheif/api/libheif/heif_properties.h
@@ -335,7 +335,7 @@ heif_error heif_image_add_sensor_bad_pixels_map(heif_image*,
                                                  uint32_t num_bad_columns,
                                                  const uint32_t* bad_columns,
                                                  uint32_t num_bad_pixels,
-                                                 const heif_bad_pixel* bad_pixels);
+                                                 const struct heif_bad_pixel* bad_pixels);
 
 // Returns the number of sensor bad pixels maps on this image (0 if none).
 LIBHEIF_API


### PR DESCRIPTION
Problem found when trying to build the latest ImageMagick with the latest libheif.