### PR TITLE
svt: don't allow getting qp unless it's set

### DIFF
--- a/libheif/plugins/encoder_svt.cc
+++ b/libheif/plugins/encoder_svt.cc
@@ -475,10 +475,16 @@ heif_error svt_get_parameter_integer(void* encoder_raw, const char* name, int* v
   else if (strcmp(name, heif_encoder_parameter_name_lossless) == 0) {
     return svt_get_parameter_lossless(encoder, value);
   }
+  else if (strcmp(name, kParam_qp) == 0) {
+    if (!encoder->qp_set) {
+      return heif_error_unsupported_parameter;
+    }
+    *value = encoder->qp;
+    return heif_error_ok;
+  }
 
   get_value(kParam_min_q, min_q);
   get_value(kParam_max_q, max_q);
-  get_value(kParam_qp, qp); // TODO: what if qp was not set ?
   get_value(kParam_threads, threads);
   get_value(kParam_speed, speed);
   get_value("tile-rows", tile_rows);


### PR DESCRIPTION
Prevents getting the qp parameter unless `qp_set` is `true`. Without this check, no distinction is made between real values and uninitialized ones, which can lead to false assumptions.

----

After upgrading to 1.22.0, I noticed some of my svt encoding calls started failing with `Svt[error]: CRF must be [0 - 63]`. Upon further investigation, it seems this started happening after c992822.

Looking at the changes introduced in that commit, when copying parameters for the alpha encode, the uninitialized `qp` is happily returned, and subsequently set, flipping `qp_set` to true in the copy. A TODO annotation even points out that this could be problematic.

To aid in understanding this issue, I had AI generate sample code for reproducing it, which turned out a bit verbose, but useful nonetheless. Without the proposed changes, we get the failure. With the changes applied, there are no failures.
[reproduce.c](https://github.com/user-attachments/files/28111505/a.c)

I can also confirm this fixes the failures I saw in my real use-case of libheif.
