### PR TITLE
Add NCLX item property reader

### DIFF
--- a/libheif/api/libheif/heif_properties.cc
+++ b/libheif/api/libheif/heif_properties.cc
@@ -23,10 +23,12 @@
 #include "api_structs.h"
 #include "file.h"
 #include "image/pixelimage.h"
+#include "nclx.h"
 
 #include <array>
 #include <cstring>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <string>
 #include <algorithm>
@@ -655,6 +657,35 @@ heif_error heif_item_get_property_raw_data(const heif_context* context,
   std::copy(data.begin(), data.end(), data_out);
 
   return heif_error_success;
+}
+
+
+heif_error heif_item_get_property_nclx_color_profile(
+    const heif_context* context,
+    heif_item_id itemId,
+    heif_property_id propertyId,
+    heif_color_profile_nclx** out_profile)
+{
+  if (out_profile) {
+    *out_profile = nullptr;
+  }
+  if (!context || !out_profile) {
+    return heif_error_null_pointer_argument;
+  }
+
+  auto colr = context->context->find_property<Box_colr>(itemId, propertyId);
+  if (!colr) {
+    return colr.error_struct(context->context.get());
+  }
+
+  auto nclx = std::dynamic_pointer_cast<const color_profile_nclx>((*colr)->get_color_profile());
+  if (!nclx) {
+    return {heif_error_Color_profile_does_not_exist, heif_suberror_Unspecified,
+            "Item property does not contain an NCLX profile"};
+  }
+
+  return nclx->get_nclx_color_profile().get_nclx_color_profile(out_profile)
+      .error_struct(context->context.get());
 }
 
 

--- a/libheif/api/libheif/heif_properties.h
+++ b/libheif/api/libheif/heif_properties.h
@@ -295,6 +295,22 @@ heif_error heif_item_get_property_raw_data(const heif_context* context,
                                            uint8_t* out_data);
 
 /**
+ * Read an NCLX color profile from a `colr` item property.
+ *
+ * The returned profile is allocated by libheif and must be released with
+ * heif_nclx_color_profile_free().
+ *
+ * @param propertyId the property index (1-based), or 0 to read the first `colr` property
+ * @param out_profile output profile; set to NULL when the call returns an error
+ */
+LIBHEIF_API
+heif_error heif_item_get_property_nclx_color_profile(
+    const heif_context* context,
+    heif_item_id itemId,
+    heif_property_id propertyId,
+    heif_color_profile_nclx** out_profile);
+
+/**
  * Get the extended type for an extended "uuid" box.
  *
  * This provides the UUID for the extended box.

--- a/tests/item_properties.cc
+++ b/tests/item_properties.cc
@@ -4,6 +4,7 @@
   MIT License
 
   Copyright (c) 2026 Dirk Farin <dirk.farin@gmail.com>
+  Copyright (c) 2026 Greg Benz Photography LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +29,7 @@
 #include "libheif/heif.h"
 #include "libheif/heif_items.h"
 #include "libheif/heif_properties.h"
+#include "test-config.h"
 #include "test_utils.h"
 #include <cstdint>
 #include <vector>
@@ -210,4 +212,53 @@ TEST_CASE("adding a property to a loaded context is refused") {
 
   heif_context_free(read_ctx);
   heif_deinit();
+}
+
+
+TEST_CASE("item properties: read NCLX from a parsed colr property")
+{
+  heif_context* ctx = get_context_for_local_file(
+      tests_data_directory + "/../../examples/example.avif");
+  REQUIRE(ctx != nullptr);
+
+  heif_item_id item_id = 0;
+  REQUIRE(heif_context_get_primary_image_ID(ctx, &item_id).code == heif_error_Ok);
+
+  const auto colr_type = static_cast<heif_item_property_type>(heif_fourcc('c', 'o', 'l', 'r'));
+  heif_property_id property_id = 0;
+  REQUIRE(heif_item_get_properties_of_type(ctx, item_id, colr_type, &property_id, 1) == 1);
+
+  // Recognized properties are parsed into typed boxes and cannot be accessed through the
+  // existing Box_other-only raw-property getter.
+  size_t raw_size = 0;
+  REQUIRE(heif_item_get_property_raw_size(ctx, item_id, property_id, &raw_size).code ==
+          heif_error_Usage_error);
+
+  heif_color_profile_nclx* profile = nullptr;
+  REQUIRE(heif_item_get_property_nclx_color_profile(ctx, item_id, property_id,
+                                                    &profile).code == heif_error_Ok);
+  REQUIRE(profile != nullptr);
+  REQUIRE(profile->color_primaries == heif_color_primaries_unspecified);
+  REQUIRE(profile->transfer_characteristics == heif_transfer_characteristic_unspecified);
+  REQUIRE(profile->matrix_coefficients == heif_matrix_coefficients_ITU_R_BT_601_6);
+  REQUIRE(profile->full_range_flag);
+  heif_nclx_color_profile_free(profile);
+
+  heif_property_id non_colr_property_id = 0;
+  REQUIRE(heif_item_get_properties_of_type(ctx, item_id, heif_item_property_type_image_size,
+                                           &non_colr_property_id, 1) == 1);
+
+  profile = reinterpret_cast<heif_color_profile_nclx*>(1);
+  REQUIRE(heif_item_get_property_nclx_color_profile(ctx, item_id, non_colr_property_id,
+                                                    &profile).code == heif_error_Usage_error);
+  REQUIRE(profile == nullptr);
+
+  profile = reinterpret_cast<heif_color_profile_nclx*>(1);
+  heif_error out_of_range_error =
+      heif_item_get_property_nclx_color_profile(ctx, item_id, 999, &profile);
+  REQUIRE(out_of_range_error.code == heif_error_Usage_error);
+  REQUIRE(out_of_range_error.subcode == heif_suberror_Invalid_property);
+  REQUIRE(profile == nullptr);
+
+  heif_context_free(ctx);
 }


### PR DESCRIPTION
## Problem

The generic raw-property getter cannot read a recognized `colr` property after libheif parses it
into a typed box. The existing image-profile getters also require an image handle, so callers
cannot retrieve NCLX signaling attached to a non-image derived item.

## Fix

Add `heif_item_get_property_nclx_color_profile()` to read an NCLX profile from a specific item
property. The returned profile uses the existing allocated-profile ownership convention and must
be released with `heif_nclx_color_profile_free()`. Invalid properties return an error and clear the
output pointer. As with the existing typed-property getters, property ID `0` selects the first
matching `colr` property.

## Tests

Locate the parsed `colr` property on the existing AVIF fixture without assuming a property index,
verify that the raw-property getter rejects it, and check the exact NCLX values including full-range
signaling. Also discover an `ispe` property and verify that the new accessor rejects it while
resetting the output pointer. Finally, verify that an out-of-range property ID returns
`heif_error_Usage_error` / `heif_suberror_Invalid_property` and clears the output pointer.
