### PR TITLE
Add item visibility and specialized entity group writers

### DIFF
--- a/libheif/api/libheif/heif_encoding.cc
+++ b/libheif/api/libheif/heif_encoding.cc
@@ -790,6 +790,11 @@ heif_error heif_context_add_overlay_image(heif_context* ctx,
 heif_error heif_context_set_primary_image(heif_context* ctx,
                                           heif_image_handle* image_handle)
 {
+  Error visibility_error = ctx->context->set_item_hidden(image_handle->image->get_id(), false);
+  if (visibility_error) {
+    return visibility_error.error_struct(ctx->context.get());
+  }
+
   ctx->context->set_primary_image(image_handle->image);
 
   return heif_error_success;

--- a/libheif/api/libheif/heif_encoding.h
+++ b/libheif/api/libheif/heif_encoding.h
@@ -365,6 +365,7 @@ heif_error heif_context_add_overlay_image(heif_context* ctx,
                                           const uint16_t background_rgba[4],
                                           heif_image_handle** out_iovl_image_handle);
 
+// Select the primary image. If the image is hidden, it is made visible first.
 LIBHEIF_API
 heif_error heif_context_set_primary_image(heif_context*,
                                           heif_image_handle* image_handle);

--- a/libheif/api/libheif/heif_entity_groups.cc
+++ b/libheif/api/libheif/heif_entity_groups.cc
@@ -27,6 +27,78 @@
 #include <vector>
 
 
+namespace {
+
+heif_error add_entity_group(heif_context* ctx,
+                            const std::shared_ptr<Box_EntityToGroup>& group,
+                            const std::vector<heif_item_id>& item_ids,
+                            bool require_image_items,
+                            bool enforce_unique_alternative_membership,
+                            heif_entity_group_id* out_group_id)
+{
+  const auto* limits = ctx->context->get_security_limits();
+  if (limits->max_size_entity_group && item_ids.size() > limits->max_size_entity_group) {
+    return {heif_error_Usage_error, heif_suberror_Security_limit_exceeded,
+            "Entity group exceeds the configured security limit"};
+  }
+
+  auto file = ctx->context->get_heif_file();
+  for (auto item = item_ids.begin(); item != item_ids.end(); ++item) {
+    const heif_item_id id = *item;
+    if (!file->get_infe_box(id)) {
+      return {heif_error_Input_does_not_exist, heif_suberror_Nonexisting_item_referenced,
+              "Entity group references a nonexisting item"};
+    }
+    if (std::find(item_ids.begin(), item, id) != item) {
+      return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
+              "Entity group contains a duplicate item"};
+    }
+    if (require_image_items && !ctx->context->is_image(id)) {
+      return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
+              "Stereo entity groups must contain image items"};
+    }
+  }
+
+  if (enforce_unique_alternative_membership) {
+    if (auto groups = file->get_grpl_box()) {
+      for (const auto& box : groups->get_all_child_boxes()) {
+        if (box->get_short_type() != fourcc("altr")) {
+          continue;
+        }
+
+        auto alternative_group = std::dynamic_pointer_cast<Box_EntityToGroup>(box);
+        if (!alternative_group) {
+          continue;
+        }
+
+        const auto& existing_ids = alternative_group->get_item_ids();
+        for (heif_item_id id : item_ids) {
+          if (std::find(existing_ids.begin(), existing_ids.end(), id) != existing_ids.end()) {
+            return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
+                    "An entity may belong to only one alternative group"};
+          }
+        }
+      }
+    }
+  }
+
+  auto group_id = file->get_id_creator().get_new_id(IDCreator::Namespace::entity_group);
+  if (!group_id) {
+    return group_id.error_struct(ctx->context.get());
+  }
+
+  group->set_group_id(*group_id);
+  group->set_item_ids(item_ids);
+  file->add_entity_group_box(group);
+  if (out_group_id) {
+    *out_group_id = *group_id;
+  }
+  return heif_error_success;
+}
+
+}  // namespace
+
+
 heif_entity_group* heif_context_get_entity_groups(const heif_context* ctx,
                                                   uint32_t type_filter,
                                                   heif_item_id item_filter,
@@ -97,4 +169,51 @@ void heif_entity_groups_release(heif_entity_group* grp, int num_groups)
   }
 
   delete[] grp;
+}
+
+
+heif_error heif_context_add_alternative_entity_group(heif_context* ctx,
+                                                     const heif_item_id* item_ids,
+                                                     uint32_t num_items,
+                                                     heif_entity_group_id* out_group_id)
+{
+  if (out_group_id) {
+    *out_group_id = 0;
+  }
+  if (!ctx || !item_ids) {
+    return heif_error_null_pointer_argument;
+  }
+  if (num_items == 0) {
+    return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
+            "Alternative entity group must not be empty"};
+  }
+  const auto* limits = ctx->context->get_security_limits();
+  if (limits->max_size_entity_group && num_items > limits->max_size_entity_group) {
+    return {heif_error_Usage_error, heif_suberror_Security_limit_exceeded,
+            "Entity group exceeds the configured security limit"};
+  }
+
+  auto group = std::make_shared<Box_EntityToGroup>();
+  group->set_short_type(fourcc("altr"));
+  return add_entity_group(ctx, group, std::vector<heif_item_id>(item_ids, item_ids + num_items),
+                          false, true,
+                          out_group_id);
+}
+
+
+heif_error heif_context_add_stereo_pair_entity_group(heif_context* ctx,
+                                                     heif_item_id left_image_id,
+                                                     heif_item_id right_image_id,
+                                                     heif_entity_group_id* out_group_id)
+{
+  if (out_group_id) {
+    *out_group_id = 0;
+  }
+  if (!ctx) {
+    return heif_error_null_pointer_argument;
+  }
+
+  auto group = std::make_shared<Box_ster>();
+  return add_entity_group(ctx, group, {left_image_id, right_image_id}, true, false,
+                          out_group_id);
 }

--- a/libheif/api/libheif/heif_entity_groups.cc
+++ b/libheif/api/libheif/heif_entity_groups.cc
@@ -23,19 +23,30 @@
 #include "api_structs.h"
 #include "file.h"
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
 
 namespace {
 
+enum class DuplicatePolicy {
+  Reject,
+  AllowLastEntityAsAlias,
+};
+
 heif_error add_entity_group(heif_context* ctx,
                             const std::shared_ptr<Box_EntityToGroup>& group,
                             const std::vector<heif_item_id>& item_ids,
                             bool require_image_items,
+                            DuplicatePolicy duplicate_policy,
                             bool enforce_unique_alternative_membership,
                             heif_entity_group_id* out_group_id)
 {
+  if (out_group_id) {
+    *out_group_id = 0;
+  }
+
   const auto* limits = ctx->context->get_security_limits();
   if (limits->max_size_entity_group && item_ids.size() > limits->max_size_entity_group) {
     return {heif_error_Usage_error, heif_suberror_Security_limit_exceeded,
@@ -49,10 +60,18 @@ heif_error add_entity_group(heif_context* ctx,
       return {heif_error_Input_does_not_exist, heif_suberror_Nonexisting_item_referenced,
               "Entity group references a nonexisting item"};
     }
+
     if (std::find(item_ids.begin(), item, id) != item) {
-      return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
-              "Entity group contains a duplicate item"};
+      const bool is_allowed_alias =
+          duplicate_policy == DuplicatePolicy::AllowLastEntityAsAlias &&
+          item_ids.size() == 3 && item == item_ids.begin() + 2 &&
+          (id == item_ids[0] || id == item_ids[1]);
+      if (!is_allowed_alias) {
+        return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
+                "Entity group contains a duplicate item"};
+      }
     }
+
     if (require_image_items && !ctx->context->is_image(id)) {
       return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
               "Stereo entity groups must contain image items"};
@@ -196,7 +215,7 @@ heif_error heif_context_add_alternative_entity_group(heif_context* ctx,
   auto group = std::make_shared<Box_EntityToGroup>();
   group->set_short_type(fourcc("altr"));
   return add_entity_group(ctx, group, std::vector<heif_item_id>(item_ids, item_ids + num_items),
-                          false, true,
+                          false, DuplicatePolicy::Reject, true,
                           out_group_id);
 }
 
@@ -214,6 +233,33 @@ heif_error heif_context_add_stereo_pair_entity_group(heif_context* ctx,
   }
 
   auto group = std::make_shared<Box_ster>();
-  return add_entity_group(ctx, group, {left_image_id, right_image_id}, true, false,
+  return add_entity_group(ctx, group, {left_image_id, right_image_id}, true,
+                          DuplicatePolicy::Reject, false,
+                          out_group_id);
+}
+
+
+heif_error heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+    heif_context* ctx,
+    heif_item_id left_image_id,
+    heif_item_id right_image_id,
+    heif_item_id monoscopic_image_id,
+    heif_entity_group_id* out_group_id)
+{
+  if (out_group_id) {
+    *out_group_id = 0;
+  }
+  if (!ctx) {
+    return heif_error_null_pointer_argument;
+  }
+  if (left_image_id == right_image_id) {
+    return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
+            "Stereo pair left and right images must differ"};
+  }
+
+  auto group = std::make_shared<Box_stem>();
+  return add_entity_group(ctx, group,
+                          {left_image_id, right_image_id, monoscopic_image_id}, true,
+                          DuplicatePolicy::AllowLastEntityAsAlias, false,
                           out_group_id);
 }

--- a/libheif/api/libheif/heif_entity_groups.h
+++ b/libheif/api/libheif/heif_entity_groups.h
@@ -70,6 +70,18 @@ heif_error heif_context_add_stereo_pair_entity_group(heif_context* ctx,
                                                      heif_item_id right_image_id,
                                                      heif_entity_group_id* out_group_id);
 
+// Create a stereo-pair-with-monoscopic-fallback ('stem') entity group. The first
+// image is the left view, the second image is the right view, and the third image
+// is the monoscopic fallback. The fallback may be identical to either stereo view.
+// `out_group_id` may be NULL.
+LIBHEIF_API
+heif_error heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+    heif_context* ctx,
+    heif_item_id left_image_id,
+    heif_item_id right_image_id,
+    heif_item_id monoscopic_image_id,
+    heif_entity_group_id* out_group_id);
+
 
 #ifdef __cplusplus
 }

--- a/libheif/api/libheif/heif_entity_groups.h
+++ b/libheif/api/libheif/heif_entity_groups.h
@@ -52,6 +52,24 @@ heif_entity_group* heif_context_get_entity_groups(const heif_context*,
 LIBHEIF_API
 void heif_entity_groups_release(heif_entity_group*, int num_groups);
 
+// Create an alternative ('altr') entity group containing the supplied item IDs,
+// preserving their order. Track entities are not currently supported. An item may
+// belong to only one alternative entity group.
+// `out_group_id` may be NULL.
+LIBHEIF_API
+heif_error heif_context_add_alternative_entity_group(heif_context* ctx,
+                                                     const heif_item_id* item_ids,
+                                                     uint32_t num_items,
+                                                     heif_entity_group_id* out_group_id);
+
+// Create a stereo-pair ('ster') entity group. The first image is the left view and
+// the second image is the right view. `out_group_id` may be NULL.
+LIBHEIF_API
+heif_error heif_context_add_stereo_pair_entity_group(heif_context* ctx,
+                                                     heif_item_id left_image_id,
+                                                     heif_item_id right_image_id,
+                                                     heif_entity_group_id* out_group_id);
+
 
 #ifdef __cplusplus
 }

--- a/libheif/api/libheif/heif_items.cc
+++ b/libheif/api/libheif/heif_items.cc
@@ -77,6 +77,18 @@ int heif_item_is_item_hidden(const heif_context* ctx, heif_item_id item_id)
 }
 
 
+heif_error heif_item_set_item_hidden(heif_context* ctx,
+                                     heif_item_id item_id,
+                                     int hidden)
+{
+  if (!ctx) {
+    return heif_error_null_pointer_argument;
+  }
+
+  return ctx->context->set_item_hidden(item_id, hidden != 0).error_struct(ctx->context.get());
+}
+
+
 const char* heif_item_get_mime_item_content_type(const heif_context* ctx, heif_item_id item_id)
 {
   auto infe = ctx->context->get_heif_file()->get_infe_box(item_id);

--- a/libheif/api/libheif/heif_items.h
+++ b/libheif/api/libheif/heif_items.h
@@ -77,6 +77,12 @@ uint32_t heif_item_get_item_type(const heif_context* ctx, heif_item_id item_id);
 LIBHEIF_API
 int heif_item_is_item_hidden(const heif_context* ctx, heif_item_id item_id);
 
+// Set or clear the hidden flag of an existing item. The primary image cannot be hidden.
+LIBHEIF_API
+heif_error heif_item_set_item_hidden(heif_context* ctx,
+                                     heif_item_id item_id,
+                                     int hidden);
+
 
 /**
  * Gets the MIME content_type for an item.

--- a/libheif/box.cc
+++ b/libheif/box.cc
@@ -602,6 +602,10 @@ Error Box::read(BitstreamRange& range, std::shared_ptr<Box>* result, const heif_
       box = std::make_shared<Box_ster>();
       break;
 
+    case fourcc("stem"):
+      box = std::make_shared<Box_stem>();
+      break;
+
     case fourcc("dinf"):
       box = std::make_shared<Box_dinf>();
       break;
@@ -4538,6 +4542,37 @@ std::string Box_ster::dump(Indent& indent) const
   sstr << indent << "group id: " << group_id << "\n"
        << indent << "left image ID: " << entity_ids[0] << "\n"
        << indent << "right image ID: " << entity_ids[1] << "\n";
+
+  return sstr.str();
+}
+
+
+Error Box_stem::parse(BitstreamRange& range, const heif_security_limits* limits)
+{
+  Error err = Box_EntityToGroup::parse(range, limits);
+  if (err) {
+    return err;
+  }
+
+  if (entity_ids.size() != 3) {
+    return {heif_error_Invalid_input,
+            heif_suberror_Invalid_box_size,
+            "'stem' entity group does not consist of exactly three images"};
+  }
+
+  return Error::Ok;
+}
+
+
+std::string Box_stem::dump(Indent& indent) const
+{
+  std::ostringstream sstr;
+  sstr << Box::dump(indent);
+
+  sstr << indent << "group id: " << group_id << "\n"
+       << indent << "left image ID: " << get_left_image() << "\n"
+       << indent << "right image ID: " << get_right_image() << "\n"
+       << indent << "monoscopic image ID: " << get_monoscopic_image() << "\n";
 
   return sstr.str();
 }

--- a/libheif/box.h
+++ b/libheif/box.h
@@ -1230,6 +1230,28 @@ protected:
 };
 
 
+class Box_stem : public Box_EntityToGroup
+{
+public:
+  Box_stem()
+  {
+    set_short_type(fourcc("stem"));
+  }
+
+  std::string dump(Indent&) const override;
+
+  const char* debug_box_name() const override { return "Stereo pair with monoscopic fallback"; }
+
+  heif_item_id get_left_image() const { return entity_ids.size() > 0 ? entity_ids[0] : 0; }
+  heif_item_id get_right_image() const { return entity_ids.size() > 1 ? entity_ids[1] : 0; }
+  heif_item_id get_monoscopic_image() const { return entity_ids.size() > 2 ? entity_ids[2] : 0; }
+
+protected:
+
+  Error parse(BitstreamRange& range, const heif_security_limits*) override;
+};
+
+
 class Box_pymd : public Box_EntityToGroup
 {
 public:

--- a/libheif/context.cc
+++ b/libheif/context.cc
@@ -356,6 +356,55 @@ bool HeifContext::is_image(heif_item_id ID) const
 }
 
 
+Error HeifContext::set_item_hidden(heif_item_id id, bool hidden)
+{
+  auto infe = m_heif_file->get_infe_box(id);
+  if (!infe) {
+    return {heif_error_Input_does_not_exist, heif_suberror_Nonexisting_item_referenced,
+            "Item does not exist"};
+  }
+
+  if (hidden && id == m_heif_file->get_primary_image_ID()) {
+    return {heif_error_Usage_error, heif_suberror_Invalid_parameter_value,
+            "The primary image cannot be hidden"};
+  }
+
+  infe->set_hidden_item(hidden);
+
+  auto image = get_image(id, true);
+  if (!image) {
+    return Error::Ok;
+  }
+
+  if (hidden) {
+    remove_top_level_image(image);
+  }
+  else {
+    bool is_region_mask = false;
+    if (auto iref_box = m_heif_file->get_iref_box()) {
+      for (heif_item_id item_id : m_heif_file->get_item_IDs()) {
+        const auto mask_references = iref_box->get_references(item_id, fourcc("mask"));
+        if (std::find(mask_references.begin(), mask_references.end(), id) !=
+            mask_references.end()) {
+          is_region_mask = true;
+          break;
+        }
+      }
+    }
+
+    if (!image->is_thumbnail() && !image->is_alpha_channel() &&
+        !image->is_depth_channel() && !image->is_aux_image() &&
+        infe->get_item_type_4cc() != fourcc("mski") && !is_region_mask &&
+        std::find(m_top_level_images.begin(), m_top_level_images.end(), image) ==
+            m_top_level_images.end()) {
+      m_top_level_images.push_back(image);
+    }
+  }
+
+  return Error::Ok;
+}
+
+
 Result<std::shared_ptr<RegionItem>> HeifContext::add_region_item(uint32_t reference_width, uint32_t reference_height)
 {
   auto boxResult = m_heif_file->add_new_infe_box(fourcc("rgan"));

--- a/libheif/context.h
+++ b/libheif/context.h
@@ -118,6 +118,8 @@ public:
 
   bool is_image(heif_item_id ID) const;
 
+  Error set_item_hidden(heif_item_id id, bool hidden);
+
   bool has_alpha(heif_item_id ID) const;
 
   Result<std::shared_ptr<HeifPixelImage>> decode_image(heif_item_id ID,

--- a/tests/entity_groups.cc
+++ b/tests/entity_groups.cc
@@ -37,11 +37,7 @@
 
 namespace {
 
-// Build a minimal HEIF file whose 'grpl' box contains a single child box
-// whose four-cc is NOT one of the registered Box_EntityToGroup subclasses
-// (pymd / altr / ster). Such children parse to Box_other and used to
-// trigger a NULL-pointer dereference in heif_context_get_entity_groups().
-std::vector<uint8_t> build_minimal_heif_with_bogus_grpl_child() {
+std::vector<uint8_t> build_minimal_heif_with_grpl_child(const std::vector<uint8_t>& child) {
   // ftyp: heic / 0 / mif1 heic
   std::vector<uint8_t> ftyp_payload;
   append_fourcc(ftyp_payload, "heic");
@@ -73,10 +69,7 @@ std::vector<uint8_t> build_minimal_heif_with_bogus_grpl_child() {
   put_u16_be(iloc_payload, 0);
   auto iloc = make_box("iloc", iloc_payload, /*full=*/true);
 
-  // grpl with a single 'pict' child — 'pict' is not registered as an
-  // entity-to-group type, so it parses to Box_other.
-  auto bogus_child = make_box("pict", {});
-  auto grpl = make_box("grpl", bogus_child);
+  auto grpl = make_box("grpl", child);
 
   // meta = hdlr + iinf + iloc + grpl
   std::vector<uint8_t> meta_payload;
@@ -90,6 +83,29 @@ std::vector<uint8_t> build_minimal_heif_with_bogus_grpl_child() {
   file.insert(file.end(), ftyp.begin(), ftyp.end());
   file.insert(file.end(), meta.begin(), meta.end());
   return file;
+}
+
+// Build a minimal HEIF file whose 'grpl' box contains a single child box
+// whose four-cc is NOT one of the registered Box_EntityToGroup subclasses
+// (pymd / altr / ster / stem). Such children parse to Box_other and used to
+// trigger a NULL-pointer dereference in heif_context_get_entity_groups().
+std::vector<uint8_t> build_minimal_heif_with_bogus_grpl_child() {
+  // grpl with a single 'pict' child — 'pict' is not registered as an
+  // entity-to-group type, so it parses to Box_other.
+  auto bogus_child = make_box("pict", {});
+  return build_minimal_heif_with_grpl_child(bogus_child);
+}
+
+std::vector<uint8_t> build_minimal_heif_with_stem_entity_count(uint32_t entity_count) {
+  std::vector<uint8_t> stem_payload;
+  put_u32_be(stem_payload, 1);  // entity_group_id
+  put_u32_be(stem_payload, entity_count);
+  for (uint32_t i = 0; i < entity_count; ++i) {
+    put_u32_be(stem_payload, i + 1);
+  }
+
+  return build_minimal_heif_with_grpl_child(
+      make_box("stem", stem_payload, /*full=*/true));
 }
 
 heif_error memory_writer(heif_context*, const void* data, size_t size, void* userdata) {
@@ -320,6 +336,153 @@ TEST_CASE("entity_groups: specialized writers enforce group semantics") {
   REQUIRE(groups[0].entities[1] == image_ids[1]);
   heif_entity_groups_release(groups, num_groups);
   heif_context_free(read_ctx);
+}
+
+
+TEST_CASE("entity_groups: stem writer preserves stereo order and accepts fallback aliases") {
+  heif_encoder* encoder = get_encoder_or_skip_test(heif_compression_AV1);
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_context_set_major_brand(ctx, heif_brand2_mif1);
+  heif_context_set_unif(ctx, 1);
+
+  const heif_item_id image_ids[] = {
+      add_test_av1_image(ctx, encoder), add_test_av1_image(ctx, encoder),
+      add_test_av1_image(ctx, encoder)};
+  heif_encoder_release(encoder);
+
+  // Stereo groups are not restricted by an item's alternative-group membership.
+  heif_entity_group_id alternative_group_id = 0;
+  REQUIRE(heif_context_add_alternative_entity_group(
+      ctx, &image_ids[0], 1, &alternative_group_id).code == heif_error_Ok);
+
+  heif_entity_group_id distinct_group_id = 123;
+  REQUIRE(heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+      ctx, image_ids[0], image_ids[1], image_ids[2], &distinct_group_id).code ==
+          heif_error_Ok);
+  REQUIRE(distinct_group_id != 0);
+
+  heif_entity_group_id left_fallback_group_id = 123;
+  REQUIRE(heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+      ctx, image_ids[0], image_ids[1], image_ids[0], &left_fallback_group_id).code ==
+          heif_error_Ok);
+
+  heif_entity_group_id right_fallback_group_id = 123;
+  REQUIRE(heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+      ctx, image_ids[0], image_ids[1], image_ids[1], &right_fallback_group_id).code ==
+          heif_error_Ok);
+
+  std::vector<uint8_t> encoded;
+  heif_writer writer{};
+  writer.writer_api_version = 1;
+  writer.write = memory_writer;
+  REQUIRE(heif_context_write(ctx, &writer, &encoded).code == heif_error_Ok);
+  heif_context_free(ctx);
+
+  ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_error read_err = heif_context_read_from_memory_without_copy(
+      ctx, encoded.data(), encoded.size(), nullptr);
+  UNSCOPED_INFO(read_err.message);
+  REQUIRE(read_err.code == heif_error_Ok);
+
+  int num_groups = 0;
+  heif_entity_group* groups = heif_context_get_entity_groups(
+      ctx, heif_fourcc('s', 't', 'e', 'm'), 0, &num_groups);
+  REQUIRE(num_groups == 3);
+  REQUIRE(groups != nullptr);
+
+  REQUIRE(groups[0].entity_group_id == distinct_group_id);
+  REQUIRE(groups[0].entity_group_type == heif_fourcc('s', 't', 'e', 'm'));
+  REQUIRE(groups[0].num_entities == 3);
+  REQUIRE(groups[0].entities[0] == image_ids[0]);
+  REQUIRE(groups[0].entities[1] == image_ids[1]);
+  REQUIRE(groups[0].entities[2] == image_ids[2]);
+
+  REQUIRE(groups[1].entity_group_id == left_fallback_group_id);
+  REQUIRE(groups[1].num_entities == 3);
+  REQUIRE(groups[1].entities[0] == image_ids[0]);
+  REQUIRE(groups[1].entities[1] == image_ids[1]);
+  REQUIRE(groups[1].entities[2] == image_ids[0]);
+
+  REQUIRE(groups[2].entity_group_id == right_fallback_group_id);
+  REQUIRE(groups[2].num_entities == 3);
+  REQUIRE(groups[2].entities[0] == image_ids[0]);
+  REQUIRE(groups[2].entities[1] == image_ids[1]);
+  REQUIRE(groups[2].entities[2] == image_ids[1]);
+
+  heif_entity_groups_release(groups, num_groups);
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: stem writer rejects invalid references without creating groups") {
+  heif_encoder* encoder = get_encoder_or_skip_test(heif_compression_AV1);
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+
+  const heif_item_id image_ids[] = {
+      add_test_av1_image(ctx, encoder), add_test_av1_image(ctx, encoder),
+      add_test_av1_image(ctx, encoder)};
+  heif_encoder_release(encoder);
+
+  const uint8_t data[] = {0x12, 0x34};
+  heif_item_id non_image_id = 0;
+  REQUIRE(heif_context_add_mime_item(ctx, "application/x-not-an-image",
+                                     heif_metadata_compression_off,
+                                     data, sizeof(data), &non_image_id).code == heif_error_Ok);
+
+  heif_entity_group_id group_id = 123;
+  heif_error err = heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+      ctx, image_ids[0], image_ids[0], image_ids[2], &group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(group_id == 0);
+
+  group_id = 123;
+  err = heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+      ctx, image_ids[0], image_ids[1], non_image_id, &group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(group_id == 0);
+
+  group_id = 123;
+  err = heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+      ctx, image_ids[0], image_ids[1], 0xFFFF, &group_id);
+  REQUIRE(err.code == heif_error_Input_does_not_exist);
+  REQUIRE(err.subcode == heif_suberror_Nonexisting_item_referenced);
+  REQUIRE(group_id == 0);
+
+  heif_security_limits* limits = heif_context_get_security_limits(ctx);
+  REQUIRE(limits != nullptr);
+  const uint32_t old_group_limit = limits->max_size_entity_group;
+  limits->max_size_entity_group = 2;
+  group_id = 123;
+  err = heif_context_add_stereo_pair_with_monoscopic_fallback_entity_group(
+      ctx, image_ids[0], image_ids[1], image_ids[2], &group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Security_limit_exceeded);
+  REQUIRE(group_id == 0);
+  limits->max_size_entity_group = old_group_limit;
+
+  int num_groups = -1;
+  heif_entity_group* groups = heif_context_get_entity_groups(ctx, 0, 0, &num_groups);
+  REQUIRE(num_groups == 0);
+  heif_entity_groups_release(groups, num_groups);
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: malformed stem entity count is rejected") {
+  auto data = build_minimal_heif_with_stem_entity_count(2);
+
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_error err = heif_context_read_from_memory_without_copy(
+      ctx, data.data(), data.size(), nullptr);
+  REQUIRE(err.code == heif_error_Invalid_input);
+  REQUIRE(err.subcode == heif_suberror_Invalid_box_size);
+  heif_context_free(ctx);
 }
 
 

--- a/tests/entity_groups.cc
+++ b/tests/entity_groups.cc
@@ -28,6 +28,8 @@
 #include "libheif/heif.h"
 #include "test_utils.h"
 #include "libheif/heif_entity_groups.h"
+#include "libheif/heif_items.h"
+#include "libheif/heif_regions.h"
 
 #include <cstdint>
 #include <cstring>
@@ -90,6 +92,43 @@ std::vector<uint8_t> build_minimal_heif_with_bogus_grpl_child() {
   return file;
 }
 
+heif_error memory_writer(heif_context*, const void* data, size_t size, void* userdata) {
+  auto* output = static_cast<std::vector<uint8_t>*>(userdata);
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  output->insert(output->end(), bytes, bytes + size);
+  return {heif_error_Ok, heif_suberror_Unspecified, "Success"};
+}
+
+heif_item_id add_test_av1_image(heif_context* ctx, heif_encoder* encoder,
+                                heif_image_handle** out_handle = nullptr) {
+  heif_image* image = nullptr;
+  REQUIRE(heif_image_create(2, 2, heif_colorspace_YCbCr,
+                            heif_chroma_420, &image).code == heif_error_Ok);
+  REQUIRE(heif_image_add_plane(image, heif_channel_Y, 2, 2, 8).code == heif_error_Ok);
+  REQUIRE(heif_image_add_plane(image, heif_channel_Cb, 1, 1, 8).code == heif_error_Ok);
+  REQUIRE(heif_image_add_plane(image, heif_channel_Cr, 1, 1, 8).code == heif_error_Ok);
+
+  for (heif_channel channel : {heif_channel_Y, heif_channel_Cb, heif_channel_Cr}) {
+    int stride = 0;
+    uint8_t* plane = heif_image_get_plane(image, channel, &stride);
+    REQUIRE(plane != nullptr);
+    const int height = channel == heif_channel_Y ? 2 : 1;
+    memset(plane, 128, static_cast<size_t>(stride * height));
+  }
+
+  heif_image_handle* handle = nullptr;
+  REQUIRE(heif_context_encode_image(ctx, image, encoder, nullptr, &handle).code == heif_error_Ok);
+  heif_item_id item_id = heif_image_handle_get_item_id(handle);
+  if (out_handle) {
+    *out_handle = handle;
+  }
+  else {
+    heif_image_handle_release(handle);
+  }
+  heif_image_release(image);
+  return item_id;
+}
+
 } // namespace
 
 
@@ -113,5 +152,362 @@ TEST_CASE("entity_groups: unknown grpl child does not crash") {
   REQUIRE(num_groups == 0);
 
   heif_entity_groups_release(groups, num_groups);
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: item visibility and ordered groups survive a round trip") {
+  heif_context* write_ctx = heif_context_alloc();
+  REQUIRE(write_ctx != nullptr);
+  heif_context_set_major_brand(write_ctx, heif_brand2_mif1);
+  heif_context_set_unif(write_ctx, 1);
+
+  const uint8_t data[] = {0x12, 0x34};
+  heif_item_id tmap_id = 0;
+  heif_item_id base_id = 0;
+  REQUIRE(heif_context_add_mime_item(write_ctx, "application/x-tmap",
+                                     heif_metadata_compression_off,
+                                     data, sizeof(data), &tmap_id).code == heif_error_Ok);
+  REQUIRE(heif_context_add_mime_item(write_ctx, "application/x-base",
+                                     heif_metadata_compression_off,
+                                     data, sizeof(data), &base_id).code == heif_error_Ok);
+  REQUIRE(tmap_id != base_id);
+
+  REQUIRE(heif_item_set_item_hidden(write_ctx, tmap_id, 0).code == heif_error_Ok);
+  REQUIRE(heif_item_set_item_hidden(write_ctx, base_id, 1).code == heif_error_Ok);
+  REQUIRE(heif_item_is_item_hidden(write_ctx, tmap_id) == 0);
+  REQUIRE(heif_item_is_item_hidden(write_ctx, base_id) == 1);
+
+  const heif_item_id alternatives[] = {tmap_id, base_id};
+  heif_entity_group_id group_id = 0;
+  REQUIRE(heif_context_add_alternative_entity_group(
+      write_ctx, alternatives, 2, &group_id).code == heif_error_Ok);
+  REQUIRE(group_id != 0);
+  REQUIRE(group_id != tmap_id);
+  REQUIRE(group_id != base_id);
+
+  std::vector<uint8_t> encoded;
+  heif_writer writer{};
+  writer.writer_api_version = 1;
+  writer.write = memory_writer;
+  REQUIRE(heif_context_write(write_ctx, &writer, &encoded).code == heif_error_Ok);
+  heif_context_free(write_ctx);
+
+  heif_context* read_ctx = heif_context_alloc();
+  REQUIRE(read_ctx != nullptr);
+  heif_error read_err = heif_context_read_from_memory_without_copy(
+      read_ctx, encoded.data(), encoded.size(), nullptr);
+  UNSCOPED_INFO(read_err.message);
+  REQUIRE(read_err.code == heif_error_Ok);
+  REQUIRE(heif_item_is_item_hidden(read_ctx, tmap_id) == 0);
+  REQUIRE(heif_item_is_item_hidden(read_ctx, base_id) == 1);
+
+  int num_groups = 0;
+  heif_entity_group* groups = heif_context_get_entity_groups(
+      read_ctx, heif_fourcc('a', 'l', 't', 'r'), 0, &num_groups);
+  REQUIRE(num_groups == 1);
+  REQUIRE(groups != nullptr);
+  REQUIRE(groups[0].entity_group_id == group_id);
+  REQUIRE(groups[0].num_entities == 2);
+  REQUIRE(groups[0].entities[0] == tmap_id);
+  REQUIRE(groups[0].entities[1] == base_id);
+
+  heif_entity_groups_release(groups, num_groups);
+  heif_context_free(read_ctx);
+}
+
+
+TEST_CASE("entity_groups: writer rejects invalid input without creating a group") {
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+
+  const heif_item_id missing_id = 17;
+  heif_entity_group_id group_id = 123;
+  heif_error err = heif_context_add_alternative_entity_group(
+      ctx, &missing_id, 1, &group_id);
+  REQUIRE(err.code == heif_error_Input_does_not_exist);
+  REQUIRE(group_id == 0);
+
+  int num_groups = -1;
+  heif_entity_group* groups = heif_context_get_entity_groups(ctx, 0, 0, &num_groups);
+  REQUIRE(num_groups == 0);
+  heif_entity_groups_release(groups, num_groups);
+
+  REQUIRE(heif_item_set_item_hidden(ctx, missing_id, 1).code == heif_error_Input_does_not_exist);
+  REQUIRE(heif_context_add_alternative_entity_group(ctx, nullptr, 1, nullptr).code ==
+          heif_error_Usage_error);
+
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: specialized writers enforce group semantics") {
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_context_set_major_brand(ctx, heif_brand2_mif1);
+  heif_context_set_unif(ctx, 1);
+
+  const uint8_t data[] = {0x12, 0x34};
+  heif_item_id item_ids[2] = {};
+  REQUIRE(heif_context_add_mime_item(ctx, "application/x-first",
+                                     heif_metadata_compression_off,
+                                     data, sizeof(data), &item_ids[0]).code == heif_error_Ok);
+  REQUIRE(heif_context_add_mime_item(ctx, "application/x-second",
+                                     heif_metadata_compression_off,
+                                     data, sizeof(data), &item_ids[1]).code == heif_error_Ok);
+
+  heif_entity_group_id group_id = 123;
+  heif_error err = heif_context_add_alternative_entity_group(
+      ctx, item_ids, 0, &group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(group_id == 0);
+
+  err = heif_context_add_stereo_pair_entity_group(
+      ctx, item_ids[0], item_ids[1], &group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(group_id == 0);
+
+  const heif_item_id duplicate_items[] = {item_ids[0], item_ids[0]};
+  group_id = 123;
+  err = heif_context_add_alternative_entity_group(
+      ctx, duplicate_items, 2, &group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(group_id == 0);
+
+  int num_groups = -1;
+  heif_entity_group* groups = heif_context_get_entity_groups(ctx, 0, 0, &num_groups);
+  REQUIRE(num_groups == 0);
+  heif_entity_groups_release(groups, num_groups);
+
+  heif_encoder* encoder = get_encoder_or_skip_test(heif_compression_AV1);
+  const heif_item_id image_ids[] = {
+      add_test_av1_image(ctx, encoder), add_test_av1_image(ctx, encoder)};
+  heif_encoder_release(encoder);
+
+  group_id = 123;
+  err = heif_context_add_stereo_pair_entity_group(
+      ctx, image_ids[0], image_ids[0], &group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(group_id == 0);
+
+  REQUIRE(heif_context_add_stereo_pair_entity_group(
+      ctx, image_ids[0], image_ids[1], &group_id).code == heif_error_Ok);
+
+  std::vector<uint8_t> encoded;
+  heif_writer writer{};
+  writer.writer_api_version = 1;
+  writer.write = memory_writer;
+  REQUIRE(heif_context_write(ctx, &writer, &encoded).code == heif_error_Ok);
+  heif_context_free(ctx);
+
+  heif_context* read_ctx = heif_context_alloc();
+  REQUIRE(read_ctx != nullptr);
+  heif_error read_err = heif_context_read_from_memory_without_copy(
+      read_ctx, encoded.data(), encoded.size(), nullptr);
+  UNSCOPED_INFO(read_err.message);
+  REQUIRE(read_err.code == heif_error_Ok);
+
+  groups = heif_context_get_entity_groups(
+      read_ctx, heif_fourcc('s', 't', 'e', 'r'), 0, &num_groups);
+  REQUIRE(num_groups == 1);
+  REQUIRE(groups != nullptr);
+  REQUIRE(groups[0].num_entities == 2);
+  REQUIRE(groups[0].entities[0] == image_ids[0]);
+  REQUIRE(groups[0].entities[1] == image_ids[1]);
+  heif_entity_groups_release(groups, num_groups);
+  heif_context_free(read_ctx);
+}
+
+
+TEST_CASE("entity_groups: an item belongs to at most one alternative group") {
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+
+  const uint8_t data[] = {0x12, 0x34};
+  heif_item_id item_ids[3] = {};
+  for (int i = 0; i < 3; ++i) {
+    REQUIRE(heif_context_add_mime_item(ctx, "application/octet-stream",
+                                       heif_metadata_compression_off,
+                                       data, sizeof(data), &item_ids[i]).code == heif_error_Ok);
+  }
+
+  const heif_item_id first_group[] = {item_ids[0], item_ids[1]};
+  heif_entity_group_id first_group_id = 0;
+  REQUIRE(heif_context_add_alternative_entity_group(
+      ctx, first_group, 2, &first_group_id).code == heif_error_Ok);
+  REQUIRE(first_group_id != 0);
+
+  const heif_item_id overlapping_group[] = {item_ids[0], item_ids[2]};
+  heif_entity_group_id overlapping_group_id = 123;
+  heif_error err = heif_context_add_alternative_entity_group(
+      ctx, overlapping_group, 2, &overlapping_group_id);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(overlapping_group_id == 0);
+
+  int num_groups = -1;
+  heif_entity_group* groups = heif_context_get_entity_groups(
+      ctx, heif_fourcc('a', 'l', 't', 'r'), 0, &num_groups);
+  REQUIRE(num_groups == 1);
+  REQUIRE(groups != nullptr);
+  REQUIRE(groups[0].entity_group_id == first_group_id);
+  heif_entity_groups_release(groups, num_groups);
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: unhiding a region-mask image keeps it non-top-level") {
+  heif_encoder* encoder = get_encoder_or_skip_test(heif_compression_AV1);
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+
+  heif_image_handle* primary_handle = nullptr;
+  const heif_item_id primary_id = add_test_av1_image(ctx, encoder, &primary_handle);
+  const heif_item_id mask_id = add_test_av1_image(ctx, encoder);
+  heif_encoder_release(encoder);
+
+  heif_region_item* region_item = nullptr;
+  REQUIRE(heif_image_handle_add_region_item(primary_handle, 2, 2, &region_item).code ==
+          heif_error_Ok);
+  REQUIRE(heif_region_item_add_region_referenced_mask(
+      region_item, 0, 0, 2, 2, mask_id, nullptr).code == heif_error_Ok);
+  heif_region_item_release(region_item);
+  heif_image_handle_release(primary_handle);
+
+  std::vector<uint8_t> encoded;
+  heif_writer writer{};
+  writer.writer_api_version = 1;
+  writer.write = memory_writer;
+  REQUIRE(heif_context_write(ctx, &writer, &encoded).code == heif_error_Ok);
+  heif_context_free(ctx);
+
+  ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_error read_err = heif_context_read_from_memory_without_copy(
+      ctx, encoded.data(), encoded.size(), nullptr);
+  UNSCOPED_INFO(read_err.message);
+  REQUIRE(read_err.code == heif_error_Ok);
+  REQUIRE(heif_context_get_number_of_top_level_images(ctx) == 1);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, primary_id) == 1);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, mask_id) == 0);
+
+  REQUIRE(heif_item_set_item_hidden(ctx, mask_id, 0).code == heif_error_Ok);
+  REQUIRE(heif_context_get_number_of_top_level_images(ctx) == 1);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, mask_id) == 0);
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: image visibility keeps top-level queries synchronized") {
+  heif_encoder* encoder = get_encoder_or_skip_test(heif_compression_AV1);
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+
+  const heif_item_id primary_id = add_test_av1_image(ctx, encoder);
+  const heif_item_id secondary_id = add_test_av1_image(ctx, encoder);
+  heif_encoder_release(encoder);
+
+  REQUIRE(heif_item_set_item_hidden(ctx, secondary_id, 1).code == heif_error_Ok);
+
+  std::vector<uint8_t> encoded;
+  heif_writer writer{};
+  writer.writer_api_version = 1;
+  writer.write = memory_writer;
+  REQUIRE(heif_context_write(ctx, &writer, &encoded).code == heif_error_Ok);
+  heif_context_free(ctx);
+
+  ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_error read_err = heif_context_read_from_memory_without_copy(
+      ctx, encoded.data(), encoded.size(), nullptr);
+  UNSCOPED_INFO(read_err.message);
+  REQUIRE(read_err.code == heif_error_Ok);
+  REQUIRE(heif_context_get_number_of_top_level_images(ctx) == 1);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, primary_id) == 1);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, secondary_id) == 0);
+
+  REQUIRE(heif_item_set_item_hidden(ctx, secondary_id, 0).code == heif_error_Ok);
+  REQUIRE(heif_context_get_number_of_top_level_images(ctx) == 2);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, secondary_id) == 1);
+
+  REQUIRE(heif_item_set_item_hidden(ctx, secondary_id, 1).code == heif_error_Ok);
+  REQUIRE(heif_context_get_number_of_top_level_images(ctx) == 1);
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: primary image cannot be hidden") {
+  heif_encoder* encoder = get_encoder_or_skip_test(heif_compression_AV1);
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+
+  const heif_item_id primary_id = add_test_av1_image(ctx, encoder);
+  heif_encoder_release(encoder);
+
+  heif_error err = heif_item_set_item_hidden(ctx, primary_id, 1);
+  REQUIRE(err.code == heif_error_Usage_error);
+  REQUIRE(err.subcode == heif_suberror_Invalid_parameter_value);
+  REQUIRE(heif_item_is_item_hidden(ctx, primary_id) == 0);
+
+  std::vector<uint8_t> encoded;
+  heif_writer writer{};
+  writer.writer_api_version = 1;
+  writer.write = memory_writer;
+  REQUIRE(heif_context_write(ctx, &writer, &encoded).code == heif_error_Ok);
+  heif_context_free(ctx);
+
+  ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_error read_err = heif_context_read_from_memory_without_copy(
+      ctx, encoded.data(), encoded.size(), nullptr);
+  UNSCOPED_INFO(read_err.message);
+  REQUIRE(read_err.code == heif_error_Ok);
+  REQUIRE(heif_context_get_number_of_top_level_images(ctx) == 1);
+  heif_context_free(ctx);
+}
+
+
+TEST_CASE("entity_groups: promoting a hidden image makes it a visible primary") {
+  heif_encoder* encoder = get_encoder_or_skip_test(heif_compression_AV1);
+  heif_context* ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+
+  const heif_item_id original_primary_id = add_test_av1_image(ctx, encoder);
+  heif_image_handle* new_primary_handle = nullptr;
+  const heif_item_id new_primary_id = add_test_av1_image(ctx, encoder, &new_primary_handle);
+  heif_encoder_release(encoder);
+
+  REQUIRE(heif_item_set_item_hidden(ctx, new_primary_id, 1).code == heif_error_Ok);
+  REQUIRE(heif_context_set_primary_image(ctx, new_primary_handle).code == heif_error_Ok);
+  heif_image_handle_release(new_primary_handle);
+
+  REQUIRE(heif_item_is_item_hidden(ctx, new_primary_id) == 0);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, new_primary_id) == 1);
+
+  std::vector<uint8_t> encoded;
+  heif_writer writer{};
+  writer.writer_api_version = 1;
+  writer.write = memory_writer;
+  REQUIRE(heif_context_write(ctx, &writer, &encoded).code == heif_error_Ok);
+  heif_context_free(ctx);
+
+  ctx = heif_context_alloc();
+  REQUIRE(ctx != nullptr);
+  heif_error read_err = heif_context_read_from_memory_without_copy(
+      ctx, encoded.data(), encoded.size(), nullptr);
+  UNSCOPED_INFO(read_err.message);
+  REQUIRE(read_err.code == heif_error_Ok);
+
+  heif_image_handle* read_primary_handle = nullptr;
+  REQUIRE(heif_context_get_primary_image_handle(ctx, &read_primary_handle).code == heif_error_Ok);
+  REQUIRE(heif_image_handle_get_item_id(read_primary_handle) == new_primary_id);
+  REQUIRE(heif_item_is_item_hidden(ctx, new_primary_id) == 0);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, original_primary_id) == 1);
+  REQUIRE(heif_context_is_top_level_image_ID(ctx, new_primary_id) == 1);
+  heif_image_handle_release(read_primary_handle);
   heif_context_free(ctx);
 }


### PR DESCRIPTION
## Problem

libheif can read item visibility and entity groups, but its public API cannot write them. This prevents callers from constructing valid derived-image layouts that need hidden items or ordered groups without private patches.

## Change

This adds:

- an API to set an existing item's hidden flag
- a specialized writer for ordered alternative (`altr`) groups
- a specialized writer for left/right stereo (`ster`) groups
- a specialized writer for stereo pairs with a monoscopic fallback (`stem`)

The specialized group APIs enforce each group type's requirements, making them easier to use without creating non-compliant files.

The `stem` writer requires distinct left and right images followed by a monoscopic fallback. The fallback may be a separate image or may reuse either stereo view. `stem` parsing is also registered so its ordered entities remain available through the public reader after serialization.

The visibility setter rejects hiding the primary image and keeps top-level image queries synchronized. Selecting a hidden image as primary makes it visible first.

Track entities are intentionally out of scope.

## Tests

Round-trip tests write and reopen files to verify:

- hidden flags and top-level image synchronization
- ordered alternative membership
- stereo-pair ordering
- all supported monoscopic fallback arrangements

Additional coverage checks invalid and non-image references, duplicate and overlapping alternatives, malformed `ster` and `stem` groups, security limits, region-mask handling, and hidden-primary promotion.