### PR TITLE
Re-enable Coverity scan job

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,10 +9,6 @@ permissions:
 
 jobs:
   scan:
-    # TEMPORARILY DISABLED: scan.coverity.com is down and the download step
-    # fails before the build can run. Re-enable by removing this `if` line
-    # once the Coverity service is back.
-    if: false
     runs-on: ubuntu-22.04
     env:
       TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
Re-enable Coverity job since Coverity Scan is now available again.