### PR TITLE
Add altt, crtt, mdft boxes

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,8 @@
 include_directories(${libheif_BINARY_DIR} ${libheif_SOURCE_DIR}/libheif/api ${libheif_SOURCE_DIR}/libheif)
 
 if (MSVC)
+    # https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+    add_compile_options(/Zc:__cplusplus)
     set(getopt_sources
             ../extra/getopt.c
             ../extra/getopt.h

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -187,7 +187,7 @@ std::optional<long> parse_int(const char* s)
 
 // for benchmarking
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 201103L
 std::chrono::time_point<std::chrono::high_resolution_clock> time_encoding_start;
 std::chrono::time_point<std::chrono::high_resolution_clock> time_encoding_end;
 #endif
@@ -2395,7 +2395,7 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
       primary_image = image;
     }
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 201103L
     if (run_benchmark) {
       time_encoding_start = std::chrono::high_resolution_clock::now();
     }
@@ -2586,7 +2586,7 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
       }
     }
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 201103L
     if (run_benchmark) {
       time_encoding_end = std::chrono::high_resolution_clock::now();
     }
@@ -2689,8 +2689,8 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
   if (run_benchmark) {
     double psnr = compute_psnr(primary_image.get(), output_filename);
     std::cout << "PSNR: " << std::setprecision(2) << std::fixed << psnr << " ";
-#if __cplusplus >= 202002L
-    std::cout << "time: " << std::chrono::duration_cast<std::chrono::milliseconds>(time_encoding_end - time_encoding_start) << " ";
+#if __cplusplus >= 201103L
+    std::cout << "time: " << std::chrono::duration_cast<std::chrono::milliseconds>(time_encoding_end - time_encoding_start).count() << "ms ";
 #endif
     std::ifstream istr(output_filename.c_str());
     istr.seekg(0, std::ios_base::end);

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -43,7 +43,9 @@
 #include <map>
 #include <tuple>
 #include <random>
+#if __cplusplus >= 201103L
 #include <chrono>
+#endif
 
 #include <libheif/heif.h>
 #include <libheif/heif_properties.h>
@@ -165,7 +167,9 @@ std::string property_pitm_description;
 std::string property_pitm_name;
 std::string property_pitm_tags;
 std::string property_pitm_alt_text;
+#if __cplusplus >= 201103L
 std::optional<std::chrono::time_point<std::chrono::system_clock>> property_pitm_timestamp;
+#endif
 
 RawImageParameters raw_input_params;
 bool force_raw_input = false;
@@ -183,8 +187,10 @@ std::optional<long> parse_int(const char* s)
 
 // for benchmarking
 
+#if __cplusplus >= 202002L
 std::chrono::time_point<std::chrono::high_resolution_clock> time_encoding_start;
 std::chrono::time_point<std::chrono::high_resolution_clock> time_encoding_end;
+#endif
 
 const int OPTION_NCLX_MATRIX_COEFFICIENTS = 1000;
 const int OPTION_NCLX_COLOUR_PRIMARIES = 1001;
@@ -392,7 +398,9 @@ static option long_options[] = {
     {(char* const) "pitm-name",                   required_argument, 0,                     OPTION_PITM_NAME},
     {(char* const) "pitm-tags",                   required_argument, 0,                     OPTION_PITM_TAGS},
     {(char* const) "pitm-alt",                    required_argument, 0,                     OPTION_PITM_ALT_TEXT},
+#if __cplusplus >= 201103L
     {(char* const) "pitm-timestamp",              no_argument,       0,                     OPTION_PITM_TIMESTAMP},
+#endif
     {(char* const) "chroma-downsampling",         required_argument, 0, 'C'},
     {(char* const) "cut-tiles",                   required_argument, nullptr, OPTION_CUT_TILES},
     {(char* const) "tiled-input",                 no_argument, 0, 'T'},
@@ -487,7 +495,9 @@ void show_help(const char* argv0)
             << "      --pitm-name TEXT              set user name for primary image\n"
             << "      --pitm-tags TEXT              set comma-separated user tags for primary image\n"
             << "      --pitm-alt TEXT               set alt text for primary image\n"
+#if __cplusplus >= 201103L
             << "      --pitm-timestamp              set timestamp for primary image to current system timestamp\n"
+#endif
 #if HEIF_ENABLE_EXPERIMENTAL_FEATURES
             << "      --add-mime-item TYPE       add a mime item of the specified content type (experimental)\n"
             << "      --mime-item-file FILE      use the specified FILE as the data to put into the mime item (experimental)\n"
@@ -1593,9 +1603,11 @@ int main(int argc, char** argv)
       case OPTION_PITM_ALT_TEXT:
         property_pitm_alt_text = optarg;
         break;
+#if __cplusplus >= 201103L
       case OPTION_PITM_TIMESTAMP:
         property_pitm_timestamp = std::chrono::system_clock::now();
         break;
+#endif
       case OPTION_USE_HEVC_COMPRESSION:
         force_enc_hevc = true;
         break;
@@ -2383,9 +2395,11 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
       primary_image = image;
     }
 
+#if __cplusplus >= 202002L
     if (run_benchmark) {
       time_encoding_start = std::chrono::high_resolution_clock::now();
     }
+#endif
 
     heif_color_profile_nclx* nclx;
     heif_error error = create_output_nclx_profile_and_configure_encoder(encoder, &nclx, primary_image,
@@ -2572,9 +2586,11 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
       }
     }
 
+#if __cplusplus >= 202002L
     if (run_benchmark) {
       time_encoding_end = std::chrono::high_resolution_clock::now();
     }
+#endif
 
     heif_image_handle_release(handle);
     heif_nclx_color_profile_free(nclx);
@@ -2582,6 +2598,7 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
     is_primary_image = false;
   }
 
+#if __cplusplus >= 201103L
   if (property_pitm_timestamp) {
     heif_image_handle* primary_image_handle;
     struct heif_error err = heif_context_get_primary_image_handle(context, &primary_image_handle);
@@ -2605,6 +2622,7 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
     }
     heif_image_handle_release(primary_image_handle);
   }
+#endif
 
   if (!property_pitm_description.empty() || !property_pitm_name.empty() || !property_pitm_tags.empty()) {
     heif_image_handle* primary_image_handle;
@@ -2671,9 +2689,9 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
   if (run_benchmark) {
     double psnr = compute_psnr(primary_image.get(), output_filename);
     std::cout << "PSNR: " << std::setprecision(2) << std::fixed << psnr << " ";
-
+#if __cplusplus >= 202002L
     std::cout << "time: " << std::chrono::duration_cast<std::chrono::milliseconds>(time_encoding_end - time_encoding_start) << " ";
-
+#endif
     std::ifstream istr(output_filename.c_str());
     istr.seekg(0, std::ios_base::end);
     std::streamoff size = istr.tellg();

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -43,6 +43,7 @@
 #include <map>
 #include <tuple>
 #include <random>
+#include <chrono>
 
 #include <libheif/heif.h>
 #include <libheif/heif_properties.h>
@@ -164,6 +165,7 @@ std::string property_pitm_description;
 std::string property_pitm_name;
 std::string property_pitm_tags;
 std::string property_pitm_alt_text;
+std::optional<std::chrono::time_point<std::chrono::system_clock>> property_pitm_timestamp;
 
 RawImageParameters raw_input_params;
 bool force_raw_input = false;
@@ -181,15 +183,8 @@ std::optional<long> parse_int(const char* s)
 
 // for benchmarking
 
-#if !defined(_MSC_VER)
-#define HAVE_GETTIMEOFDAY 1  // TODO: should be set by CMake
-#endif
-
-#if HAVE_GETTIMEOFDAY
-#include <sys/time.h>
-timeval time_encoding_start;
-timeval time_encoding_end;
-#endif
+std::chrono::time_point<std::chrono::high_resolution_clock> time_encoding_start;
+std::chrono::time_point<std::chrono::high_resolution_clock> time_encoding_end;
 
 const int OPTION_NCLX_MATRIX_COEFFICIENTS = 1000;
 const int OPTION_NCLX_COLOUR_PRIMARIES = 1001;
@@ -244,6 +239,7 @@ const int OPTION_MINI = 1049;
 const int OPTION_PITM_NAME = 1050;
 const int OPTION_PITM_TAGS = 1051;
 const int OPTION_PITM_ALT_TEXT = 1052;
+const int OPTION_PITM_TIMESTAMP = 1053;
 
 
 #if HEIF_ENABLE_EXPERIMENTAL_FEATURES
@@ -396,6 +392,7 @@ static option long_options[] = {
     {(char* const) "pitm-name",                   required_argument, 0,                     OPTION_PITM_NAME},
     {(char* const) "pitm-tags",                   required_argument, 0,                     OPTION_PITM_TAGS},
     {(char* const) "pitm-alt",                    required_argument, 0,                     OPTION_PITM_ALT_TEXT},
+    {(char* const) "pitm-timestamp",              no_argument,       0,                     OPTION_PITM_TIMESTAMP},
     {(char* const) "chroma-downsampling",         required_argument, 0, 'C'},
     {(char* const) "cut-tiles",                   required_argument, nullptr, OPTION_CUT_TILES},
     {(char* const) "tiled-input",                 no_argument, 0, 'T'},
@@ -490,6 +487,7 @@ void show_help(const char* argv0)
             << "      --pitm-name TEXT              set user name for primary image\n"
             << "      --pitm-tags TEXT              set comma-separated user tags for primary image\n"
             << "      --pitm-alt TEXT               set alt text for primary image\n"
+            << "      --pitm-timestamp              set timestamp for primary image to current system timestamp\n"
 #if HEIF_ENABLE_EXPERIMENTAL_FEATURES
             << "      --add-mime-item TYPE       add a mime item of the specified content type (experimental)\n"
             << "      --mime-item-file FILE      use the specified FILE as the data to put into the mime item (experimental)\n"
@@ -1595,6 +1593,9 @@ int main(int argc, char** argv)
       case OPTION_PITM_ALT_TEXT:
         property_pitm_alt_text = optarg;
         break;
+      case OPTION_PITM_TIMESTAMP:
+        property_pitm_timestamp = std::chrono::system_clock::now();
+        break;
       case OPTION_USE_HEVC_COMPRESSION:
         force_enc_hevc = true;
         break;
@@ -2382,11 +2383,9 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
       primary_image = image;
     }
 
-#if HAVE_GETTIMEOFDAY
     if (run_benchmark) {
-      gettimeofday(&time_encoding_start, nullptr);
+      time_encoding_start = std::chrono::high_resolution_clock::now();
     }
-#endif
 
     heif_color_profile_nclx* nclx;
     heif_error error = create_output_nclx_profile_and_configure_encoder(encoder, &nclx, primary_image,
@@ -2573,16 +2572,38 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
       }
     }
 
-#if HAVE_GETTIMEOFDAY
     if (run_benchmark) {
-      gettimeofday(&time_encoding_end, nullptr);
+      time_encoding_end = std::chrono::high_resolution_clock::now();
     }
-#endif
 
     heif_image_handle_release(handle);
     heif_nclx_color_profile_free(nclx);
 
     is_primary_image = false;
+  }
+
+  if (property_pitm_timestamp) {
+    heif_image_handle* primary_image_handle;
+    struct heif_error err = heif_context_get_primary_image_handle(context, &primary_image_handle);
+    if (err.code) {
+      std::cerr << "No primary image set, cannot set timestamp\n";
+      return 5;
+    }
+    uint64_t time = std::chrono::duration_cast<std::chrono::microseconds>(property_pitm_timestamp->time_since_epoch()).count();
+    time += heif_property_timestamp_mac_to_unix_epoch_difference;
+
+    heif_item_id pitm_id = heif_image_handle_get_item_id(primary_image_handle);
+    err = heif_item_add_property_time(context, pitm_id, heif_item_property_type_creation_time, time, nullptr);
+    if (err.code) {
+      std::cerr << "Cannot set timestamp\n";
+      return 5;
+    }
+    err = heif_item_add_property_time(context, pitm_id, heif_item_property_type_modification_time, time, nullptr);
+    if (err.code) {
+      std::cerr << "Cannot set timestamp\n";
+      return 5;
+    }
+    heif_image_handle_release(primary_image_handle);
   }
 
   if (!property_pitm_description.empty() || !property_pitm_name.empty() || !property_pitm_tags.empty()) {
@@ -2651,10 +2672,7 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
     double psnr = compute_psnr(primary_image.get(), output_filename);
     std::cout << "PSNR: " << std::setprecision(2) << std::fixed << psnr << " ";
 
-#if HAVE_GETTIMEOFDAY
-    double t = (double) (time_encoding_end.tv_sec - time_encoding_start.tv_sec) + (double) (time_encoding_end.tv_usec - time_encoding_start.tv_usec) / 1000000.0;
-    std::cout << "time: " << std::setprecision(1) << std::fixed << t << " ";
-#endif
+    std::cout << "time: " << std::chrono::duration_cast<std::chrono::milliseconds>(time_encoding_end - time_encoding_start) << " ";
 
     std::ifstream istr(output_filename.c_str());
     istr.seekg(0, std::ios_base::end);

--- a/examples/heif_enc.cc
+++ b/examples/heif_enc.cc
@@ -161,6 +161,9 @@ heif_output_nclx_color_profile_preset output_color_profile_preset = heif_output_
 
 
 std::string property_pitm_description;
+std::string property_pitm_name;
+std::string property_pitm_tags;
+std::string property_pitm_alt_text;
 
 RawImageParameters raw_input_params;
 bool force_raw_input = false;
@@ -238,6 +241,9 @@ const int OPTION_DO_ROTATE = 1046;
 const int OPTION_DO_FLIP_H = 1047;
 const int OPTION_DO_FLIP_V = 1048;
 const int OPTION_MINI = 1049;
+const int OPTION_PITM_NAME = 1050;
+const int OPTION_PITM_TAGS = 1051;
+const int OPTION_PITM_ALT_TEXT = 1052;
 
 
 #if HEIF_ENABLE_EXPERIMENTAL_FEATURES
@@ -387,6 +393,9 @@ static option long_options[] = {
     {(char* const) "benchmark",                   no_argument,       &run_benchmark,        1},
     {(char* const) "enable-metadata-compression", required_argument, 0, OPTION_METADATA_COMPRESSION},
     {(char* const) "pitm-description",            required_argument, 0,                     OPTION_PITM_DESCRIPTION},
+    {(char* const) "pitm-name",                   required_argument, 0,                     OPTION_PITM_NAME},
+    {(char* const) "pitm-tags",                   required_argument, 0,                     OPTION_PITM_TAGS},
+    {(char* const) "pitm-alt",                    required_argument, 0,                     OPTION_PITM_ALT_TEXT},
     {(char* const) "chroma-downsampling",         required_argument, 0, 'C'},
     {(char* const) "cut-tiles",                   required_argument, nullptr, OPTION_CUT_TILES},
     {(char* const) "tiled-input",                 no_argument, 0, 'T'},
@@ -477,7 +486,10 @@ void show_help(const char* argv0)
             << "  -C, --chroma-downsampling ALGO    force chroma downsampling algorithm (nn = nearest-neighbor / average / sharp-yuv)\n"
             << "                                    (sharp-yuv makes edges look sharper when using YUV420 with bilinear chroma upsampling)\n"
             << "      --benchmark                   measure encoding time, PSNR, and output file size\n"
-            << "      --pitm-description TEXT       set user description for primary image (experimental)\n"
+            << "      --pitm-description TEXT       set user description for primary image\n"
+            << "      --pitm-name TEXT              set user name for primary image\n"
+            << "      --pitm-tags TEXT              set comma-separated user tags for primary image\n"
+            << "      --pitm-alt TEXT               set alt text for primary image\n"
 #if HEIF_ENABLE_EXPERIMENTAL_FEATURES
             << "      --add-mime-item TYPE       add a mime item of the specified content type (experimental)\n"
             << "      --mime-item-file FILE      use the specified FILE as the data to put into the mime item (experimental)\n"
@@ -1574,6 +1586,15 @@ int main(int argc, char** argv)
       case OPTION_PITM_DESCRIPTION:
         property_pitm_description = optarg;
         break;
+      case OPTION_PITM_NAME:
+        property_pitm_name = optarg;
+        break;
+      case OPTION_PITM_TAGS:
+        property_pitm_tags = optarg;
+        break;
+      case OPTION_PITM_ALT_TEXT:
+        property_pitm_alt_text = optarg;
+        break;
       case OPTION_USE_HEVC_COMPRESSION:
         force_enc_hevc = true;
         break;
@@ -2564,7 +2585,7 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
     is_primary_image = false;
   }
 
-  if (!property_pitm_description.empty()) {
+  if (!property_pitm_description.empty() || !property_pitm_name.empty() || !property_pitm_tags.empty()) {
     heif_image_handle* primary_image_handle;
     struct heif_error err = heif_context_get_primary_image_handle(context, &primary_image_handle);
     if (err.code) {
@@ -2578,10 +2599,38 @@ int do_encode_images(heif_context* context, heif_encoder* encoder, heif_encoding
     udes.lang = nullptr;
     udes.name = nullptr;
     udes.tags = nullptr;
-    udes.description = property_pitm_description.c_str();
+    udes.description = nullptr;
+    if (!property_pitm_name.empty())
+      udes.name = property_pitm_name.c_str();
+    if (!property_pitm_description.empty())
+      udes.description = property_pitm_description.c_str();
+    if (!property_pitm_tags.empty())
+      udes.tags = property_pitm_tags.c_str();
     err = heif_item_add_property_user_description(context, pitm_id, &udes, nullptr);
     if (err.code) {
       std::cerr << "Cannot set user description\n";
+      return 5;
+    }
+
+    heif_image_handle_release(primary_image_handle);
+  }
+
+  if (!property_pitm_alt_text.empty()) {
+    heif_image_handle* primary_image_handle;
+    struct heif_error err = heif_context_get_primary_image_handle(context, &primary_image_handle);
+    if (err.code) {
+      std::cerr << "No primary image set, cannot set alt text\n";
+      return 5;
+    }
+
+    heif_item_id pitm_id = heif_image_handle_get_item_id(primary_image_handle);
+
+    heif_property_alt_text altt;
+    altt.alt_lang = nullptr;
+    altt.alt_text = property_pitm_alt_text.c_str();
+    err = heif_item_add_property_alt_text(context, pitm_id, &altt, nullptr);
+    if (err.code) {
+      std::cerr << "Cannot set alt text\n";
       return 5;
     }
 

--- a/examples/heif_info.cc
+++ b/examples/heif_info.cc
@@ -186,6 +186,35 @@ static const char* matrix_coefficients_name(uint16_t v)
   }
 }
 
+static void print_timestamp(const char* text, uint64_t timestamp)
+{
+  if (timestamp >= heif_property_timestamp_mac_to_unix_epoch_difference)
+  {
+    time_t t = (time_t)(timestamp - heif_property_timestamp_mac_to_unix_epoch_difference) / 1000000ull;
+    struct tm tm;
+
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+
+    printf(
+      "%s: %04d-%02d-%02d %02d:%02d:%02d UTC\n",
+      text,
+      tm.tm_year + 1900,
+      tm.tm_mon + 1,
+      tm.tm_mday,
+      tm.tm_hour,
+      tm.tm_min,
+      tm.tm_sec
+    );
+  }
+  else {
+    printf("%s: before 1970-01-01 00:00:00 UTC\n", text);
+  }
+}
+
 
 int main(int argc, char** argv)
 {
@@ -836,6 +865,38 @@ int main(int argc, char** argv)
 
           heif_property_alt_text_release(altt);
         }
+      }
+    }
+
+    count = heif_item_get_properties_of_type(ctx.get(), IDs[i], heif_item_property_type_creation_time,
+      propertyIds, 1);
+
+    if (count > 0) {
+      uint64_t creation_time;
+      err = heif_item_get_property_time(ctx.get(), IDs[i], propertyIds[0], heif_item_property_type_creation_time, &creation_time);
+      if (err.code) {
+        std::cerr << "Error reading creation time " << IDs[i] << "/" << propertyIds[0] << "\n";
+      }
+      else {
+        print_timestamp("  creation time", creation_time);
+
+        properties_shown = true;
+      }
+    }
+
+    count = heif_item_get_properties_of_type(ctx.get(), IDs[i], heif_item_property_type_modification_time,
+      propertyIds, 1);
+
+    if (count > 0) {
+      uint64_t modification_time;
+      err = heif_item_get_property_time(ctx.get(), IDs[i], propertyIds[0], heif_item_property_type_modification_time, &modification_time);
+      if (err.code) {
+        std::cerr << "Error reading modification time " << IDs[i] << "/" << propertyIds[0] << "\n";
+      }
+      else {
+        print_timestamp("  modification time", modification_time);
+
+        properties_shown = true;
       }
     }
 

--- a/examples/heif_info.cc
+++ b/examples/heif_info.cc
@@ -731,6 +731,26 @@ int main(int argc, char** argv)
             heif_property_user_description_release(udes);
           }
         }
+
+        nDescr = heif_item_get_properties_of_type(ctx.get(),
+          region_item_id,
+          heif_item_property_type_alt_text,
+          properties,
+          MAX_PROPERTIES);
+
+        for (int k = 0; k < nDescr; k++) {
+          heif_property_alt_text* alttext;
+          err = heif_item_get_property_alt_text(ctx.get(),
+            region_item_id,
+            properties[k],
+            &alttext);
+          if (err.code == 0) {
+            printf("    alt text:\n");
+            printf("      lang: %s\n", alttext->alt_lang);
+            printf("      alt text: %s\n", alttext->alt_text);
+            heif_property_alt_text_release(alttext);
+          }
+        }
       }
     }
     else {
@@ -794,6 +814,27 @@ int main(int argc, char** argv)
           properties_shown = true;
 
           heif_property_user_description_release(udes);
+        }
+      }
+    }
+
+    count = heif_item_get_properties_of_type(ctx.get(), IDs[i], heif_item_property_type_alt_text,
+      propertyIds, MAX_PROPERTIES);
+
+    if (count > 0) {
+      for (int p = 0; p < count; p++) {
+        heif_property_alt_text* altt;
+        err = heif_item_get_property_alt_text(ctx.get(), IDs[i], propertyIds[p], &altt);
+        if (err.code) {
+          std::cerr << "Error reading alt text " << IDs[i] << "/" << propertyIds[p] << "\n";
+        }
+        else {
+          printf("  alt text:\n");
+          printf("    lang: %s\n", altt->alt_lang);
+          printf("    alt text: %s\n", altt->alt_text);
+          properties_shown = true;
+
+          heif_property_alt_text_release(altt);
         }
       }
     }

--- a/libheif/api/libheif/heif_properties.cc
+++ b/libheif/api/libheif/heif_properties.cc
@@ -209,6 +209,142 @@ void heif_property_user_description_release(heif_property_user_description* udes
 }
 
 
+heif_error heif_item_get_property_alt_text(const heif_context* context,
+  heif_item_id itemId,
+  heif_property_id propertyId,
+  heif_property_alt_text** out)
+{
+  if (!out || !context) {
+    return heif_error_null_pointer_argument;
+  }
+  auto altt = context->context->find_property<Box_altt>(itemId, propertyId);
+  if (!altt) {
+    return altt.error_struct(context->context.get());
+  }
+
+  auto* altt_c = new heif_property_alt_text();
+  altt_c->version = 1;
+  altt_c->alt_lang = create_c_string_copy((*altt)->get_lang());
+  altt_c->alt_text = create_c_string_copy((*altt)->get_alt_text());
+
+  *out = altt_c;
+
+  return heif_error_success;
+}
+
+
+heif_error heif_item_add_property_alt_text(const heif_context* context,
+  heif_item_id itemId,
+  const heif_property_alt_text* description,
+  heif_property_id* out_propertyId)
+{
+  if (!context || !description) {
+    return heif_error_null_pointer_argument;
+  }
+
+  auto altt = std::make_shared<Box_altt>();
+  altt->set_lang(description->alt_lang ? description->alt_lang : "");
+  altt->set_alt_text(description->alt_text ? description->alt_text : "");
+
+  heif_property_id id = context->context->add_property(itemId, altt, false);
+
+  if (out_propertyId) {
+    *out_propertyId = id;
+  }
+
+  return heif_error_success;
+}
+
+
+void heif_property_alt_text_release(heif_property_alt_text* altt)
+{
+  if (altt == nullptr) {
+    return;
+  }
+
+  delete[] altt->alt_lang;
+  delete[] altt->alt_text;
+
+  delete altt;
+}
+
+
+heif_error heif_item_get_property_time(const heif_context* context,
+  heif_item_id itemId,
+  heif_property_id propertyId,
+  uint32_t propertyType,
+  uint64_t* out)
+{
+  if (!out || !context) {
+    return heif_error_null_pointer_argument;
+  }
+
+  switch (propertyType) {
+  case heif_item_property_type_creation_time:
+  {
+    auto crtt = context->context->find_property<Box_crtt>(itemId, propertyId);
+    if (!crtt) {
+      return crtt.error_struct(context->context.get());
+    }
+    *out = (*crtt)->get_time();
+    break;
+  }
+  return heif_error_success;
+  case heif_item_property_type_modification_time:
+  {
+    auto mdft = context->context->find_property<Box_mdft>(itemId, propertyId);
+    if (!mdft) {
+      return mdft.error_struct(context->context.get());
+    }
+    *out = (*mdft)->get_time();
+  }
+  return heif_error_success;
+  default:
+    return heif_error_invalid_parameter_value;
+  }
+}
+
+
+heif_error heif_item_add_property_time(const heif_context* context,
+  heif_item_id itemId,
+  uint32_t propertyType,
+  uint64_t time,
+  heif_property_id* out_propertyId)
+{
+  if (!context) {
+    return heif_error_null_pointer_argument;
+  }
+  std::shared_ptr<FullBox> prop_box;
+
+  switch (propertyType) {
+  case heif_item_property_type_creation_time:
+    {
+      auto crtt = std::make_shared<Box_crtt>();
+      crtt->set_time(time);
+      prop_box = crtt;
+    }
+    break;
+  case heif_item_property_type_modification_time:
+    {
+      auto mdft = std::make_shared<Box_mdft>();
+      mdft->set_time(time);
+      prop_box = mdft;
+    }
+    break;
+  default:
+    return heif_error_invalid_parameter_value;
+  }
+
+  heif_property_id id = context->context->add_property(itemId, prop_box, false);
+
+  if (out_propertyId) {
+    *out_propertyId = id;
+  }
+
+  return heif_error_success;
+}
+
+
 heif_transform_mirror_direction heif_item_get_property_transform_mirror(const heif_context* context,
                                                                         heif_item_id itemId,
                                                                         heif_property_id propertyId)

--- a/libheif/api/libheif/heif_properties.cc
+++ b/libheif/api/libheif/heif_properties.cc
@@ -287,9 +287,8 @@ heif_error heif_item_get_property_time(const heif_context* context,
       return crtt.error_struct(context->context.get());
     }
     *out = (*crtt)->get_time();
-    break;
+    return heif_error_success;
   }
-  return heif_error_success;
   case heif_item_property_type_modification_time:
   {
     auto mdft = context->context->find_property<Box_mdft>(itemId, propertyId);
@@ -297,10 +296,10 @@ heif_error heif_item_get_property_time(const heif_context* context,
       return mdft.error_struct(context->context.get());
     }
     *out = (*mdft)->get_time();
+    return heif_error_success;
   }
-  return heif_error_success;
   default:
-    return heif_error_invalid_parameter_value;
+    return { heif_error_Usage_error, heif_suberror_Invalid_parameter_value, "Unsupported propertyType fourcc" };
   }
 }
 
@@ -332,7 +331,7 @@ heif_error heif_item_add_property_time(const heif_context* context,
     }
     break;
   default:
-    return heif_error_invalid_parameter_value;
+    return { heif_error_Usage_error, heif_suberror_Invalid_parameter_value, "Unsupported propertyType fourcc" };
   }
 
   heif_property_id id = context->context->add_property(itemId, prop_box, false);

--- a/libheif/api/libheif/heif_properties.h
+++ b/libheif/api/libheif/heif_properties.h
@@ -140,7 +140,12 @@ heif_error heif_item_add_property_alt_text(const heif_context* context,
 LIBHEIF_API
 void heif_property_alt_text_release(heif_property_alt_text*);
 
+// ISO/IEC 23008-12:2025 native timestamp is defined as microseconds since macOS epoch time (1904-01-01 00:00:00 UTC).
+// This constant is the difference in microseconds between macOS epoch and UNIX epoch (1970-01-01), used to convert between timestamps in different epoch
+#define heif_property_timestamp_mac_to_unix_epoch_difference 2082844800000000ull
+
 // Get the "crtt"/"mdft" creation time and modification time property content.
+// Timestamp is in microseconds since 1904-01-01.
 // propertyType is the fourcc of property (heif_item_property_type_creation_time or heif_item_property_type_modification_time)
 LIBHEIF_API
 heif_error heif_item_get_property_time(const heif_context* context,
@@ -150,6 +155,7 @@ heif_error heif_item_get_property_time(const heif_context* context,
   uint64_t* out);
 
 // Set the "crtt"/"mdft" creation time and modification time property content.
+// Timestamp is in microseconds since 1904-01-01.
 // propertyType is the fourcc of property (heif_item_property_type_creation_time or heif_item_property_type_modification_time)
 LIBHEIF_API
 heif_error heif_item_add_property_time(const heif_context* context,

--- a/libheif/api/libheif/heif_properties.h
+++ b/libheif/api/libheif/heif_properties.h
@@ -41,7 +41,10 @@ typedef enum heif_item_property_type
   heif_item_property_type_uuid = heif_fourcc('u', 'u', 'i', 'd'),
   heif_item_property_type_tai_clock_info = heif_fourcc('t', 'a', 'i', 'c'),
   heif_item_property_type_tai_timestamp = heif_fourcc('i', 't', 'a', 'i'),
-  heif_item_property_type_extended_language = heif_fourcc('e', 'l', 'n', 'g')
+  heif_item_property_type_extended_language = heif_fourcc('e', 'l', 'n', 'g'),
+  heif_item_property_type_creation_time = heif_fourcc('c','r','t','t'),
+  heif_item_property_type_modification_time = heif_fourcc('m','d','f','t'),
+  heif_item_property_type_alt_text = heif_fourcc('a','l','t','t')
 } heif_item_property_type;
 
 // Get the heif_property_id for a heif_item_id.
@@ -78,10 +81,10 @@ typedef struct heif_property_user_description
 
   // version 1
 
-  const char* lang;
-  const char* name;
-  const char* description;
-  const char* tags;
+  const char* lang; // lanuage of user descriptions in IETF language tag
+  const char* name; // name of image in UTF-8
+  const char* description; // description of image in UTF-8
+  const char* tags; // comma-separated tags of image in UTF-8
 } heif_property_user_description;
 
 // Get the "udes" user description property content.
@@ -104,6 +107,56 @@ heif_error heif_item_add_property_user_description(const heif_context* context,
 // Only call for objects that you received from heif_item_get_property_user_description().
 LIBHEIF_API
 void heif_property_user_description_release(heif_property_user_description*);
+
+// The strings are managed by libheif. They will be deleted in heif_property_user_description_release().
+typedef struct heif_property_alt_text
+{
+  int version;
+
+  // version 1
+
+  const char* alt_text; // alternative text for accessiblity in UTF-8
+  const char* alt_lang; // lanuage of alt_text in IETF language tag
+} heif_property_alt_text;
+
+// Get the "altt" alt text property content.
+// Undefined strings are returned as empty strings.
+LIBHEIF_API
+heif_error heif_item_get_property_alt_text(const heif_context* context,
+  heif_item_id itemId,
+  heif_property_id propertyId,
+  heif_property_alt_text** out);
+
+// Add a "altt" alt text property to the item.
+// If any string pointers are NULL, an empty string will be used instead.
+LIBHEIF_API
+heif_error heif_item_add_property_alt_text(const heif_context* context,
+  heif_item_id itemId,
+  const heif_property_alt_text* description,
+  heif_property_id* out_propertyId);
+
+// Release all strings and the object itself.
+// Only call for objects that you received from heif_item_get_property_alt_text().
+LIBHEIF_API
+void heif_property_alt_text_release(heif_property_alt_text*);
+
+// Get the "crtt"/"mdft" creation time and modification time property content.
+// propertyType is the fourcc of property (heif_item_property_type_creation_time or heif_item_property_type_modification_time)
+LIBHEIF_API
+heif_error heif_item_get_property_time(const heif_context* context,
+  heif_item_id itemId,
+  heif_property_id propertyId,
+  uint32_t propertyType,
+  uint64_t* out);
+
+// Set the "crtt"/"mdft" creation time and modification time property content.
+// propertyType is the fourcc of property (heif_item_property_type_creation_time or heif_item_property_type_modification_time)
+LIBHEIF_API
+heif_error heif_item_add_property_time(const heif_context* context,
+  heif_item_id itemId,
+  uint32_t propertyType,
+  uint64_t time,
+  heif_property_id* out_propertyId);
 
 typedef enum heif_transform_mirror_direction
 {

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -650,6 +650,18 @@ Error Box::read(BitstreamRange& range, std::shared_ptr<Box>* result, const heif_
       box = std::make_shared<Box_udes>();
       break;
 
+    case fourcc("altt"):
+      box = std::make_shared<Box_altt>();
+      break;
+
+    case fourcc("crtt"):
+      box = std::make_shared<Box_crtt>();
+      break;
+
+    case fourcc("mdft"):
+      box = std::make_shared<Box_mdft>();
+      break;
+
     case fourcc("jpgC"):
       box = std::make_shared<Box_jpgC>();
       break;
@@ -4706,7 +4718,7 @@ std::string Box_udes::dump(Indent& indent) const
   sstr << indent << "lang: " << m_lang << "\n";
   sstr << indent << "name: " << m_name << "\n";
   sstr << indent << "description: " << m_description << "\n";
-  sstr << indent << "tags: " << m_lang << "\n";
+  sstr << indent << "tags: " << m_tags << "\n";
   return sstr.str();
 }
 
@@ -4717,6 +4729,96 @@ Error Box_udes::write(StreamWriter& writer) const
   writer.write(m_name);
   writer.write(m_description);
   writer.write(m_tags);
+  prepend_header(writer, box_start);
+  return Error::Ok;
+}
+
+
+Error Box_altt::parse(BitstreamRange& range, const heif_security_limits* limits)
+{
+  parse_full_box_header(range);
+
+  if (get_version() > 0) {
+    return unsupported_version_error("altt");
+  }
+
+  m_alt_text = range.read_string();
+  m_lang = range.read_string();
+  return range.get_error();
+}
+
+std::string Box_altt::dump(Indent& indent) const
+{
+  std::ostringstream sstr;
+  sstr << Box::dump(indent);
+  sstr << indent << "lang: " << m_lang << "\n";
+  sstr << indent << "alt text: " << m_alt_text << "\n";
+  return sstr.str();
+}
+
+Error Box_altt::write(StreamWriter& writer) const
+{
+  size_t box_start = reserve_box_header_space(writer);
+  writer.write(m_alt_text);
+  writer.write(m_lang);
+  prepend_header(writer, box_start);
+  return Error::Ok;
+}
+
+
+Error Box_crtt::parse(BitstreamRange& range, const heif_security_limits* limits)
+{
+  parse_full_box_header(range);
+
+  if (get_version() > 0) {
+    return unsupported_version_error("crtt");
+  }
+
+  m_time = range.read64();
+  return range.get_error();
+}
+
+std::string Box_crtt::dump(Indent& indent) const
+{
+  std::ostringstream sstr;
+  sstr << Box::dump(indent);
+  sstr << indent << "creation timestamp: " << m_time << "\n";
+  return sstr.str();
+}
+
+Error Box_crtt::write(StreamWriter& writer) const
+{
+  size_t box_start = reserve_box_header_space(writer);
+  writer.write64(m_time);
+  prepend_header(writer, box_start);
+  return Error::Ok;
+}
+
+
+Error Box_mdft::parse(BitstreamRange& range, const heif_security_limits* limits)
+{
+  parse_full_box_header(range);
+
+  if (get_version() > 0) {
+    return unsupported_version_error("crtt");
+  }
+
+  m_time = range.read64();
+  return range.get_error();
+}
+
+std::string Box_mdft::dump(Indent& indent) const
+{
+  std::ostringstream sstr;
+  sstr << Box::dump(indent);
+  sstr << indent << "modification timestamp: " << m_time << "\n";
+  return sstr.str();
+}
+
+Error Box_mdft::write(StreamWriter& writer) const
+{
+  size_t box_start = reserve_box_header_space(writer);
+  writer.write64(m_time);
   prepend_header(writer, box_start);
   return Error::Ok;
 }

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -1805,6 +1805,159 @@ private:
 };
 
 
+/**
+ * Alt Text property.
+ *
+ * Permits the association of items or entity groups with a alt text;
+ * there may be multiple udes properties, each with a different language code.
+ *
+ * See ISO/IEC 23008-12:2025(E) Section 6.5.21.
+ */
+class Box_altt : public FullBox
+{
+public:
+  Box_altt()
+  {
+    set_short_type(fourcc("altt"));
+  }
+
+  std::string dump(Indent&) const override;
+
+  const char* debug_box_name() const override { return "Alt Text"; }
+
+  Error write(StreamWriter& writer) const override;
+
+  /**
+   * Language tag.
+   *
+   * An RFC 5646 compliant language identifier for the language of the text contained in the other properties.
+   * Examples: "en-AU", "de-DE", or "zh-CN“.
+   * When is empty, the language is unknown or not undefined.
+   */
+  std::string get_lang() const { return m_lang; }
+
+  /**
+   * Set the language tag.
+   *
+   * An RFC 5646 compliant language identifier for the language of the text contained in the other properties.
+   * Examples: "en-AU", "de-DE", or "zh-CN“.
+   */
+  void set_lang(const std::string lang) { m_lang = lang; }
+
+  /**
+   * Alt Text.
+   *
+   * Human readable name for the item or group being described.
+   * May be empty, indicating no name is applicable.
+   */
+  std::string get_alt_text() const { return m_alt_text; }
+
+  /**
+  * Set the name.
+  *
+  * Human readable name for the item or group being described.
+  */
+  void set_alt_text(const std::string alt_text) { m_alt_text = alt_text; }
+
+  [[nodiscard]] parse_error_fatality get_parse_error_fatality() const override { return parse_error_fatality::optional; }
+
+protected:
+  Error parse(BitstreamRange& range, const heif_security_limits*) override;
+
+private:
+  std::string m_lang;
+  std::string m_alt_text;
+};
+
+
+/**
+ * Creation Time property.
+ *
+ * Permits the association of items or entity groups with the creation time.
+ *
+ * See ISO/IEC 23008-12:2025 Section 6.5.18.
+ */
+class Box_crtt : public FullBox
+{
+public:
+  Box_crtt()
+  {
+    set_short_type(fourcc("crtt"));
+    m_time = 0;
+  }
+
+  std::string dump(Indent&) const override;
+
+  const char* debug_box_name() const override { return "Creation Time"; }
+
+  Error write(StreamWriter& writer) const override;
+
+  /**
+   * Creation time.
+   *
+   * The creation time of the item, in microseconds since 1904-01-01 00:00:00 UTC
+   */
+  uint64_t get_time() const { return m_time; }
+
+  /**
+   * Set the creation time.
+   */
+  void set_time(const uint64_t time) { m_time = time; }
+
+  [[nodiscard]] parse_error_fatality get_parse_error_fatality() const override { return parse_error_fatality::optional; }
+
+protected:
+  Error parse(BitstreamRange& range, const heif_security_limits*) override;
+
+private:
+  uint64_t m_time;
+};
+
+
+/**
+ * Modification Time property.
+ *
+ * Permits the association of items or entity groups with the modification time.
+ *
+ * See ISO/IEC 23008-12:2025 Section 6.5.19.
+ */
+class Box_mdft : public FullBox
+{
+public:
+  Box_mdft()
+  {
+    set_short_type(fourcc("mdft"));
+    m_time = 0;
+  }
+
+  std::string dump(Indent&) const override;
+
+  const char* debug_box_name() const override { return "Modification Time"; }
+
+  Error write(StreamWriter& writer) const override;
+
+  /**
+   * Modification time.
+   *
+   * The modification time of the item, in microseconds since 1904-01-01 00:00:00 UTC
+   */
+  uint64_t get_time() const { return m_time; }
+
+  /**
+   * Set the modification time.
+   */
+  void set_time(const uint64_t time) { m_time = time; }
+
+  [[nodiscard]] parse_error_fatality get_parse_error_fatality() const override { return parse_error_fatality::optional; }
+
+protected:
+  Error parse(BitstreamRange& range, const heif_security_limits*) override;
+
+private:
+  uint64_t m_time;
+};
+
+
 void initialize_heif_tai_clock_info(heif_tai_clock_info* taic);
 void initialize_heif_tai_timestamp_packet(heif_tai_timestamp_packet* itai);
 


### PR DESCRIPTION
Add support for `altt`, `crtt`, `mdft` boxes (alt text, creation time, modification time). Tested reading and writing alt text in the examples.