### PR TITLE
Validate bit depth in uvg266 encoder

### DIFF
--- a/libheif/plugins/encoder_uvg266.cc
+++ b/libheif/plugins/encoder_uvg266.cc
@@ -479,6 +479,13 @@ static heif_error uvg266_start_sequence_encoding_intern(void* encoder_raw, const
   }
 
   int bit_depth = heif_image_get_bits_per_pixel_range(image, heif_channel_Y);
+  if (bit_depth != UVG_BIT_DEPTH) {
+    return {
+      heif_error_Encoder_plugin_error,
+      heif_suberror_Unsupported_bit_depth,
+      kError_unsupported_bit_depth
+    };
+  }
 
   const uvg_api* api = uvg_api_get(bit_depth);
   if (api == nullptr) {


### PR DESCRIPTION
uvg266 seems to only support 8-bit, and the existing bit depth detection is flawed because the upstream ignores the bit depth passed in (https://github.com/ultravideo/uvg266/blob/fb17bbc1ca64ca059293f45627886b1faa2faff7/src/uvg266.c#L423). Adds direct validation to only accept 8-bit images.