### PR TITLE
uncompressed: enforce security limits on icef unit allocation

### DIFF
--- a/libheif/codecs/uncompressed/unc_boxes.cc
+++ b/libheif/codecs/uncompressed/unc_boxes.cc
@@ -833,9 +833,12 @@ Error Box_icef::parse(BitstreamRange& range, const heif_security_limits* limits)
             sstr.str()};
   }
 
-  // TODO: should we impose some security limit?
-
   // --- read box content
+
+  if (auto err = m_memory_handle.alloc(num_compressed_units, sizeof(CompressedUnitInfo),
+                                       limits, "icef box compressed unit infos")) {
+    return err;
+  }
 
   m_unit_infos.resize(num_compressed_units);
 

--- a/libheif/codecs/uncompressed/unc_boxes.h
+++ b/libheif/codecs/uncompressed/unc_boxes.h
@@ -335,6 +335,7 @@ protected:
   Error parse(BitstreamRange& range, const heif_security_limits* limits) override;
 
   std::vector<CompressedUnitInfo> m_unit_infos;
+  MemoryHandle m_memory_handle;
 
 private:
   const uint8_t get_required_offset_code(uint64_t offset) const;


### PR DESCRIPTION
Box_icef::parse() resized m_unit_infos to the file-controlled num_compressed_units without routing the allocation through the security-limits memory accounting (the existing "// TODO: should we impose some security limit?"). A crafted icef box could therefore drive a very large allocation before the per-unit reads run.

Allocate via m_memory_handle.alloc(num_compressed_units, sizeof(CompressedUnitInfo), limits, ...) before the resize, mirroring Box_snuc and the sequence boxes, so the configured heif_security_limits apply.