### PR TITLE
file_layout: add box size integer overflow checks

### DIFF
--- a/libheif/file_layout.cc
+++ b/libheif/file_layout.cc
@@ -135,8 +135,13 @@ Error FileLayout::read(const std::shared_ptr<StreamReader>& stream, const heif_s
                 "Cannot read meta box with unspecified size"};
       }
 
-      // TODO: overflow
-      uint64_t end_of_meta_box = meta_box_start + box_header.get_box_size();
+      uint64_t end_of_meta_box = box_header.get_box_size();
+      if (end_of_meta_box > std::numeric_limits<uint64_t>::max() - meta_box_start) {
+        return {heif_error_Invalid_input,
+                heif_suberror_No_meta_box,
+                "Cannot read meta box with invalid size"};
+      }
+      end_of_meta_box += meta_box_start;
       if (m_max_length < end_of_meta_box) {
         m_max_length = m_stream_reader->request_range(meta_box_start, end_of_meta_box);
       }
@@ -168,7 +173,13 @@ Error FileLayout::read(const std::shared_ptr<StreamReader>& stream, const heif_s
                 heif_suberror_Invalid_mini_box,
                 "Cannot read mini box with unspecified size"};
       }
-      uint64_t end_of_mini_box = mini_box_start + box_header.get_box_size();
+      uint64_t end_of_mini_box = box_header.get_box_size();
+      if (end_of_mini_box > std::numeric_limits<uint64_t>::max() - mini_box_start) {
+        return {heif_error_Invalid_input,
+                heif_suberror_Invalid_mini_box,
+                "Cannot read mini box with invalid size"};
+      }
+      end_of_mini_box += mini_box_start;
       if (m_max_length < end_of_mini_box) {
         m_max_length = m_stream_reader->request_range(mini_box_start, end_of_mini_box);
       }
@@ -200,8 +211,13 @@ Error FileLayout::read(const std::shared_ptr<StreamReader>& stream, const heif_s
                 "Cannot read moov box with unspecified size"};
       }
 
-      // TODO: overflow
-      uint64_t end_of_moov_box = moov_box_start + box_header.get_box_size();
+      uint64_t end_of_moov_box = box_header.get_box_size();
+      if (end_of_moov_box > std::numeric_limits<uint64_t>::max() - moov_box_start) {
+        return {heif_error_Invalid_input,
+                heif_suberror_No_moov_box,
+                "Cannot read moov box with invalid size"};
+      }
+      end_of_moov_box += moov_box_start;
       if (m_max_length < end_of_moov_box) {
         m_max_length = m_stream_reader->request_range(moov_box_start, end_of_moov_box);
       }

--- a/libheif/mini.cc
+++ b/libheif/mini.cc
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -55,6 +56,11 @@ Error Box_mini::parse(BitstreamRange &range, const heif_security_limits *limits)
     return range.get_error();
   }
 
+  if (mini_data.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return {heif_error_Invalid_input,
+            heif_suberror_Invalid_mini_box,
+            "Payload too large in MinimizedImageBox"};
+  }
   BitReader bits(mini_data.data(), (int)(mini_data.size()));
 
   m_version = bits.get_bits8(2);
@@ -1295,6 +1301,12 @@ static Error parse_codec_config_box(const std::vector<uint8_t>& config_bytes,
                                     std::shared_ptr<Box>* out_box)
 {
   const size_t header_size = 8;
+  if (config_bytes.size() > std::numeric_limits<size_t>::max() - header_size) {
+    return {heif_error_Invalid_input,
+            heif_suberror_Invalid_mini_box,
+            "Codec config in MinimizedImageBox is too large"};
+  }
+
   const size_t total_size = header_size + config_bytes.size();
   if (total_size > 0x7FFFFFFFu) {
     return {heif_error_Invalid_input,


### PR DESCRIPTION
Implements a couple of "TODO" comments, plus similar missing checks in neighbouring code. I suspect the existing security limits would prevent this also, so unlikely to be exploitable when using defaults.