### PR TITLE
Use the ispe size for the decoder image size limit

### DIFF
--- a/libheif/image-items/image_item.cc
+++ b/libheif/image-items/image_item.cc
@@ -1289,9 +1289,12 @@ Result<std::shared_ptr<HeifPixelImage>> ImageItem::decode_compressed_image(const
   // Tighten max_image_size_pixels for this decode so a decoder plugin (e.g.
   // dav1d) cannot allocate buffers far larger than the ispe-declared size
   // when the codec bitstream lies about its dimensions.
+  // Use the 'ispe' size here: get_width()/get_height() are post-transform, so for a
+  // 'clap'-cropped item they describe the display size while the decoder still has to
+  // allocate the full coded frame.
   heif_security_limits tightened = tighten_image_size_limit_for_ispe(
       get_context()->get_security_limits(),
-      get_width(), get_height(),
+      get_ispe_width(), get_ispe_height(),
       max_coding_unit_size_for_codec(get_compression_format()));
 
   return decoder->decode_single_frame_from_compressed_data(options, &tightened);


### PR DESCRIPTION
`ImageItem::decode_compressed_image()` passes `get_width()`/`get_height()` into `tighten_image_size_limit_for_ispe()`. Those are post-transform, but the limit bounds what the decoder allocates, which is the coded frame that `ispe` describes. Once an item carries a `clap` the two diverge and a valid cropped image fails to decode:

```
Memory allocation error: Security limit exceeded:
Allocating an image of size 722x1024 exceeds the security limit of 234954 pixels
```

For an AVIF coded 722x1024 and cropped to 385x330:

```
budget = (385 + 128) * (330 + 128) = 234954   <- from get_width()/get_height()
needed =         722 *        1024 = 739328   <- what the decoder allocates
```

The coding unit margin hides this for small crops. A 4032x3024 image trimmed to 4030x3020 gets ~13.1M against 12.2M needed and passes, so only aggressive crops break. HEIC is more exposed than AVIF, since the margin is 64 for HEVC against 128 for AV1.

Raising `max_image_size_pixels` doesn't help either, as the function only ever clamps downward.

`clap` is the only property that triggers it. `irot` swaps width and height and the budget is symmetric under that swap, and `imir` doesn't change dimensions at all. Across the `kimono.*` conformance variants only the two cropped ones failed.

Using `get_ispe_width()`/`get_ispe_height()` also matches `check_decoded_image_size()` further down the same file, which already uses the `ispe` accessors and calls them the "Pre-transform coded size". `ImageItem_Tiled::decode_grid_tile()` is the only other caller and already passes the tile size.

Behaviour without an `ispe` is unchanged, since `m_width`/`m_height` are only set once one has been read, so both pairs return 0 and the tightening is skipped. The one case that differs is a file with a `clap` but no `ispe`, which is malformed anyway and already gets a `No_ispe_property` warning. It used to get a budget from the crop size and now falls back to the global limit. Happy to handle that differently if you'd prefer.

The guard still holds: the function only narrows, so a large `ispe` can't lift the budget above the global maximum, a too-small one still fails its own decode, and `check_decoded_image_size()` validates the decoded planes afterwards.