### PR TITLE
svt encoder: use fractional QP via "cqp" option with SVT-AV1 >= 4.2.0

### DIFF
--- a/libheif/plugins/encoder_svt.cc
+++ b/libheif/plugins/encoder_svt.cc
@@ -28,6 +28,8 @@
 #include <deque>
 #include <memory>
 #include <limits>
+#include <cmath>
+#include <cstdio>
 
 #include "svt-av1/EbSvtAv1.h"
 #include "svt-av1/EbSvtAv1Enc.h"
@@ -853,16 +855,25 @@ static heif_error svt_start_sequence_encoding_intern(void* encoder_raw, const he
   // disable 2-pass
   svt_config.rc_stats_buffer = SvtAv1FixedBuf{nullptr, 0};
 
-  svt_config.rate_control_mode = 0; // constant rate factor
   //svt_config.enable_adaptive_quantization = 0;   // 2 is CRF (the default), 0 would be CQP
-  int qp;
+  float qp;
   if (encoder->qp_set) {
-    qp = encoder->qp;
+    qp = (float) encoder->qp;
   }
   else {
-    qp = ((100 - encoder->quality) * 63 + 50) / 100;
+    qp = (float) (100 - encoder->quality) * 63.0f / 100.0f;
   }
-  svt_config.qp = qp;
+#if SVT_AV1_CHECK_VERSION(4, 2, 0)
+  // "cqp" accepts fractional QP values and switches to constant-QP rate control.
+  char qp_string[64];
+  snprintf(qp_string, sizeof(qp_string), "%.2f", qp);
+  if (svt_av1_enc_parse_parameter(&svt_config, "cqp", qp_string) != EB_ErrorNone) {
+    return heif_error_codec_library_error;
+  }
+#else
+  svt_config.qp = (uint32_t) std::lround(qp);
+  svt_config.rate_control_mode = 0; // constant rate factor
+#endif
   svt_config.min_qp_allowed = encoder->min_q;
   svt_config.max_qp_allowed = encoder->max_q;
 


### PR DESCRIPTION
When libheif is built against SVT-AV1 >= 4.2.0, the encoder QP is passed through `svt_av1_enc_parse_parameter(&config, "cqp", ...)` instead of assigning `svt_config.qp` directly. The `"cqp"` option (introduced in SVT-AV1 4.2.0):

- accepts fractional QP values with quarter-QP precision
- sets `rate_control_mode = 0`

The QP derived from the `quality` parameter is no longer rounded to an integer:
e.g. `quality=50` now maps to CQP 31.50 instead of 32, so the 0–100 quality scale gets finer granularity. For SVT-AV1 < 4.2.0 the behavior is unchanged — the fractional value is rounded to the same integer the previous formula produced.

### Testing

Built against SVT-AV1 v4.2.0:

- `heif-enc -A -q 50` → SVT log shows `BRC mode / CQP Assignment: CQP / 31.50`
- `heif-enc -A -p qp=40` → `CQP / 40.00`,
- out-of-range QP values are rejected by SVT-AV1 at encoder initialization.

### Possible follow-ups (separate PRs)

Things worth considering next, intentionally left out of this PR:

- Use `svt_av1_enc_parse_parameter()` for setting the other encoder parameters as well — libheif would gain SVT-AV1's own validation of the values it sets.
- Allow setting a fractional CQP directly from the CLI / encoder parameter API. This PR only enables the fractional `quality` → QP mapping; the `qp` parameter still accepts integers only.
