### PR TITLE
Support 12, 14 and 16 bit monochrome in the FFmpeg decoder plugin

### DIFF
--- a/libheif/plugins/decoder_ffmpeg.cc
+++ b/libheif/plugins/decoder_ffmpeg.cc
@@ -339,6 +339,9 @@ static heif_chroma ffmpeg_get_chroma_format(AVPixelFormat pix_fmt) {
   switch (pix_fmt) {
     case AV_PIX_FMT_GRAY8:
     case AV_PIX_FMT_GRAY10LE:
+    case AV_PIX_FMT_GRAY12LE:
+    case AV_PIX_FMT_GRAY14LE:
+    case AV_PIX_FMT_GRAY16LE:
       return heif_chroma_monochrome;
 
     case AV_PIX_FMT_YUV420P:


### PR DESCRIPTION
`ffmpeg_get_chroma_format()` only maps `GRAY8` and `GRAY10LE` to `heif_chroma_monochrome`. Anything deeper falls through to `default:` and returns `heif_chroma_undefined`, so the decode fails with "Unsupported color conversion: Pixel format not implemented".

Looks like drift rather than intent, since `get_ffmpeg_format_bpp()` right below already handles `GRAY12LE`, `GRAY14LE` and `GRAY16LE`.

It also isn't limited to genuinely monochrome images. An alpha channel is stored as a separate monochrome item, so 12 bit colour images with alpha fail the same way. That's what put me onto it.

Checked against the [av1-avif](https://github.com/AOMediaCodec/av1-avif) conformance files: 10 bit monochrome decodes, 12 bit monochrome doesn't, and 12 bit colour without alpha is fine, so it tracks bit depth rather than subsampling.

Only `GRAY12LE` is reachable via AVIF since AV1 stops at 12 bit, but the plugin also serves HEVC/VVC, so I added all three.