### PR TITLE
Add heifio just for examples and testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,7 +604,9 @@ else ()
     set(CMAKE_CXX_VISIBILITY_PRESET default)
 endif ()
 
-add_subdirectory(heifio)
+if(WITH_EXAMPLES OR BUILD_TESTING)
+    add_subdirectory(heifio)
+endif()
 
 if(WITH_EXAMPLES)
     add_subdirectory (examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,7 @@ option(WITH_EXAMPLES "Build examples" ON)
 option(WITH_EXAMPLE_HEIF_THUMB "Build heif-thumbnailer tool" ON)
 option(WITH_EXAMPLE_HEIF_VIEW "Build heif-view tool" ON)
 option(WITH_GDK_PIXBUF "Build gdk-pixbuf plugin" ON)
+option(BUILD_TESTING "Build the unit tests" ON)
 
 option(BUILD_DEVELOPMENT_TOOLS "Build development tools (heif-gen-bayer, etc.)" OFF)
 
@@ -604,6 +605,8 @@ else ()
     set(CMAKE_CXX_VISIBILITY_PRESET default)
 endif ()
 
+# heifio is a helper library for reading and writing image files.
+# It is only needed by the example programs and the unit tests.
 if(WITH_EXAMPLES OR BUILD_TESTING)
     add_subdirectory(heifio)
 endif()
@@ -658,7 +661,6 @@ if(ENABLE_COVERAGE)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
-option(BUILD_TESTING "" ON)
 set(CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 include(CTest)
 if(BUILD_TESTING)


### PR DESCRIPTION
Don't add `heifio` in `CMakeLists.txt` for `libheif` consumers.

----

Original review https://github.com/microsoft/vcpkg/pull/53645#discussion_r3966981286