### PR TITLE
gdk-pixbuf: set GError on stop_load() failure

### DIFF
--- a/gdk-pixbuf/pixbufloader-heif.c
+++ b/gdk-pixbuf/pixbufloader-heif.c
@@ -81,25 +81,29 @@ static gboolean stop_load(gpointer context, GError** error)
 
   err = heif_init(NULL);
   if (err.code != heif_error_Ok) {
-    g_warning("%s", err.message);
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                "HEIF decoding failed: %s", err.message);
     goto cleanup;
   }
 
   hc = heif_context_alloc();
   if (!hc) {
-    g_warning("cannot allocate heif_context");
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_INSUFFICIENT_MEMORY,
+                "cannot allocate heif_context");
     goto cleanup;
   }
 
   err = heif_context_read_from_memory_without_copy(hc, hpc->data->data, hpc->data->len, NULL);
   if (err.code != heif_error_Ok) {
-    g_warning("%s", err.message);
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
+                "HEIF decoding failed: %s", err.message);
     goto cleanup;
   }
 
   err = heif_context_get_primary_image_handle(hc, &hdl);
   if (err.code != heif_error_Ok) {
-    g_warning("%s", err.message);
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
+                "HEIF decoding failed: %s", err.message);
     goto cleanup;
   }
 
@@ -109,7 +113,10 @@ static gboolean stop_load(gpointer context, GError** error)
                           has_alpha ? heif_chroma_interleaved_RGBA : heif_chroma_interleaved_RGB,
                           NULL);
   if (err.code != heif_error_Ok) {
-    g_warning("%s", err.message);
+    g_set_error(error, GDK_PIXBUF_ERROR,
+                err.code == heif_error_Unsupported_feature ? GDK_PIXBUF_ERROR_UNSUPPORTED_OPERATION
+                                                            : GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
+                "HEIF decoding failed: %s", err.message);
     goto cleanup;
   }
 


### PR DESCRIPTION
*Made with AI assistance (Claude). I built this branch and verified the fix myself before opening this -- see Verification below.*

Fixes #1861.

## Problem

`stop_load()` in the gdk-pixbuf loader only calls `g_warning()` on every failure path and returns `FALSE` without setting the `GError**` out-parameter, which violates the gdk-pixbuf module contract ("If an error occurs, error should be set and FALSE returned"). Callers that drive the load through `GTask` (eg. mutter's `meta_background_image` -> `gdk_pixbuf_new_from_stream_at_scale_async`) hit `g_task_return_error`/`g_task_propagate_pointer` assertion failures on a NULL error, which crashes the caller.

The issue includes a real-world report: a HEIF wallpaper with an unsupported codec crashed GNOME Shell on every session start after `libheif-plugin-libde265` was removed, since the missing `GError` led to a NULL-pointer dereference in mutter's `file_loaded()` -- the user could not log in until the wallpaper was reset from a console.

## Fix

Replaced the `g_warning(...); goto cleanup;` on each of the 5 failure paths in `stop_load()` with `g_set_error()`, picking an error code that fits each case (`GDK_PIXBUF_ERROR_INSUFFICIENT_MEMORY` for the context allocation failure, `GDK_PIXBUF_ERROR_UNSUPPORTED_OPERATION` for `heif_error_Unsupported_feature` -- the exact case from the crash report -- `GDK_PIXBUF_ERROR_CORRUPT_IMAGE`/`GDK_PIXBUF_ERROR_FAILED` for the rest).

## Verification

Built just the `pixbufloader-heif` CMake target (gdk-pixbuf loader only, no codec backends needed since this doesn't touch decode logic) and wrote a small C test that `dlopen()`s the built `.so`, calls `fill_vtable()` to get the module's function pointers, and drives `begin_load`/`load_increment`/`stop_load` directly with garbage bytes (not a valid HEIF/HEIC container, so `heif_context_read_from_memory_without_copy` fails).

- **Before the fix** (reverted locally to confirm): `stop_load` returns `FALSE`, `g_warning` prints to stderr, and `GError` stays `NULL` -- exactly the bug described in the issue.
- **After the fix**: `stop_load` still returns `FALSE`, but `GError` is correctly set (`domain=gdk-pixbuf-error-quark`, message `"HEIF decoding failed: Invalid input: No 'ftyp' box: ..."`).

I did not have a way to reproduce the full GNOME Shell crash (no GNOME Shell/mutter environment available), so I verified at the level the fix actually operates: that the module contract is honored (`GError` set whenever `FALSE` is returned).