### PR TITLE
Support 'altt' Item Property

### DIFF
--- a/libheif/api/libheif/heif_experimental.cc
+++ b/libheif/api/libheif/heif_experimental.cc
@@ -370,3 +370,26 @@ heif_error heif_context_add_tiled_image(heif_context* ctx,
   return heif_error_success;
 }
 #endif
+
+
+heif_error heif_item_add_property_accessibility_text(const heif_context* context,
+                                                     heif_item_id itemId,
+                                                     const heif_property_accessibility_text* altt,
+                                                     heif_property_id* out_propertyId)
+{
+  if (!context || !altt) {
+    return heif_error_null_pointer_argument;
+  }
+
+  auto altt_box = std::make_shared<Box_altt>();
+  altt_box->set_alt_text(altt->alt_text ? altt->alt_text : "");
+  altt_box->set_alt_lang(altt->alt_lang ? altt->alt_lang : "");
+
+  heif_property_id id = context->context->add_property(itemId, altt_box, false);
+
+  if (out_propertyId) {
+    *out_propertyId = id;
+  }
+
+  return heif_error_success;
+}

--- a/libheif/api/libheif/heif_experimental.h
+++ b/libheif/api/libheif/heif_experimental.h
@@ -178,6 +178,20 @@ void heif_pyramid_layer_info_release(heif_pyramid_layer_info*);
 #endif
 
 
+typedef struct heif_property_accessibility_text
+{
+  const char* alt_text;
+  const char* alt_lang;
+} heif_property_accessibility_text;
+
+// Add a "altt" user description property to the item.
+LIBHEIF_API
+heif_error heif_item_add_property_accessibility_text(const heif_context* context,
+                                                     heif_item_id itemId,
+                                                     const heif_property_accessibility_text* altt,
+                                                     heif_property_id* out_propertyId);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -530,6 +530,10 @@ Error Box::read(BitstreamRange& range, std::shared_ptr<Box>* result, const heif_
       box = std::make_shared<Box_clap>();
       break;
 
+    case fourcc("altt"):
+      box = std::make_shared<Box_altt>();
+      break;
+
     case fourcc("iscl"):
       box = std::make_shared<Box_iscl>();
       break;
@@ -3792,6 +3796,40 @@ void Box_clap::set(uint32_t clap_width, uint32_t clap_height,
 
   m_horizontal_offset = Fraction(-(int32_t) (image_width - clap_width), 2);
   m_vertical_offset = Fraction(-(int32_t) (image_height - clap_height), 2);
+}
+
+
+
+Error Box_altt::parse(BitstreamRange& range, const heif_security_limits*)
+{
+  parse_full_box_header(range);
+
+  m_alt_text = range.read_string();
+  m_alt_lang = range.read_string();
+
+  return range.get_error();
+}
+
+std::string Box_altt::dump(Indent& indent) const
+ {
+  std::ostringstream sstr;
+  sstr << Box::dump(indent);
+  sstr << indent << "alt text: " << m_alt_text << "\n";
+  sstr << indent << "alt lang: " << m_alt_lang << "\n";
+
+  return sstr.str();
+ }
+
+Error Box_altt::write(StreamWriter& writer) const
+{
+  size_t box_start = reserve_box_header_space(writer);
+
+  writer.write(m_alt_text);
+  writer.write(m_alt_lang);
+
+  prepend_header(writer, box_start);
+
+  return Error::Ok;
 }
 
 

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -1040,6 +1040,38 @@ private:
 };
 
 
+class Box_altt : public FullBox
+{
+public:
+  Box_altt()
+  {
+    set_short_type(fourcc("altt"));
+  }
+
+  std::string get_alt_text() const { return m_alt_text; }
+
+  std::string get_alt_lang() const { return m_alt_lang; }
+
+  void set_alt_text(const std::string& text) { m_alt_text = text; }
+
+  void set_alt_lang(const std::string& lang) { m_alt_lang = lang; }
+
+  std::string dump(Indent&) const override;
+
+  const char* debug_box_name() const override { return "Accessibility Text Property"; }
+
+  Error write(StreamWriter& writer) const override;
+
+  protected:
+  Error parse(BitstreamRange& range, const heif_security_limits*) override;
+
+private:
+  std::string m_alt_text;
+  std::string m_alt_lang;
+
+};
+
+
 class Box_iref : public FullBox
 {
 public:


### PR DESCRIPTION
See ISO/IEC 23008-12 Section 6.5.21:

``` C
aligned(8) class AccessibilityTextProperty
extends ItemFullProperty('altt', version = 0, flags = 0) {
  utf8string alt_text;
  utf8string alt_lang;
}
```