### PR TITLE
fix the size passed to tighten_image_size_limit_for_ispe()

### DIFF
--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -1291,7 +1291,7 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem::decode_compressed_image(const
   // when the codec bitstream lies about its dimensions.
   heif_security_limits tightened = tighten_image_size_limit_for_ispe(
       get_context()->get_security_limits(),
-      get_width(), get_height(),
+      get_ispe_width(), get_ispe_height(),
       max_coding_unit_size_for_codec(get_compression_format()));
 
   return decoder->decode_single_frame_from_compressed_data(options, &tightened);


### PR DESCRIPTION
While upgrading libheif I hit "Security limit exceeded" on cropped HEIC files. I think this is the cause of #1856. 

`tighten_image_size_limit_for_ispe()` receives the post-transform size (`get_width()`) instead of the ispe size, so images with a large clap crop can no longer be decoded. Passing `get_ispe_width()/get_ispe_height()` fixes it for me.